### PR TITLE
fix(mcl.commands.{shard_matrix,ci_matrix}): Various bug fixes and refactorings

### DIFF
--- a/packages/mcl/src/src/mcl/commands/ci.d
+++ b/packages/mcl/src/src/mcl/commands/ci.d
@@ -9,7 +9,7 @@ import std.conv : to;
 import std.process : ProcessPipes;
 
 import mcl.utils.env : optional, parseEnv;
-import mcl.commands.ci_matrix: nixEvalJobs, SupportedSystem, Params;
+import mcl.commands.ci_matrix: nixEvalJobs, SupportedSystem, Params, flakeAttr;
 import mcl.commands.shard_matrix: generateShardMatrix;
 import mcl.utils.path : rootDir, createResultDirs;
 import mcl.utils.process : execute;
@@ -52,7 +52,9 @@ export void ci()
             string os = "darwin";
         }
 
-        auto matrix = nixEvalJobs(params, (arch ~ "_" ~ os).to!(SupportedSystem), cachixUrl, false);
+        auto matrix = flakeAttr(params.flakePre, arch, os, params.flakePost)
+            .nixEvalJobs(cachixUrl, false);
+
         foreach (pkg; matrix)
         {
             if (pkg.isCached)

--- a/packages/mcl/src/src/mcl/commands/deploy_spec.d
+++ b/packages/mcl/src/src/mcl/commands/deploy_spec.d
@@ -8,7 +8,7 @@ import mcl.utils.process : spawnProcessInline;
 import mcl.utils.path : resultDir;
 import mcl.utils.env : parseEnv;
 
-import mcl.commands.ci_matrix : ci_matrix, Params, nixEvalJobs, SupportedSystem;
+import mcl.commands.ci_matrix : flakeAttr, Params, nixEvalJobs, SupportedSystem;
 
 shared string deploySpecFile;
 
@@ -39,11 +39,11 @@ void createMachineDeploySpec()
     import std.file : writeFile = write;
 
     auto params = parseEnv!Params;
-    params.flakePre = "legacyPackages";
-    params.flakePost = ".bareMetalMachines";
 
     string cachixUrl = "https://" ~ params.cachixCache ~ ".cachix.org";
-    auto packages = nixEvalJobs(params, SupportedSystem.x86_64_linux, cachixUrl);
+
+    auto packages = flakeAttr("legacyPackages", SupportedSystem.x86_64_linux, "bareMetalMachines")
+        .nixEvalJobs(cachixUrl);
 
     auto result = [
         "agents": packages

--- a/packages/mcl/src/src/mcl/commands/shard_matrix.d
+++ b/packages/mcl/src/src/mcl/commands/shard_matrix.d
@@ -6,7 +6,7 @@ import std.array : array;
 import std.conv : to, parse;
 import std.file : append, write;
 import std.format : fmt = format;
-import std.logger : errorf, infof;
+import std.logger : warningf, infof;
 import std.path : buildPath;
 import std.range : iota;
 import std.regex : matchFirst, regex;
@@ -69,7 +69,7 @@ ShardMatrix generateShardMatrix(string flakeRef = ".")
 
     if (shardCount == 0)
     {
-        errorf("No shards found, exiting");
+        warningf("No shards found, exiting");
         return ShardMatrix([Shard("", "", -1)]);
     }
 

--- a/packages/mcl/src/src/mcl/commands/shard_matrix.d
+++ b/packages/mcl/src/src/mcl/commands/shard_matrix.d
@@ -5,6 +5,7 @@ import std.algorithm : map;
 import std.array : array;
 import std.conv : to, parse;
 import std.file : append, write;
+import std.format : fmt = format;
 import std.logger : errorf, infof;
 import std.path : buildPath;
 import std.range : iota;
@@ -92,7 +93,7 @@ unittest
     auto shards = generateShardMatrix(flakeRef);
     assert(shards.include.length == 11);
     assert(shards.include[0].prefix == "legacyPackages");
-    assert(shards.include[0].postfix == "shards.0");
+    assert(shards.include[0].postfix == "mcl.matrix.shards.0");
     assert(shards.include[0].digit == 0);
 }
 
@@ -114,7 +115,7 @@ ShardMatrix splitToShards(int shardCount)
     ShardMatrix shards;
     shards.include = shardCount
         .iota
-        .map!(i => Shard("legacyPackages", "shards." ~ i.to!string, i))
+        .map!(i => Shard("legacyPackages", "mcl.matrix.shards.%s".fmt(i), i))
         .array;
 
     return shards;
@@ -126,13 +127,13 @@ unittest
     auto shards = splitToShards(3);
     assert(shards.include.length == 3);
     assert(shards.include[0].prefix == "legacyPackages");
-    assert(shards.include[0].postfix == "shards.0");
+    assert(shards.include[0].postfix == "mcl.matrix.shards.0");
     assert(shards.include[0].digit == 0);
     assert(shards.include[1].prefix == "legacyPackages");
-    assert(shards.include[1].postfix == "shards.1");
+    assert(shards.include[1].postfix == "mcl.matrix.shards.1");
     assert(shards.include[1].digit == 1);
     assert(shards.include[2].prefix == "legacyPackages");
-    assert(shards.include[2].postfix == "shards.2");
+    assert(shards.include[2].postfix == "mcl.matrix.shards.2");
     assert(shards.include[2].digit == 2);
 
 }

