### PR TITLE
feat(gh-actions): Allow passing custom GitHub token to use as nix access-token

### DIFF
--- a/.github/install-nix/action.yml
+++ b/.github/install-nix/action.yml
@@ -27,20 +27,19 @@ runs:
     - name: Install Nix
       uses: cachix/install-nix-action@v27
       if: ${{ runner.environment == 'github-hosted' }}
-      with:
-        extra_nix_config: |
-          ${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
-          accept-flake-config = true
-          allow-import-from-derivation = true
-          substituters = https://cache.nixos.org ${{inputs.substituters}}
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{inputs.trusted-public-keys}}
-          netrc-file = $HOME/.config/nix/netrc
 
     - name: Configure Nix
-      if: ${{ runner.environment == 'github-hosted' }}
       shell: bash
       run: |
         mkdir -p $HOME/.config/nix
         {
           echo "machine ${{inputs.cachix-cache}}.cachix.org password ${{inputs.cachix-auth-token}}"
         } >> $HOME/.config/nix/netrc
+        {
+          echo "${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
+          accept-flake-config = true
+          allow-import-from-derivation = true
+          substituters = https://cache.nixos.org ${{inputs.substituters}}
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{inputs.trusted-public-keys}}
+          netrc-file = $HOME/.config/nix/netrc"
+        } > $HOME/.config/nix/nix.conf

--- a/.github/install-nix/action.yml
+++ b/.github/install-nix/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: Substituters
     required: false
     default: ''
+  nix-github-token:
+    description: GitHub token to add as access-token in nix.conf
+    default: ''
+    required: false
 
 runs:
   using: "composite"
@@ -25,6 +29,7 @@ runs:
       if: ${{ runner.environment == 'github-hosted' }}
       with:
         extra_nix_config: |
