### PR TITLE
build(flake.nix/inputs): Upgrade and fix non-existant input overrides

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,16 +454,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1702195668,
-        "narHash": "sha256-Lxmjez0nfNBptdqV5GsXKm7Bb7swjGsrxiLxWJu0tL8=",
+        "lastModified": 1705273357,
+        "narHash": "sha256-JAlkxgJbWh7+auiT0rJL3IUXXtkULRqygfxQA6mvLgc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "33110fb3c7fe6a94b98b641866a5eddb64b7c23f",
+        "rev": "924d91e1e4c802fd8e60279a022dbae5acb36f2d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -657,34 +657,18 @@
         "type": "github"
       }
     },
-    "nixos-2305": {
-      "locked": {
-        "lastModified": 1704290814,
-        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixos-2311": {
       "locked": {
-        "lastModified": 1704932590,
-        "narHash": "sha256-v6thNIL9pJXn3GosAoQz8y4PBhiarTbA/1T190C/ZmE=",
+        "lastModified": 1705183652,
+        "narHash": "sha256-rnfkyUH0x72oHfiSDhuCHDHg3gFgF+lF8zkkg5Zihsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2aaf35bc85b2a6f9957fe9df17bcf5f94fbd0e85",
+        "rev": "428544ae95eec077c7f823b422afae5f174dee4b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -724,7 +708,9 @@
     },
     "nixos-images": {
       "inputs": {
-        "nixos-2311": "nixos-2311",
+        "nixos-2311": [
+          "nixos-2311"
+        ],
         "nixos-unstable": [
           "nixpkgs-unstable"
         ]
@@ -862,11 +848,11 @@
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixd": "nixd",
-        "nixos-2305": "nixos-2305",
+        "nixos-2311": "nixos-2311",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-images": "nixos-images",
         "nixpkgs": [
-          "nixos-2305"
+          "nixos-2311"
         ],
         "nixpkgs-unstable": "nixpkgs-unstable",
         "pre-commit-hooks": "pre-commit-hooks",

--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704835383,
-        "narHash": "sha256-SoC0rYR9iHW0dVOEmxNEfa8vk9dTK86P5iXTgHafmwM=",
+        "lastModified": 1705316332,
+        "narHash": "sha256-mIwp6veH8gho/9uFdRqROMtR7h1JmhOsi6uCEzPxQYk=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "18ef9849d1ecac7a9a7920eb4f2e4adcf67a8c3a",
+        "rev": "75dfa5e6c5caac2098a6d46c711e5307e4557e2c",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705017253,
-        "narHash": "sha256-/ysUOnF/dYJXDTxi/fi4MNN7uYKRji5CKp3EIamXB+0=",
+        "lastModified": 1705281959,
+        "narHash": "sha256-9NZiSMAduz4qbFu77Cg9RNFcrjgS9UOjriD+v8FeueY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "fa5db12d76f9e8ee11e572cdbe021230e48b6afa",
+        "rev": "2a561be6b5dd049182af1973bb7e28f7a0ac9be2",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705189113,
-        "narHash": "sha256-ZETEXzIbveou7SkdJ8I9qpPw8qyfxCvmi05Hl500KwM=",
+        "lastModified": 1705315165,
+        "narHash": "sha256-MJIwS6KTRvskumBTjR75zmH/X+qwG2KZ/OCEg9rnpJA=",
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
-        "rev": "5e4444561452074543fa48341ee85d9fb1b3af2e",
+        "rev": "028d4aa3def9a7697bf9d5d5741ae217325983eb",
         "type": "github"
       },
       "original": {
@@ -344,11 +344,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -388,11 +388,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {
@@ -644,11 +644,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704982974,
-        "narHash": "sha256-BqRhnQLq+iKeHg0z7UIq/IprLF3tluci02ek4ZH7rpc=",
+        "lastModified": 1705244338,
+        "narHash": "sha256-o+IXgYlzUWftoslnmeSZ6LJKTwv/7wRZ/G0/Ds3UIkQ=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "ad23935dff90f7c30d02bfbcaeb39ea17f2b4e77",
+        "rev": "13142d8a2681dbd177d46741cc89a181b8f3dcc1",
         "type": "github"
       },
       "original": {
@@ -716,11 +716,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704934879,
-        "narHash": "sha256-eSsJEQ0Khkuebmenc+UzGvzgrmEoTjIiCEgW4IsTXwQ=",
+        "lastModified": 1705314292,
+        "narHash": "sha256-AF30cc/u+F4AByguXSppkvN/Go/fjOJKKVBMr2wvAso=",
         "owner": "nix-community",
         "repo": "nixos-images",
-        "rev": "bf5c4f258ba5e272c5cb109398b4b313d42d4d27",
+        "rev": "97d38e1b77d88c70b03a6b8de71607381b7a4434",
         "type": "github"
       },
       "original": {
@@ -763,11 +763,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1704722960,
-        "narHash": "sha256-mKGJ3sPsT6//s+Knglai5YflJUF2DGj7Ai6Ynopz0kI=",
+        "lastModified": 1705133751,
+        "narHash": "sha256-rCIsyE80jgiOU78gCWN3A0wE0tR2GI5nH6MlS+HaaSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "317484b1ead87b9c1b8ac5261a8d2dd748a0492d",
+        "rev": "9b19f5e77dd906cb52dade0b7bd280339d2a1f3d",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705056064,
-        "narHash": "sha256-pi9UtBFD5/U48Jrc6uvA8ZCmW4xnceUDp2QysBEkZCw=",
+        "lastModified": 1705229514,
+        "narHash": "sha256-itILy0zimR/iyUGq5Dgg0fiW8plRDyxF153LWGsg3Cw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "54d60d191aa8ba0629f662d8873a892cbe3d65ad",
+        "rev": "ffa9a5b90b0acfaa03b1533b83eaf5dead819a05",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,14 @@
   description = "Metacraft Nixos Modules";
 
   inputs = {
-    nixos-2305.url = "github:NixOS/nixpkgs/nixos-23.05";
+    nixos-2311.url = "github:NixOS/nixpkgs/nixos-23.11";
 
-    nixpkgs.follows = "nixos-2305";
+    nixpkgs.follows = "nixos-2311";
 
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-23.05";
+      url = "github:nix-community/home-manager/release-23.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -60,7 +60,6 @@
       inputs.nixpkgs-unstable.follows = "nixpkgs-unstable";
       inputs.flake-parts.follows = "flake-parts";
       inputs.flake-compat.follows = "flake-compat";
-      inputs.hercules-ci-effects.follows = "hercules-ci-effects";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };
 
@@ -88,7 +87,7 @@
 
     nixos-images = {
       url = "github:nix-community/nixos-images";
-      inputs.nixos-2305.follows = "nixos-2305";
+      inputs.nixos-2311.follows = "nixos-2311";
       inputs.nixos-unstable.follows = "nixpkgs-unstable";
     };
 
@@ -98,7 +97,6 @@
       inputs.nixos-images.follows = "nixos-images";
       inputs.flake-parts.follows = "flake-parts";
       inputs.disko.follows = "disko";
-      inputs.nixos-2305.follows = "nixos-2305";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };
 


### PR DESCRIPTION
- build(flake.nix/inputs): Upgrade to NixOS 23.11 branch and fix incorrect `<input>.follows` directives
- chore(flake.lock): Update all Flake inputs (2024-01-15)
