### PR TITLE
config(lido-withdrawals): add missing timer, fix type

### DIFF
--- a/modules/lido/withdrawals-automation/default.nix
+++ b/modules/lido/withdrawals-automation/default.nix
@@ -17,6 +17,11 @@
     {
       options.services.lido-withdrawals-automation = with lib; {
         enable = mkEnableOption (lib.mdDoc "Lido Withdrawals Automation");
+        timerFrequency = mkOption {
+          type = types.str;
+          default = "daily";
+          example = "hourly";
+        };
         args = {
           percentage = mkOption {
             type = types.nullOr types.int;
@@ -78,8 +83,18 @@
           };
         };
       };
-      config = {
-        systemd.services.lido-withdrawals-automation = lib.mkIf cfg.enable {
+      config = lib.mkIf cfg.enable {
+
+        systemd.timers.lido-withdrawals-automation = {
+          wantedBy = ["timers.target"];
+          partOf = ["lido-withdrawals-automation.service"];
+          timerConfig = {
+            OnCalendar = cfg.timerFrequency;
+            Unit = "lido-withdrawals-automation.service";
+          };
+        };
+
+        systemd.services.lido-withdrawals-automation = {
           description = "Lido Withdrawals Automation";
 
           wantedBy = [ "multi-user.target" ];
@@ -90,6 +105,7 @@
 
           serviceConfig = lib.mkMerge [
             {
+              Type = "oneshot";
               Group = "lido";
               ExecStart = lib.getExe (
                 pkgs.writeShellApplication {


### PR DESCRIPTION
Because of missing Type=oneshot the service keeps failing when system is being activated with error like this:
```
🚀 Lido Withdrawals Automation developed by Stakely.io - 2023 v1.0.1
Step 1: Checking environment variables and asking for missing values...
Cannot read properties of undefined (reading 'trim')
```