### PR TITLE
chore(flake.lock): Update ethereum-nix flake input (2024-02-15)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -199,11 +199,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706022236,
-        "narHash": "sha256-aXgWZnDO1jmffoIroiia9vZJ5MsO5nPmA0ZElDwFaAA=",
+        "lastModified": 1708019804,
+        "narHash": "sha256-o3WgK7IDYRV+mTQlNAWztVefmdzVFr7L+e56DYu+DKU=",
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
-        "rev": "02767e1516eddadc36d355a30cc4e2f7fbe82088",
+        "rev": "771a17fc12c19c6c66e14b1dda306098cdea85a1",
         "type": "github"
       },
       "original": {

--- a/modules/lido/keys-api/default.nix
+++ b/modules/lido/keys-api/default.nix
@@ -175,7 +175,7 @@
         backend = "docker";
         containers = {
           lido-keys-api = {
-            image = "lidofinance/lido-keys-api:stable";
+            image = "lidofinance/lido-keys-api:1.0.1";
             environment = toEnvVariables cfg.args;
             ports = ["${toString cfg.args.port}:${toString cfg.args.port}"];
             dependsOn = ["postgresql-lido"];


### PR DESCRIPTION
- update(modules/lido/keys-api): Update docker image to version 1.0.1
- chore(flake.lock): Update `ethereum-nix` flake input (2024-02-15)
