### PR TITLE
build(flake.nix/inputs): Let `nixd` use its own instance of nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -690,9 +690,7 @@
           "flake-parts"
         ],
         "flake-root": "flake-root_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1714186137,
@@ -840,6 +838,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1714280680,
+        "narHash": "sha256-eNTZCX/vK/BQOpY+6n5a6oGxBBe7qfSbtcppepCLAAQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9516f3c963708933abe984df94a925af38916237",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -134,7 +134,10 @@
     nixd = {
       url = "github:nix-community/nixd";
       inputs.flake-parts.follows = "flake-parts";
-      inputs.nixpkgs.follows = "nixpkgs";
+      # Please refrain from adding the following line:
+      # inputs.nixpkgs.follows = "nixpkgs";
+      #
+      # See: https://github.com/nix-community/nixd/blob/main/nixd/docs/editor-setup.md#installation---get-a-working-executable:~:text=do%20NOT%20override%20nixpkgs%20revision
     };
 
     validator-ejector = {


### PR DESCRIPTION
Changelog:

```
• Updated input 'nixd/nixpkgs':
    follows 'nixpkgs'
  → 'github:NixOS/nixpkgs/9516f3c963708933abe984df94a925af38916237' (2024-04-28)
```
