### PR TITLE
chore(flake.lock): Update ethereum-nix input (2025-02-25)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740131728,
-        "narHash": "sha256-Qg+IvBAf3DEI9VbOy2ZZcJ5Sv98C9zxJ5QMuXd91gTQ=",
+        "lastModified": 1740476118,
+        "narHash": "sha256-F6eMtPaszqzvX7XOVpjkAJUuYgfylqmj1lDeMvbXnfg=",
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
-        "rev": "3b34218a88c25e2e8801e87875b2572155843f32",
+        "rev": "34a25367b8f71ba6fafffbff512d566b15dc0b32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'ethereum-nix':
    'github:metacraft-labs/ethereum.nix/3b34218a88c25e2e8801e87875b2572155843f32?narHash=sha256-Qg%2BIvBAf3DEI9VbOy2ZZcJ5Sv98C9zxJ5QMuXd91gTQ%3D' (2025-02-21)
  → 'github:metacraft-labs/ethereum.nix/34a25367b8f71ba6fafffbff512d566b15dc0b32?narHash=sha256-F6eMtPaszqzvX7XOVpjkAJUuYgfylqmj1lDeMvbXnfg%3D' (2025-02-25)
```
