### PR TITLE
update(flake.lock): Update ethereum-nix in Flake lockfile

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738758842,
-        "narHash": "sha256-IJKw5uQElURWsCNdresXy53AEEfx4fZ/Wy2NEu9yPNE=",
+        "lastModified": 1739196730,
+        "narHash": "sha256-APZ7vA83cLA1/n2TBHacjKUrDMmB/sfh6oyHzlElLNk=",
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
-        "rev": "c173a6474155f19e69c80db11c934b962611def4",
+        "rev": "22bd52c9056044384473ee6abd76fe281fdbd346",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'ethereum-nix':
    'github:metacraft-labs/ethereum.nix/c173a6474155f19e69c80db11c934b962611def4?narHash=sha256-IJKw5uQElURWsCNdresXy53AEEfx4fZ/Wy2NEu9yPNE%3D' (2025-02-05)
  → 'github:metacraft-labs/ethereum.nix/22bd52c9056044384473ee6abd76fe281fdbd346?narHash=sha256-APZ7vA83cLA1/n2TBHacjKUrDMmB/sfh6oyHzlElLNk%3D' (2025-02-10)
 ```