### PR TITLE
chore(flake.lock): Update ethereum-nix input (2025-02-25)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740476118,
-        "narHash": "sha256-F6eMtPaszqzvX7XOVpjkAJUuYgfylqmj1lDeMvbXnfg=",
+        "lastModified": 1740477392,
+        "narHash": "sha256-Xs+cYer4cWYHdqTizUGEAKYzQSrHTkfDuVyfwzhB78E=",
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
-        "rev": "34a25367b8f71ba6fafffbff512d566b15dc0b32",
+        "rev": "8bd2db47e19cb9219f6d039a82e4d55df8e0887b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
• Updated input 'ethereum-nix':
    'github:metacraft-labs/ethereum.nix/34a25367b8f71ba6fafffbff512d566b15dc0b32?narHash=sha256-F6eMtPaszqzvX7XOVpjkAJUuYgfylqmj1lDeMvbXnfg%3D' (2025-02-25)
  → 'github:metacraft-labs/ethereum.nix/8bd2db47e19cb9219f6d039a82e4d55df8e0887b?narHash=sha256-Xs%2BcYer4cWYHdqTizUGEAKYzQSrHTkfDuVyfwzhB78E%3D' (2025-02-25)
