### PR TITLE
feat(flake.nix/inputs): Add `home-manager-unstable`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,6 +540,26 @@
         "type": "github"
       }
     },
+    "home-manager-unstable": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746727295,
+        "narHash": "sha256-0364XVBdfEA8rWfqEPvsgBqGFfq5r9LAo9CS9tvT7tg=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "a51598236f23c89e59ee77eb8e0614358b0e896c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "lib-extras": {
       "inputs": {
         "devshell": [
@@ -938,6 +958,7 @@
         "git-hooks-nix": "git-hooks-nix",
         "hercules-ci-effects": "hercules-ci-effects",
         "home-manager": "home-manager",
+        "home-manager-unstable": "home-manager-unstable",
         "microvm": "microvm",
         "nix-darwin": "nix-darwin",
         "nix2container": "nix2container",

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    home-manager-unstable = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+
     nix-darwin = {
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
- Its `nixpkgs` follows our `nixpkgs-unstable`