### PR TITLE
config(modules/withdrawals-automation): Remove `wantedBy` option

### DIFF
--- a/modules/lido/withdrawals-automation/default.nix
+++ b/modules/lido/withdrawals-automation/default.nix
@@ -97,8 +97,6 @@
         systemd.services.lido-withdrawals-automation = {
           description = "Lido Withdrawals Automation";
 
-          wantedBy = [ "multi-user.target" ];
-
           environment = toEnvVariables cfg.args;
 
           path = [ package ];


### PR DESCRIPTION
The service does not need to be launched on a reboot or configuration switch because a timer starts it.