+          ${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
           accept-flake-config = true
           allow-import-from-derivation = true
           substituters = https://cache.nixos.org ${{inputs.substituters}}

--- a/.github/print-matrix/action.yml
+++ b/.github/print-matrix/action.yml
@@ -21,8 +21,8 @@ inputs:
   precalc_matrix:
     description: Pre-calculated matrix
     required: true
-  token:
-    description: GitHub token
+  pr-comment-github-token:
+    description: GitHub token used to post the PR comment
     required: true
 
 outputs:
@@ -63,6 +63,6 @@ runs:
     - name: Update GitHub Comment
       uses: marocchino/sticky-pull-request-comment@v2.9.0
       with:
-        GITHUB_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN: ${{ inputs.pr-comment-github-token }}
         recreate: true
         path: comment.md

--- a/.github/print-matrix/action.yml
+++ b/.github/print-matrix/action.yml
@@ -57,13 +57,8 @@ runs:
         CACHIX_CACHE: ${{ inputs.cachix-cache }}
         CACHIX_AUTH_TOKEN: ${{ inputs.cachix-auth-token }}
         PRECALC_MATRIX: ${{ inputs.precalc_matrix }}
-      run: |
-        if [ "${{ github.repository }}" != "metacraft-labs/nixos-modules" ]; then
-          nix run --accept-flake-config github:metacraft-labs/nixos-modules#mcl print_table
-        else
-          nix run --accept-flake-config .#mcl print_table
-        fi
-        cat comment.md
+        MCL_BRANCH: ${{ github.repository == 'metacraft-labs/nixos-modules' && github.sha || 'main' }}
+      run: nix run --accept-flake-config github:metacraft-labs/nixos-modules/${{ env.MCL_BRANCH }}#mcl print_table
 
     - name: Update GitHub Comment
       uses: marocchino/sticky-pull-request-comment@v2.9.0

--- a/.github/print-matrix/action.yml
+++ b/.github/print-matrix/action.yml
@@ -24,6 +24,10 @@ inputs:
   pr-comment-github-token:
     description: GitHub token used to post the PR comment
     required: true
+  nix-github-token:
+    description: GitHub token to add as access-token in nix.conf
+    default: ''
+    required: false
 
 outputs:
   matrix:
@@ -43,6 +47,7 @@ runs:
         cachix-auth-token: ${{ inputs.CACHIX_AUTH_TOKEN }}
         trusted-public-keys: ${{ inputs.TRUSTED_PUBLIC_KEYS }}
         substituters: ${{ inputs.SUBSTITUTERS }}
+        nix-github-token: ${{ inputs.nix-github-token }}
 
     - name: Print CI Matrix
       id: print-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           precalc_matrix: ${{ steps.matrix.outputs.fullMatrix }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     needs: slurp-matrix
@@ -213,7 +213,7 @@ jobs:
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           precalc_matrix: ${{ needs.slurp-matrix.outputs.fullMatrix }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: exit 1
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,6 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       fullMatrix: ${{ steps.matrix.outputs.fullMatrix }}
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
       - name: Merge matrices
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,9 @@
 name: 'CI'
+inputs:
+  nix-github-token:
+    description: GitHub token to add as access-token in nix.conf
+    default: ''
+    required: false
 
 on:
   # Allow this workflow to be reused by other workflows:
@@ -182,8 +187,15 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@V27
-        with:
-          extra_nix_config: accept-flake-config = true
+
+      - name: Configure Nix
+        shell: bash
+        run: |
+          mkdir -p $HOME/.config/nix
+          {
+            echo "${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
+            accept-flake-config = true"
+          } > $HOME/.config/nix/nix.conf
 
       - uses: cachix/cachix-action@v15
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,11 @@ jobs:
       - uses: actions/download-artifact@v4
       - name: Merge matrices
         run: |
-          PATH="$(nix build --print-out-paths 'nixpkgs#jq^bin')/bin:$PATH"
-          export PATH
+          # Check if jq is installed
+          if ! command -v jq &> /dev/null; then
+            PATH="$(nix build --print-out-paths 'nixpkgs#jq^bin')/bin:$PATH"
+            export PATH
+          fi
 
           ls */matrix-pre.json
           matrix="$(cat */matrix-pre.json | jq -cr '.include[]' | jq '[ select (.isCached == false) ]' | jq -s 'add' | jq -c  '. | {include: .}')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,9 @@ jobs:
 
       - name: Generate Matrix for Matrix
         id: generate-matrix
-        run: |
-          if [ "${{ github.repository }}" != "metacraft-labs/nixos-modules" ]; then
-            nix run --accept-flake-config github:metacraft-labs/nixos-modules#mcl shard_matrix
-          else
-            nix run --accept-flake-config .#mcl shard_matrix
-          fi
+        env:
+          MCL_BRANCH: ${{ github.repository == 'metacraft-labs/nixos-modules' && github.sha || 'main' }}
+        run: nix run --accept-flake-config github:metacraft-labs/nixos-modules/${{ env.MCL_BRANCH }}#mcl shard_matrix
     outputs:
       gen_matrix: ${{ steps.generate-matrix.outputs.gen_matrix }}
 
@@ -103,12 +100,8 @@ jobs:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           FLAKE_PRE: ${{ matrix.prefix }}
           FLAKE_POST: ${{ matrix.postfix }}
-        run: |
-          if [ "${{ github.repository }}" != "metacraft-labs/nixos-modules" ]; then
-            nix run --accept-flake-config github:metacraft-labs/nixos-modules#mcl ci_matrix
-          else
-            nix run --accept-flake-config .#mcl ci_matrix
-          fi
+          MCL_BRANCH: ${{ github.repository == 'metacraft-labs/nixos-modules' && github.sha || 'main' }}
+        run: nix run --accept-flake-config github:metacraft-labs/nixos-modules/${{ env.MCL_BRANCH }}#mcl ci_matrix
 
       - uses: actions/upload-artifact@v4
         with:
@@ -244,4 +237,5 @@ jobs:
           CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_ACTIVATE_TOKEN: '${{ secrets.CACHIX_ACTIVATE_TOKEN }}'
-        run: nix run --accept-flake-config github:metacraft-labs/nixos-modules#mcl deploy_spec
+          MCL_BRANCH: ${{ github.repository == 'metacraft-labs/nixos-modules' && github.sha || 'main' }}
+        run: nix run --accept-flake-config github:metacraft-labs/nixos-modules/${{ env.MCL_BRANCH }}#mcl deploy_spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
         type: 'boolean'
         default: false
         required: false
+    secrets:
+      nix-github-token:
+        description: GitHub token to add as access-token in nix.conf
+        required: false
 
   # Allow this workflow to be triggered manually:
   workflow_dispatch:
@@ -57,6 +61,7 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.nix-github-token }}
 
       - uses: actions/checkout@v4
 
@@ -85,6 +90,7 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.nix-github-token }}
 
       - uses: actions/checkout@v4
 
