### PR TITLE
ci(gh-actions): Initial CI pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '00:00'
+    timezone: UTC
+  commit-message:
+      prefix: "chore"
+      include: "scope"
+  groups:
+    gh-actions:
+      patterns:
+        # Bundle all GH Actions updates in a single PR
+        - "*"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,39 @@
+name: CI/CD
+
+on:
+  # Enable option to manually run the action:
+  workflow_dispatch:
+
+  # Run on the `main` branch or on PRs that target it:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  CI-CD:
+    timeout-minutes: 360
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf:
+            accept-flake-config = true
+
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v1
+
+      - uses: cachix/cachix-action@v12
+        with:
+          name: ${{ vars.CACHIX_CACHE }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: nix flake check
+        run: nix flake check

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,44 @@
+name: Update Nix Flake lockfile
+
+on:
+  # Enable option to manually run the action:
+  workflow_dispatch:
+
+  # Run every Sunday at 00:00:
+  schedule:
+    - cron: 0 0 * * 0
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf:
+            accept-flake-config = true
+
+      - name: Run `nix flake update`
+        id: update-lockfile
+        run: ./scripts/commit_flake_update.bash
+
+      - uses: tibdex/github-app-token@v2.1.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          title: 'Update Nix Flake lockfile'
+          commit-message: ${{ env.COMMIT_MSG }}
+          branch: 'create-pull-request/update-flake-lockfile'
+          delete-branch: true
+          branch-suffix: timestamp
+          add-paths: flake.lock


### PR DESCRIPTION
Changes compared to the CI configuration used in other repos:

* Use [`DeterminateSystems/nix-installer-action`][1] instead of [`cachix/install-nix-action`][2]
* Use [`DeterminateSystems/magic-nix-cache-action`][3] - should make things slightly faster, compared to only using Cachix, as it adds a closer level cache (the GH Runner cache), which while smaller, should have higher performance
* In `cachix/cachix-action`
  * Use `${{ vars.CACHIX_CACHE }}` and `${{ secrets.CACHIX_AUTH_TOKEN }}`
    * Use generic names to make reuse across repos easier
    * make `CACHIX_CACHE` a regular GH repo-scoped variable, and not a secret
* Add `groups` section to `.github/dependabot.yml` to bundle all gh-actions related changes in one PR

[1]: https://github.com/DeterminateSystems/nix-installer-action
[2]: https://github.com/cachix/install-nix-action
[3]: https://github.com/DeterminateSystems/magic-nix-cache-action
