### PR TITLE
chore(flake): Update `ethereum-nix` input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733694224,
-        "narHash": "sha256-BH523P77WD2Bxt3UO3EgZ3lmRPmmqHmfEDf0Atppi28=",
+        "lastModified": 1737131381,
+        "narHash": "sha256-HSB25rwO+ZWQgUVlnF1QW0Q6i16hEewDV5JQ352DvrU=",
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
-        "rev": "2f1aab0a41962dba729bdd112fed2eb8719d30d4",
+        "rev": "bb7bbe4cd420a3c05be57b1f543a89686d6b9749",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'ethereum-nix':
    'github:metacraft-labs/ethereum.nix/2f1aab0a41962dba729bdd112fed2eb8719d30d4?narHash=sha256-BH523P77WD2Bxt3UO3EgZ3lmRPmmqHmfEDf0Atppi28%3D' (2024-12-08)
  → 'github:metacraft-labs/ethereum.nix/bb7bbe4cd420a3c05be57b1f543a89686d6b9749?narHash=sha256-HSB25rwO%2BZWQgUVlnF1QW0Q6i16hEewDV5JQ352DvrU%3D' (2025-01-17)
```
