### PR TITLE
build(flake.nix/inputs): Add `nix2container`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,6 +568,29 @@
         "type": "github"
       }
     },
+    "nix2container": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708764364,
+        "narHash": "sha256-+pOtDvmuVTg0Gi58hKDUyrNla5NbyUvt3Xs3gLR0Fws=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "c891f90d2e3c48a6b33466c96e4851e0fc0cf455",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixd": {
       "inputs": {
         "flake-parts": [
@@ -790,6 +813,7 @@
         "home-manager": "home-manager",
         "microvm": "microvm",
         "nix-darwin": "nix-darwin",
+        "nix2container": "nix2container",
         "nixd": "nixd",
         "nixos-2311": "nixos-2311",
         "nixos-anywhere": "nixos-anywhere",

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,12 @@
       inputs.treefmt-nix.follows = "treefmt-nix";
     };
 
+    nix2container = {
+      url = "github:nlewo/nix2container";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+
     disko = {
       url = "github:nix-community/disko";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
```
• Added input 'nix2container':
    'github:nlewo/nix2container/c891f90d2e3c48a6b33466c96e4851e0fc0cf455' (2024-02-24)
• Added input 'nix2container/flake-utils':
    follows 'flake-utils'
• Added input 'nix2container/nixpkgs':
    follows 'nixpkgs'
```