### PR TITLE
ci(gh-actions): Fix `Final Results` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,9 +202,8 @@ jobs:
     runs-on: self-hosted
     name: Final Results
     needs: [build, slurp-matrix]
+    if: always()
     steps:
-      - uses: actions/checkout@v4
-
       - name: Post Comment
         uses: metacraft-labs/nixos-modules/.github/print-matrix@main
         with:
@@ -216,6 +215,12 @@ jobs:
           precalc_matrix: ${{ needs.slurp-matrix.outputs.fullMatrix }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: exit 1
+        if: >-
+          needs.slurp-matrix.outputs.matrix != '{"include":[]}'
+            && contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+
       - uses: cachix/cachix-action@v15
         if: inputs.do_deploy
         with:
@@ -225,14 +230,7 @@ jobs:
       - name: Deploy
         if: inputs.do_deploy
         env:
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_ACTIVATE_TOKEN: '${{ secrets.CACHIX_ACTIVATE_TOKEN }}'
         run: nix run --accept-flake-config github:metacraft-labs/nixos-modules#mcl deploy_spec
-
-      - run: exit 1
-        if: >-
-          ${{ fromJSON(needs.slurp-matrix.outputs.matrix).include.length > 0 &&
-            (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
-      - run: exit 0
-        if: >-
-          ${{fromJSON(needs.slurp-matrix.outputs.matrix).include.length == 0 &&
-          (contains(needs.*.result, 'success') || contains(needs.*.result, 'skipped')) }}

--- a/packages/mcl/src/main.d
+++ b/packages/mcl/src/main.d
@@ -1,7 +1,7 @@
 import std.stdio : writefln, writeln, stderr;
 import std.array : replace;
 import std.getopt : getopt;
-import std.logger : info, errorf;
+import std.logger : info, errorf, LogLevel;
 
 import cmds = mcl.commands;
 
@@ -22,10 +22,10 @@ int main(string[] args)
         return wrongUsage("no command selected");
 
     string command = args[1];
-    bool quiet = false;
-    args.getopt("q|quiet", &quiet);
+    LogLevel logLevel = LogLevel.info;
+    args.getopt("log-level", &logLevel);
 
-    if (quiet) disableLogging();
+    setLogLevel(logLevel);
 
     try switch (args[1])
     {
@@ -50,10 +50,11 @@ int main(string[] args)
     }
 }
 
-void disableLogging()
+void setLogLevel(LogLevel l)
 {
-    import std.logger : sharedLog, LogLevel, NullLogger;
-    sharedLog = cast(shared)new NullLogger(LogLevel.all);
+    import std.logger : globalLogLevel, sharedLog;
+    globalLogLevel = l;
+    (cast()sharedLog()).logLevel = l;
 }
 
 int wrongUsage(string error)

--- a/packages/mcl/src/src/mcl/commands/deploy_spec.d
+++ b/packages/mcl/src/src/mcl/commands/deploy_spec.d
@@ -1,27 +1,25 @@
 module mcl.commands.deploy_spec;
 
-import std.stdio : writeln;
-import mcl.utils.env : parseEnv;
-import mcl.utils.process : execute;
-import mcl.utils.path : rootDir;
+import std.logger : warningf;
+import std.file : exists;
+import std.path : buildPath;
+
+import mcl.utils.process : spawnProcessInline;
+import mcl.utils.path : resultDir;
+
+import mcl.commands.ci_matrix : ci_matrix;
 
 export void deploy_spec()
 {
-    const params = parseEnv!Params;
+    auto deploySpecFile = resultDir.buildPath("cachix-deploy-spec.json");
 
-    writeln(execute([
-            "cachix", "deploy", "activate", rootDir ~ "cachix-deploy-spec.json",
-            "--async"
-        ]));
-
-}
-
-struct Params
-{
-    string cachixAuthToken;
-    string cachixCache;
-
-    void setup()
+    if (!deploySpecFile.exists)
     {
+        warningf("'%s' file not found - building...", deploySpecFile);
+        ci_matrix();
     }
+
+    spawnProcessInline([
+        "cachix", "deploy", "activate", deploySpecFile
+    ]);
 }

--- a/packages/mcl/src/src/mcl/commands/deploy_spec.d
+++ b/packages/mcl/src/src/mcl/commands/deploy_spec.d
@@ -6,20 +6,50 @@ import std.path : buildPath;
 
 import mcl.utils.process : spawnProcessInline;
 import mcl.utils.path : resultDir;
+import mcl.utils.env : parseEnv;
 
-import mcl.commands.ci_matrix : ci_matrix;
+import mcl.commands.ci_matrix : ci_matrix, Params, nixEvalJobs, SupportedSystem;
+
+shared string deploySpecFile;
+
+shared static this()
+{
+    deploySpecFile = resultDir.buildPath("cachix-deploy-spec.json");
+}
 
 export void deploy_spec()
 {
-    auto deploySpecFile = resultDir.buildPath("cachix-deploy-spec.json");
-
     if (!deploySpecFile.exists)
     {
         warningf("'%s' file not found - building...", deploySpecFile);
-        ci_matrix();
+        createMachineDeploySpec();
     }
 
     spawnProcessInline([
         "cachix", "deploy", "activate", deploySpecFile
     ]);
+}
+
+void createMachineDeploySpec()
+{
+    import std.algorithm : map;
+    import std.array : assocArray;
+    import std.json : JSONValue;
+    import std.typecons : tuple;
+    import std.file : writeFile = write;
+
+    auto params = parseEnv!Params;
+    params.flakePre = "legacyPackages";
+    params.flakePost = ".bareMetalMachines";
+
+    string cachixUrl = "https://" ~ params.cachixCache ~ ".cachix.org";
+    auto packages = nixEvalJobs(params, SupportedSystem.x86_64_linux, cachixUrl);
+
+    auto result = [
+        "agents": packages
+            .map!(pkg => tuple(pkg.name, pkg.output))
+            .assocArray
+    ].JSONValue;
+
+    writeFile(deploySpecFile, result.toString());
 }

--- a/packages/mcl/src/src/mcl/utils/process.d
+++ b/packages/mcl/src/src/mcl/utils/process.d
@@ -61,3 +61,19 @@ unittest
     assert(execute(["true"]) == "");
     // assertThrown(execute(["false"]), "Command `false` failed with status 1");
 }
+
+void spawnProcessInline(string[] args)
+{
+    import std.logger : tracef;
+    import std.exception : enforce;
+    import std.process : spawnProcess, wait;
+
+    const bold = "\033[1m";
+    const normal = "\033[0m";
+
+
+    tracef("$ %s%-(%s %)%s", bold, args, normal);
+
+    auto pid = spawnProcess(args);
+    enforce(wait(pid) == 0, "Process failed.");
+}


### PR DESCRIPTION
- **ci(gh-actions): Always run the final step jobs**
- **feat(mcl): Add adjust the loglevel with via command-line args**
- **feat(mcl.utils.process): Add `spawnProcessInline` function**
- **refactor(mcl.commands.deploy_spec): Remove unused parameters and use `spawnProcessInline`**
- **improve(mcl.commands.ci_matrix): Log nix-eval-jobs cmd line**
- **feat(mcl.commands.deploy_spec): Implement `createMachineDeploySpec` and use it**
