### PR TITLE
feat(mcl/get_fstab): Add program that fetches `/etc/fstab` from Cachix deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           name: ${{ vars.CACHIX_CACHE }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: ${{ vars.EXTRA_CACHIX_CACHES }}
 
       - name: Build ${{ matrix.package }}
         run: nix build -L --json --no-link '.#${{ matrix.attrPath }}'

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ result
 
 # Direnv
 .direnv
+.env
 
 *.qcow2
 

--- a/flake.lock
+++ b/flake.lock
@@ -201,6 +201,30 @@
         "type": "github"
       }
     },
+    "dlang-nix": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1711390973,
+        "narHash": "sha256-Mi7pi0TRlN+5/5GL9XXrXINaODqd9cq97eUXtDUWpKc=",
+        "owner": "PetarKirov",
+        "repo": "dlang.nix",
+        "rev": "d7fedd89dd4d783aa20c63bb79a199d8ad02d19d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "PetarKirov",
+        "repo": "dlang.nix",
+        "type": "github"
+      }
+    },
     "ethereum-nix": {
       "inputs": {
         "devour-flake": "devour-flake",
@@ -743,6 +767,22 @@
         "type": "github"
       }
     },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -846,6 +886,7 @@
         "crane": "crane",
         "devenv": "devenv",
         "disko": "disko",
+        "dlang-nix": "dlang-nix",
         "ethereum-nix": "ethereum-nix",
         "fenix": "fenix",
         "flake-compat": "flake-compat_2",

--- a/flake.lock
+++ b/flake.lock
@@ -611,6 +611,32 @@
         "type": "github"
       }
     },
+    "nix-fast-build": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709911523,
+        "narHash": "sha256-XNutwbRI6h57ybeKy0yYupfngWYcfcIqE0b0LgXnyxs=",
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
+        "rev": "692fe3e98f36b60c678d637235271b57910a7f80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
+        "type": "github"
+      }
+    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
@@ -897,6 +923,7 @@
         "home-manager": "home-manager",
         "microvm": "microvm",
         "nix-darwin": "nix-darwin",
+        "nix-fast-build": "nix-fast-build",
         "nix2container": "nix2container",
         "nixd": "nixd",
         "nixos-2311": "nixos-2311",

--- a/flake.nix
+++ b/flake.nix
@@ -177,6 +177,15 @@
         flake-parts.follows = "flake-parts";
       };
     };
+
+    nix-fast-build = {
+      url = "github:Mic92/nix-fast-build";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
   };
 
   outputs = inputs @ {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "Metacraft Nixos Modules";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://mcl-public-cache.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "mcl-public-cache.cachix.org-1:OcUzMeoSAwNEd3YCaEbNjLV5/Gd+U5VFxdN2WGHfpCI="
+    ];
+  };
+
   inputs = {
     nixos-2311.url = "github:NixOS/nixpkgs/nixos-23.11";
 

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,11 @@
   nixConfig = {
     extra-substituters = [
       "https://mcl-public-cache.cachix.org"
+      "https://dlang-community.cachix.org"
     ];
     extra-trusted-public-keys = [
       "mcl-public-cache.cachix.org-1:OcUzMeoSAwNEd3YCaEbNjLV5/Gd+U5VFxdN2WGHfpCI="
+      "dlang-community.cachix.org-1:eAX1RqX4PjTDPCAp/TvcZP+DYBco2nJBackkAJ2BsDQ="
     ];
   };
 
@@ -166,6 +168,14 @@
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    dlang-nix = {
+      url = "github:PetarKirov/dlang.nix";
+      inputs = {
+        flake-compat.follows = "flake-compat";
+        flake-parts.follows = "flake-parts";
+      };
     };
   };
 

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -3,16 +3,24 @@
     inputs',
     pkgs,
     ...