--- a/packages/mcl/src/src/mcl/utils/process.d
+++ b/packages/mcl/src/src/mcl/utils/process.d
@@ -18,7 +18,7 @@ T execute(T = string)(string[] args, bool printCommand = true, bool returnErr = 
     import std.exception : enforce;
     import std.format : format;
     import std.process : pipeShell, wait, Redirect, escapeShellCommand;
-    import std.logger : infof, logf, LogLevel;
+    import std.logger : tracef, errorf, infof;
     import std.array : join;
     import std.algorithm : map;
     import std.conv : to;
@@ -27,7 +27,7 @@ T execute(T = string)(string[] args, bool printCommand = true, bool returnErr = 
 
     if (printCommand)
     {
-        LogLevel.info.logf("\n$ `%s`", cmd);
+        infof("\n$ `%s`", cmd.bold);
     }
     auto res = pipeShell(cmd, Redirect.all);
     static if (is(T == ProcessPipes))
@@ -41,14 +41,26 @@ T execute(T = string)(string[] args, bool printCommand = true, bool returnErr = 
         string output = stdout;
 
         int status = wait(res.pid);
-        // enforce(status == 0, "Command `%s` failed with status %s, stderr: \n%s".format(args, status, stderr));
 
-        infof("
-        ---
-        $ `%s`
-        stdout: `%s`
-        stderr: `%s`
-        ---", cmd.bold, stdout.bold, stderr.bold);
+        if (status != 0)
+        {
+            errorf("Command failed:
+            ---
+            $ `%s`
+            stdout: `%s`
+            stderr: `%s`
+            ---", cmd.bold, stdout.bold, stderr.bold);
+        }
+        else
+        {
+            tracef("
+            ---
+            $ `%s`
+            stdout: `%s`
+            stderr: `%s`
+            ---", cmd.bold, stdout.bold, stderr.bold);
+        }
+
 
         if (returnErr)
         {


### PR DESCRIPTION
- **refactor(mcl/commands/{ci,ci_matrix,deploy_spec}): Factor-out repreating code in `flakeAttr` function**
- **refactor(mcl/commands/ci_matrix): Factor-out `packageFromNixEvalJobsJson` function**
- **fix(mcl.commands.shard_matrix): Use the new nixos-modules option**
- **improve(mcl.utils.process): Improve logging**
- **improve(mcl.commands.ci_matrix): Run nix-eval-jobs only for the supported systems**
- **fix(mcl.commands.ci_matrix): Fail-fast if `nix-eval-jobs` returns an error**
