### PR TITLE
fix(gh-actions): Refactor install-nix action and update secret inputs'

### DIFF
--- a/.github/install-nix/action.yml
+++ b/.github/install-nix/action.yml
@@ -32,14 +32,15 @@ runs:
       shell: bash
       run: |
         mkdir -p $HOME/.config/nix
-        {
-          echo "machine ${{inputs.cachix-cache}}.cachix.org password ${{inputs.cachix-auth-token}}"
-        } >> $HOME/.config/nix/netrc
-        {
-          echo "${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
-          accept-flake-config = true
+
+        cat << EOF > "$HOME/.config/nix/nix.conf"
+          ${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
           allow-import-from-derivation = true
           substituters = https://cache.nixos.org ${{inputs.substituters}}
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{inputs.trusted-public-keys}}
           netrc-file = $HOME/.config/nix/netrc"
-        } > $HOME/.config/nix/nix.conf
+        EOF
+
+        cat << EOF > "$HOME/.config/nix/netrc"
+          machine ${{inputs.cachix-cache}}.cachix.org password ${{inputs.cachix-auth-token}}
+        EOF

--- a/.github/install-nix/action.yml
+++ b/.github/install-nix/action.yml
@@ -28,6 +28,11 @@ runs:
       uses: cachix/install-nix-action@v27
       if: ${{ runner.environment == 'github-hosted' }}
 
+    - name: Install Cachix
+      if: ${{ runner.environment == 'github-hosted' }}
+      shell: bash
+      run: nix profile install nixpkgs#cachix
+
     - name: Configure Nix
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
         default: false
         required: false
     secrets:
-      nix-github-token:
+      NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
 