-  }: rec {
+  }: let
+    inherit (pkgs.hostPlatform) isLinux isx86;
+  in rec {
     packages =
-      rec {
+      {
         lido-withdrawals-automation = pkgs.callPackage ./lido-withdrawals-automation {};
         pyroscope = pkgs.callPackage ./pyroscope {};
         grafana-agent = import ./grafana-agent {inherit inputs';};
         ci-matrix = pkgs.callPackage ./ci-matrix {};
       }
-      // pkgs.lib.optionalAttrs pkgs.hostPlatform.isLinux rec {
-        validator-ejector = inputs'.validator-ejector.packages.validator-ejector;
+      // pkgs.lib.optionalAttrs isLinux {
+        inherit (inputs'.validator-ejector.packages) validator-ejector;
+      }
+      // pkgs.lib.optionalAttrs (isLinux && isx86) {
+        mcl = pkgs.callPackage ./mcl {
+          inherit (inputs'.dlang-nix.packages) dub;
+          dcompiler = inputs'.dlang-nix.packages.ldc;
+        };
       };
     checks = packages;
   };

--- a/packages/mcl/.gitignore
+++ b/packages/mcl/.gitignore
@@ -1,0 +1,17 @@
+.dub
+docs.json
+__dummy.html
+docs/
+build/
+/mcl
+mcl.so
+mcl.dylib
+mcl.dll
+mcl.a
+mcl.lib
+mcl-test-*
+*.exe
+*.pdb
+*.o
+*.obj
+*.lst

--- a/packages/mcl/default.nix
+++ b/packages/mcl/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  stdenv,
+  dub,
+  dcompiler,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mcl";
+  version = "0.0.1";
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.fileFilter (file: builtins.any file.hasExt ["d" "sdl" "json"]) ./.;
+  };
+
+  nativeBuildInputs = [dub dcompiler];
+
+  buildPhase = "dub build";
+  checkPhase = "dub test";
+  installPhase = ''
+    install -D -m755 ./build/${finalAttrs.pname} $out/bin/${finalAttrs.pname}
+  '';
+
+  meta.mainProgram = finalAttrs.pname;
+})

--- a/packages/mcl/dub.sdl
+++ b/packages/mcl/dub.sdl
@@ -1,0 +1,10 @@
+name "mcl"
+description "Swiss-knife for managing NixOS deployments"
+authors "Metacraft Labs"
+copyright "Copyright © 2024, Metacraft Labs"
+license "MIT"
+targetPath "build"
+
+dflags "-preview=shortenedMethods"
+dflags "-defaultlib=libphobos2.so" platform="dmd"
+lflags "-fuse-ld=gold" platform="dmd"

--- a/packages/mcl/src/main.d
+++ b/packages/mcl/src/main.d
@@ -1,4 +1,40 @@
-void main()
+import std.stdio : writefln, writeln;
+
+import cmds = mcl.commands;
+
+alias supportedCommands = imported!`std.traits`.AliasSeq!(
+    cmds.get_fstab
+);
+
+int main(string[] args)
 {
-    imported!`std.stdio`.writeln("Hello, World!");
+    if (args.length < 2)
+        return wrongUsage("no command selected");
+
+    try switch (args[1])
+    {
+        default:
+            return wrongUsage("unknown command: `" ~ args[1] ~ "`");
+
+    	static foreach (cmd; supportedCommands)
+            case __traits(identifier, cmd):
+                cmd();
+    }
+    catch (Exception e)
+    {
+        writefln("Error: %s", e.msg);
+        return 1;
+    }
+
+    return 0;
+}
+
+int wrongUsage(string error)
+{
+    writefln("Error: %s.", error);
+    writeln("Usage:\n");
+	static foreach (cmd; supportedCommands)
+        writefln("    mcl %s", __traits(identifier, cmd));
+
+   return 1;
 }

--- a/packages/mcl/src/main.d
+++ b/packages/mcl/src/main.d
@@ -1,0 +1,4 @@
+void main()
+{
+    imported!`std.stdio`.writeln("Hello, World!");
+}

--- a/packages/mcl/src/src/mcl/commands/get_fstab.d
+++ b/packages/mcl/src/src/mcl/commands/get_fstab.d
@@ -1,0 +1,48 @@
+module mcl.commands.get_fstab;
+
+import std;
+import std.conv : to;
+import std.json : JSONValue;
+import std.format : fmt = format;
+import std.exception : enforce;
+
+import mcl.utils.cachix : cachixNixStoreUrl, getCachixDeploymentApiUrl;
+import mcl.utils.env : optional, parseEnv;
+import mcl.utils.fetch : fetchJson;
+import mcl.utils.nix;
+import mcl.utils.string : camelCaseToCapitalCase;
+import mcl.utils.process : execute;
+
+export void get_fstab() {
+    const params = parseEnv!Params;
+    const machineStorePath = getCachixDeploymentStorePath(params);
+    const fstabStorePath = queryStorePath(
+        machineStorePath,
+        ["-etc", "-etc-fstab"],
+        params.cachixStoreUrl
+    );
+    nixBuild(fstabStorePath);
+    writeln(fstabStorePath);
+}
+
+struct Params {
+    string cachixAuthToken;
+    string cachixCache;
+    @optional() string cachixStoreUrl;
+    @optional() string cachixDeployWorkspace;
+    string machineName;
+    uint deploymentId;
+
+    void setup() {
+
+        cachixStoreUrl = cachixNixStoreUrl(cachixCache);
+        if (!cachixDeployWorkspace) cachixDeployWorkspace = cachixCache;
+    }
+}
+
+string getCachixDeploymentStorePath(Params p)
+{
+    const url = getCachixDeploymentApiUrl(p.cachixDeployWorkspace, p.machineName, p.deploymentId);
+    const response = fetchJson(url, p.cachixAuthToken);
+    return response["storePath"].get!string;
+}