@@ -162,6 +168,7 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           precalc_matrix: ${{ steps.matrix.outputs.fullMatrix }}
           pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-github-token: ${{ secrets.nix-github-token }}
 
   build:
     needs: slurp-matrix
@@ -214,6 +221,7 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           precalc_matrix: ${{ needs.slurp-matrix.outputs.fullMatrix }}
           pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}
+          nix-github-token: ${{ secrets.nix-github-token }}
 
       - run: exit 1
         if: >-

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -11,6 +11,12 @@ on:
   schedule:
     - cron: 0 0 * * 0 # https://crontab.guru/#0_0_*_*_0
 
+inputs:
+  nix-github-token:
+    description: GitHub token to add as access-token in nix.conf
+    default: ''
+    required: false
+
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -21,8 +27,15 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v27
         if: ${{ runner.environment == 'github-hosted' }}
-        with:
-          extra_nix_config: accept-flake-config = true
+
+      - name: Configure Nix
+        shell: bash
+        run: |
+          mkdir -p $HOME/.config/nix
+          {
+            echo "${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
+            accept-flake-config = true"
+          } > $HOME/.config/nix/nix.conf
 
       - name: Run `nix flake update`
         id: update-lockfile

--- a/.github/workflows/update-flake-packages.yml
+++ b/.github/workflows/update-flake-packages.yml
@@ -11,6 +11,12 @@ on:
   schedule:
     - cron: "0 0 * * *" # https://crontab.guru/#0_0_*_*_*
 
+inputs:
+  nix-github-token:
+    description: GitHub token to add as access-token in nix.conf
+    default: ''
+    required: false
+
 jobs:
   updateFlakePackages:
     runs-on: ubuntu-latest
@@ -21,10 +27,16 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v27
         if: ${{ runner.environment == 'github-hosted' }}
-        with:
-          extra_nix_config: |
+
+      - name: Configure Nix
+        shell: bash
+        run: |
+          mkdir -p $HOME/.config/nix
+          {
+            echo "${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
             accept-flake-config = true
-            allow-import-from-derivation = true
+            allow-import-from-derivation = true"
+          } > $HOME/.config/nix/nix.conf
 
       - uses: tibdex/github-app-token@v2.1.0
         id: generate-token

--- a/packages/mcl/src/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/src/mcl/commands/ci_matrix.d
@@ -422,7 +422,7 @@ unittest
 
 void saveGHCIComment(SummaryTableEntry[] tableSummaryJSON)
 {
-    import std.path : buildPath, absolutePath;
+    import std.path : buildNormalizedPath, absolutePath;
 
     string comment = "Thanks for your Pull Request!";
     comment ~= "\n\nBelow you will find a summary of the cachix status of each package, for each supported platform.";
@@ -432,7 +432,7 @@ void saveGHCIComment(SummaryTableEntry[] tableSummaryJSON)
         pkg => "\n| " ~ pkg.name ~ " | " ~ pkg.x86_64.linux ~ " | " ~ pkg.x86_64.darwin ~ " | " ~ pkg.aarch64.darwin ~ " |")
         .join("");
 
-    auto outputPath = rootDir.buildPath("comment.md").absolutePath;
+    auto outputPath = rootDir.buildNormalizedPath("comment.md");
     write(outputPath, comment);
     infof("Wrote GitHub comment file to '%s'", outputPath);
 }


### PR DESCRIPTION
* ci(gh-actions/print-matrix-action): Rename `token` to `pr-comment-github-token` input parameter
* ci(gh-actions/workflows/ci): Allow passing custom GITHUB_TOKEN to use as Nix access-token
* ci(gh-actions/workflows/ci): Switch to github-hosted runners to allow setting nix.conf access-tokens
* fix(mcl.utils.path.rootDir): Handle the case where we're not in a git repo