### PR TITLE
config(flake/inputs): Make `terranix` to use `nixpkgs 23.11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -840,6 +840,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1717880976,
+        "narHash": "sha256-BRvSCsKtDUr83NEtbGfHLUOdDK0Cgbezj2PtcHnz+sQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4913a7c3d8b8d00cb9476a6bd730ff57777f740c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -950,6 +966,7 @@
         "nixpkgs": [
           "nixos-2405"
         ],
+        "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems",
         "terranix": "terranix",
@@ -1014,7 +1031,7 @@
           "flake-utils"
         ],
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-2311"
         ],
         "terranix-examples": "terranix-examples"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,8 @@
 
     nixpkgs.follows = "nixos-2405";
 
+    nixpkgs-2311.url = "github:NixOS/nixpkgs/nixos-23.11";
+
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     home-manager = {
@@ -165,7 +167,7 @@
     terranix = {
       url = "github:terranix/terranix";
       inputs = {
-        nixpkgs.follows = "nixpkgs";
+        nixpkgs.follows = "nixpkgs-2311";
         flake-utils.follows = "flake-utils";
       };
     };


### PR DESCRIPTION
• Added input 'nixpkgs-2311':
    'github:NixOS/nixpkgs/4913a7c3d8b8d00cb9476a6bd730ff57777f740c' (2024-06-08)
• Updated input 'terranix/nixpkgs':
    follows 'nixpkgs'
  → follows 'nixpkgs-2311'
