### PR TITLE
build(flake/inputs): Switch to stable branch of `nixos-2411` input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -779,16 +779,16 @@
     },
     "nixos-2411": {
       "locked": {
-        "lastModified": 1734740237,
-        "narHash": "sha256-vuJ1YSKW5qAEqgz8l8//tjRc075hjjp8QrFF3mkQ7U0=",
+        "lastModified": 1735141468,
+        "narHash": "sha256-VIAjBr1qGcEbmhLwQJD6TABppPMggzOvqFsqkDoMsAY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7567e02bce78609fda55d7afcd40092b0492ce6",
+        "rev": "4005c3ff7505313cbc21081776ad0ce5dfd7a3ce",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "staging-next-24.11",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,10 +15,7 @@
   inputs = {
     nixos-2311.url = "github:NixOS/nixpkgs/nixos-23.11";
     nixos-2405.url = "github:NixOS/nixpkgs/nixos-24.05";
-
-    # FIXME: change back to `nixos-24.11` once
-    # https://nixpk.gs/pr-tracker.html?pr=356660 is all green
-    nixos-2411.url = "github:NixOS/nixpkgs/staging-next-24.11";
+    nixos-2411.url = "github:NixOS/nixpkgs/nixos-24.11";
 
     nixpkgs.follows = "nixos-2411";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
```
• Updated input 'nixos-2411':
    'github:NixOS/nixpkgs/d7567e02bce78609fda55d7afcd40092b0492ce6?narHash=sha256-vuJ1YSKW5qAEqgz8l8//tjRc075hjjp8QrFF3mkQ7U0%3D' (2024-12-21)
  → 'github:NixOS/nixpkgs/4005c3ff7505313cbc21081776ad0ce5dfd7a3ce?narHash=sha256-VIAjBr1qGcEbmhLwQJD6TABppPMggzOvqFsqkDoMsAY%3D' (2024-12-25)
```