--- a/packages/mcl/src/src/mcl/commands/package.d
+++ b/packages/mcl/src/src/mcl/commands/package.d
@@ -1,0 +1,3 @@
+module mcl.commands;
+
+public import mcl.commands.get_fstab : get_fstab;

--- a/packages/mcl/src/src/mcl/utils/cachix.d
+++ b/packages/mcl/src/src/mcl/utils/cachix.d
@@ -1,0 +1,23 @@
+module mcl.utils.cachix;
+
+import std.format : fmt = format;
+
+string getCachixDeploymentApiUrl(string workspace, string machine, uint deploymentId)
+in (workspace && machine && deploymentId) =>
+    "https://app.cachix.org/api/v1/deploy/deployment/%s/%s/%s"
+    .fmt(workspace, machine, deploymentId);
+
+unittest
+{
+    assert(getCachixDeploymentApiUrl("my-workspace", "my-machine", 123) ==
+        "https://app.cachix.org/api/v1/deploy/deployment/my-workspace/my-machine/123");
+
+}
+
+string cachixNixStoreUrl(string cachixCache) =>
+    "https://%s.cachix.org".fmt(cachixCache);
+
+unittest
+{
+    assert(cachixNixStoreUrl("my-cache") == "https://my-cache.cachix.org");
+}

--- a/packages/mcl/src/src/mcl/utils/env.d
+++ b/packages/mcl/src/src/mcl/utils/env.d
@@ -1,0 +1,42 @@
+module mcl.utils.env;
+
+struct Optional {}
+auto optional() => Optional();
+
+enum isOptional(alias field) = imported!`std.traits`.hasUDA!(field, Optional);
+
+class MissingEnvVarsException : Exception {
+    import std.exception : basicExceptionCtors;
+    mixin basicExceptionCtors;
+}
+
+T parseEnv(T)() {
+    import std.conv : to;
+    import std.exception : enforce;
+    import std.format : fmt = format;
+    import std.process : environment;
+    import std.traits : Fields;
+
+    import mcl.utils.string : camelCaseToCapitalCase;
+
+    T result;
+    string[] missingEnvVars = [];
+
+    static foreach (idx, field; T.tupleof)
+    {{
+        string envVarName = field.stringof.camelCaseToCapitalCase;
+        if (auto envVar = environment.get(envVarName))
+            result.tupleof[idx] = envVar.to!(typeof(field));
+        else if (!isOptional!field)
+            missingEnvVars ~= envVarName;
+    }}
+
+    enforce!MissingEnvVarsException(
+        missingEnvVars.length == 0,
+        "missing environment variables:\n%(* %s\n%)".fmt(missingEnvVars)
+    );
+
+    result.setup();
+
+    return result;
+}

--- a/packages/mcl/src/src/mcl/utils/fetch.d
+++ b/packages/mcl/src/src/mcl/utils/fetch.d
@@ -1,0 +1,14 @@
+module mcl.utils.fetch;
+
+import std.stdio : stderr;
+import std.json : JSONValue;
+
+JSONValue fetchJson(string url, string authToken) {
+    import std.json : parseJSON;
+    import std.net.curl : HTTP, get;
+    auto client = HTTP();
+    client.addRequestHeader("Authorization", "Bearer " ~ authToken);
+    stderr.writefln("GET %s", url);
+    auto response = get(url, client);
+    return parseJSON(response);
+}