@@ -61,7 +61,7 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
-          nix-github-token: ${{ secrets.nix-github-token }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
 
@@ -87,7 +87,7 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
-          nix-github-token: ${{ secrets.nix-github-token }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
 
@@ -163,7 +163,7 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           precalc_matrix: ${{ steps.matrix.outputs.fullMatrix }}
           pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-github-token: ${{ secrets.nix-github-token }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
 
   build:
     needs: slurp-matrix
@@ -223,7 +223,7 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           precalc_matrix: ${{ needs.slurp-matrix.outputs.fullMatrix }}
           pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-github-token: ${{ secrets.nix-github-token }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
 
       - run: exit 1
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
         default: false
         required: false
     secrets:
+      CACHIX_AUTH_TOKEN:
+        description: 'Cachix auth token'
+        required: true
+      CACHIX_ACTIVATE_TOKEN:
+        description: 'Cachix activate token'
+        required: false
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
@@ -181,22 +187,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@V27
-
-      - name: Configure Nix
-        shell: bash
-        run: |
-          mkdir -p $HOME/.config/nix
-          {
-            echo "${{ inputs.nix-github-token != '' && format('access-tokens = github.com={0}', inputs.nix-github-token) || '' }}
-            accept-flake-config = true"
-          } > $HOME/.config/nix/nix.conf
-
-      - uses: cachix/cachix-action@v15
+        uses: metacraft-labs/nixos-modules/.github/install-nix@main
         with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          extraPullNames: ${{ vars.EXTRA_CACHIX_CACHES }}
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
 
       - name: Build ${{ matrix.name }}
         run: |
@@ -230,12 +227,6 @@ jobs:
           needs.slurp-matrix.outputs.matrix != '{"include":[]}'
             && contains(needs.*.result, 'failure')
             || contains(needs.*.result, 'cancelled')
-
-      - uses: cachix/cachix-action@v15
-        if: inputs.do_deploy
-        with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Deploy
         if: inputs.do_deploy

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -7,6 +7,9 @@ on:
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
+      CACHIX_AUTH_TOKEN:
+        description: 'Cachix auth token'
+        required: true
       CREATE_PR_APP_ID:
         description: ID of the GitHub App used for opening pull requests.
         required: true
@@ -29,17 +32,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        if: ${{ runner.environment == 'github-hosted' }}
-
-      - name: Configure Nix
-        shell: bash
-        run: |
-          mkdir -p $HOME/.config/nix
-          cat << EOF > "$HOME/.config/nix/nix.conf"
-            ${{ secrets.NIX_GITHUB_TOKEN != '' && format('access-tokens = github.com={0}', secrets.NIX_GITHUB_TOKEN) || '' }}
-            allow-import-from-derivation = true
-          EOF
+        uses: metacraft-labs/nixos-modules/.github/install-nix@main
+        with:
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
 
       - name: Run `nix flake update`
         id: update-lockfile

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -4,7 +4,7 @@ on:
   # Allow this workflow to be reused by other workflows:
   workflow_call:
     secrets:
-      nix-github-token:
+      NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
 
@@ -31,7 +31,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/nix
           {
-            echo "${{ secrets.nix-github-token != '' && format('access-tokens = github.com={0}', secrets.nix-github-token) || '' }}
+            echo "${{ secrets.NIX_GITHUB_TOKEN != '' && format('access-tokens = github.com={0}', secrets.NIX_GITHUB_TOKEN) || '' }}
             accept-flake-config = true"
           } > $HOME/.config/nix/nix.conf
 

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -36,11 +36,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p $HOME/.config/nix
-          {
-            echo "${{ secrets.NIX_GITHUB_TOKEN != '' && format('access-tokens = github.com={0}', secrets.NIX_GITHUB_TOKEN) || '' }}
-            accept-flake-config = true"
-          } > $HOME/.config/nix/nix.conf
-
+          cat << EOF > "$HOME/.config/nix/nix.conf"
+            ${{ secrets.NIX_GITHUB_TOKEN != '' && format('access-tokens = github.com={0}', secrets.NIX_GITHUB_TOKEN) || '' }}
+            allow-import-from-derivation = true
+          EOF
 
       - name: Run `nix flake update`
         id: update-lockfile

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -7,6 +7,12 @@ on:
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
+      CREATE_PR_APP_ID:
+        description: ID of the GitHub App used for opening pull requests.
+        required: true
+      CREATE_PR_APP_PRIVATE_KEY:
+        description: Private key of the GitHub App used for opening pull requests.
+        required: true
 
   # Allow this workflow to be triggered manually:
   workflow_dispatch:
@@ -47,8 +53,8 @@ jobs:
       - uses: tibdex/github-app-token@v2.1.0
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.CREATE_PR_APP_ID }}
+          private_key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: ${{ hashFiles('commit_msg_body.txt') != '' }}

--- a/.github/workflows/update-flake-packages.yml
+++ b/.github/workflows/update-flake-packages.yml
@@ -7,6 +7,9 @@ on:
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
+      CACHIX_AUTH_TOKEN:
+        description: 'Cachix auth token'
+        required: true
       CREATE_PR_APP_ID:
         description: ID of the GitHub App used for opening pull requests.
         required: true
@@ -29,17 +32,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        if: ${{ runner.environment == 'github-hosted' }}
-
-      - name: Configure Nix
-        shell: bash
-        run: |
-          mkdir -p $HOME/.config/nix
-          cat << EOF > "$HOME/.config/nix/nix.conf"
-            ${{ secrets.NIX_GITHUB_TOKEN != '' && format('access-tokens = github.com={0}', secrets.NIX_GITHUB_TOKEN) || '' }}
-            allow-import-from-derivation = true
-          EOF
+        uses: metacraft-labs/nixos-modules/.github/install-nix@main
+        with:
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
 
       - uses: tibdex/github-app-token@v2.1.0
         id: generate-token

--- a/.github/workflows/update-flake-packages.yml
+++ b/.github/workflows/update-flake-packages.yml
@@ -36,11 +36,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p $HOME/.config/nix
-          {
-            echo "${{ secrets.NIX_GITHUB_TOKEN != '' && format('access-tokens = github.com={0}', secrets.NIX_GITHUB_TOKEN) || '' }}
-            accept-flake-config = true
-            allow-import-from-derivation = true"
-          } > $HOME/.config/nix/nix.conf
+          cat << EOF > "$HOME/.config/nix/nix.conf"
+            ${{ secrets.NIX_GITHUB_TOKEN != '' && format('access-tokens = github.com={0}', secrets.NIX_GITHUB_TOKEN) || '' }}
+            allow-import-from-derivation = true
+          EOF
 
       - uses: tibdex/github-app-token@v2.1.0
         id: generate-token

--- a/.github/workflows/update-flake-packages.yml
+++ b/.github/workflows/update-flake-packages.yml
@@ -4,7 +4,7 @@ on:
   # Allow this workflow to be reused by other workflows:
   workflow_call:
     secrets:
-      nix-github-token:
+      NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
 
@@ -31,7 +31,7 @@ jobs:
         run: |
           mkdir -p $HOME/.config/nix
           {
-            echo "${{ secrets.nix-github-token != '' && format('access-tokens = github.com={0}', secrets.nix-github-token) || '' }}
+            echo "${{ secrets.NIX_GITHUB_TOKEN != '' && format('access-tokens = github.com={0}', secrets.NIX_GITHUB_TOKEN) || '' }}
             accept-flake-config = true
             allow-import-from-derivation = true"
           } > $HOME/.config/nix/nix.conf

--- a/.github/workflows/update-flake-packages.yml
+++ b/.github/workflows/update-flake-packages.yml
@@ -7,6 +7,12 @@ on:
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
+      CREATE_PR_APP_ID:
+        description: ID of the GitHub App used for opening pull requests.
+        required: true
+      CREATE_PR_APP_PRIVATE_KEY:
+        description: Private key of the GitHub App used for opening pull requests.
+        required: true
 
   # Allow this workflow to be triggered manually:
   workflow_dispatch:
@@ -39,8 +45,8 @@ jobs:
       - uses: tibdex/github-app-token@v2.1.0
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.CREATE_PR_APP_ID }}
+          private_key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
       - name: Update flake packages
         uses: metacraft-labs/nix-update-action@main

--- a/.github/workflows/update-flake-packages.yml
+++ b/.github/workflows/update-flake-packages.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   updateFlakePackages:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- **refactor(gh-actions): Rename `nix-github-token` secret to `NIX_GITHUB_TOKEN`**
- **refactor(gh-actions/update-{flake-lock,flake-packages}): Switch to self-hosted runners**
- **fix(gh-actions/update-{flake-lock,flake-packages}): Pass all secrets used by the action on `workflow_call`**
- **refactor(gh-actions): Use bash heredoc string**
- **refactor(gh-actions): Use the our own `install-nix` action**
