### PR TITLE
ci(reusable-flake-checks): Resolve deadlock by removing concurrency on reusable workflow

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -25,19 +25,6 @@ on:
         description: GitHub token to add as access-token in nix.conf
         required: false
 
-  # Allow this workflow to be triggered manually:
-  workflow_dispatch:
-    inputs:
-      run-cachix-deploy:
-        description: 'Deploy to cachix'
-        type: 'boolean'
-        default: false
-        required: false
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   post-initial-comment:
     runs-on: ${{ fromJSON(inputs.runner) }}


### PR DESCRIPTION
Also remove provision to run the workflow manually, as that's not possible without providing a bunch of inputs and secrets. Instead, the `ci` workflow (which calls this one) is enabled to run on `workflow_dispatch` events, so it can be used to run this workflow manually.