--- a/packages/mcl/src/src/mcl/utils/nix.d
+++ b/packages/mcl/src/src/mcl/utils/nix.d
@@ -1,0 +1,47 @@
+module mcl.utils.nix;
+
+import std.algorithm : filter, endsWith;
+import std.array : array;
+import std.conv : to;
+import std.exception : enforce;
+import std.format : fmt = format;
+import std.string : lineSplitter;
+
+import mcl.utils.process : execute;
+
+string queryStorePath(string storePath, string[] referenceSuffixes, string storeUrl)
+{
+    string lastMatch = storePath;
+
+    foreach (suffix; referenceSuffixes)
+        lastMatch = findMatchingNixReferences(lastMatch, suffix, storeUrl);
+
+    return lastMatch;
+}
+
+string findMatchingNixReferences(string nixStorePath, string suffix, string storeUrl) {
+    auto matches = nixQueryReferences(nixStorePath, storeUrl)
+        .filter!(path => path.endsWith(suffix))
+        .array;
+
+    enforce(matches.length > 0,
+        "No store paths with suffix: '%s'".fmt(suffix));
+    enforce(matches.length == 1,
+        "Multiple store paths with suffix: '%s'".fmt(suffix));
+
+    return matches[0];
+}
+
+string[] nixQueryReferences(string nixStorePath, string storeUrl) {
+    return [
+        "nix-store", "--store", storeUrl, "--query", "--references", nixStorePath
+    ]
+        .execute
+        .lineSplitter
+        .array
+        .to!(string[]);
+}
+
+void nixBuild(string storePath) {
+    ["nix", "build", storePath].execute();
+}

--- a/packages/mcl/src/src/mcl/utils/process.d
+++ b/packages/mcl/src/src/mcl/utils/process.d
@@ -1,0 +1,20 @@
+module mcl.utils.process;
+
+string execute(string[] args) {
+    import std.exception : enforce;
+    import std.format : format;
+    import std.process : execute;
+    import std.stdio : stderr;
+    stderr.writefln("$ %-(%s %)", args);
+    const res = execute(args);
+    enforce(res.status == 0, "Command `%s` failed with status %s".format(args, res.status));
+    return res.output;
+}
+
+unittest
+{
+    import std.exception : assertThrown;
+    assert(execute(["echo", "hello"]) == "hello\n");
+    assert(execute(["true"]) == "");
+    assertThrown(execute(["false"]), "Command `false` failed with status 1");
+}

--- a/packages/mcl/src/src/mcl/utils/string.d
+++ b/packages/mcl/src/src/mcl/utils/string.d
@@ -1,0 +1,32 @@
+module mcl.utils.string;
+
+string camelCaseToCapitalCase(string camelCase) {
+    import std.algorithm : splitWhen, map, joiner;
+    import std.conv : to;
+    import std.uni : isLower, isUpper, asUpperCase;
+
+    return camelCase
+        .splitWhen!((a, b) => isLower(a) && isUpper(b))
+        .map!asUpperCase
+        .joiner("_")
+        .to!string;
+}
+
+unittest {
+    assert(camelCaseToCapitalCase("camelCase") == "CAMEL_CASE");
+
+    assert(camelCaseToCapitalCase("") == "");
+    assert(camelCaseToCapitalCase("_") == "_");
+    assert(camelCaseToCapitalCase("a") == "A");
+    assert(camelCaseToCapitalCase("ab") == "AB");
+    assert(camelCaseToCapitalCase("aB") == "A_B");
+    assert(camelCaseToCapitalCase("aBc") == "A_BC");
+    assert(camelCaseToCapitalCase("aBC") == "A_BC");
+    assert(camelCaseToCapitalCase("aBCD") == "A_BCD");
+    assert(camelCaseToCapitalCase("aBcD") == "A_BC_D");
+
+    assert(camelCaseToCapitalCase("rpcUrl") == "RPC_URL");
+    assert(camelCaseToCapitalCase("parsedJSON") == "PARSED_JSON");
+    assert(camelCaseToCapitalCase("fromXmlToJson") == "FROM_XML_TO_JSON");
+    assert(camelCaseToCapitalCase("fromXML2JSON") == "FROM_XML2JSON");
+}

--- a/shells/default.nix
+++ b/shells/default.nix
@@ -23,6 +23,8 @@ in
       nix-output-monitor
       repl
       rage
+      inputs'.dlang-nix.packages.dmd
+      inputs'.dlang-nix.packages.dub
     ];
 
     shellHook = ''


### PR DESCRIPTION
- build(nix/flake): Add `dlang-nix` as flake input
- build(nix/shells): Add D tools
- config(git): Ignore `.env` files
- build(mcl/dub): Init project config
- feat(mcl/get_fstab): Add program that fetches `/etc/fstab` from Cachix deployment

Example usage:
```sh
export MACHINE=gpu-server-002
export DEPLOYMENT_ID=93
nix run 'github:metacraft-labs/nixos-modules#mcl' get_fstab
```