### PR TITLE
feat(flake.nix/inputs/nixpkgs): Switch `nixos-24.11` -> `staging-next-24.11` to fix `curl v8.11.0` regression

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -779,16 +779,16 @@
     },
     "nixos-2411": {
       "locked": {
-        "lastModified": 1731755305,
-        "narHash": "sha256-v5P3dk5JdiT+4x69ZaB18B8+Rcu3TIOrcdG4uEX7WZ8=",
+        "lastModified": 1732493954,
+        "narHash": "sha256-sRq0GxKiKFkoPfa7h23UgVFaHNMOq7T7xykzLdjo5Go=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "057f63b6dc1a2c67301286152eb5af20747a9cb4",
+        "rev": "7c57e4c3e26c247f93791a9aafbd89260e661504",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "staging-next-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,10 @@
   inputs = {
     nixos-2311.url = "github:NixOS/nixpkgs/nixos-23.11";
     nixos-2405.url = "github:NixOS/nixpkgs/nixos-24.05";
-    nixos-2411.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+    # FIXME: change back to `nixos-24.11` once
+    # https://nixpk.gs/pr-tracker.html?pr=356660 is all green
+    nixos-2411.url = "github:NixOS/nixpkgs/staging-next-24.11";
 
     nixpkgs.follows = "nixos-2411";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
`curl` v8.11.0 was released with a bug that causes `git fetch` (and related commands, including Nix's [fetchers][3]) to fail due to failure to parse `.netrc` files. Luckily, after the bug was [reported upstream][1], a fix was quickly proposed and merged by its main [developer][2]. Not long after, the upstream `curl` patch was [backported][5] to the Nixpkgs `curl` derivation.

Given that we rely on `.netrc` files this bug is a showstopper for us, so its important that we switch to the patched `curl` version ASAP. Instead of [waiting for the build to land][5] on the `nixos-24.11` branch, we will switch directly to the `staging-next-24.11` branch, which already includes the fix.

[1]: https://github.com/curl/curl/issues/15496
[2]: https://github.com/curl/curl/commit/f5c616930b5cf148b1b2632da4f5963ff48bdf88
[3]: https://github.com/NixOS/nixpkgs/issues/356114
[4]: https://github.com/NixOS/nixpkgs/pull/356133
[5]: https://nixpk.gs/pr-tracker.html?pr=356660