### PR TITLE
packages/secret: refactor, add handling of Age identities

### DIFF
--- a/packages/secret/default.nix
+++ b/packages/secret/default.nix
@@ -1,113 +1,19 @@
 {
   inputs',
   pkgs,
+  lib,
   ...
 }:
 let
   agenix = inputs'.agenix.packages.agenix.override { ageBin = "${pkgs.rage}/bin/rage"; };
 in
-pkgs.writeShellApplication {
-  name = "secret";
-  text = ''
-    #!/usr/bin/env bash
-    set -euo pipefail
+  pkgs.substituteAll {
+    name = "secret";
+    dir = "bin";
+    src = ./secret.sh;
+    isExecutable = true;
 
-    machine=""
-    service=""
-    secret=""
-    vm=false
-    reEncrypt=false
-    reEncryptAll=false
-    export RULES=""
-    secretsFolder=""
-
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --machine=*) machine="''${1#*=}";;
-            --secrets-folder=*) secretsFolder="''${1#*=}";;
-            --service=*) service="''${1#*=}";;
-            --secret=*) secret="''${1#*=}";;
-            --vm) vm=true;;
-            -r) reEncrypt=true;;
-            --re-encrypt-all) reEncryptAll=true;;
-            --help)
-                echo -e "NAME\n\
-        secret\n\n\
-    SYNOPSIS\n\
-        secret [OPTION]\n\n\
-    EXAMPLE\n\
-        secret --machine=mymachine --service=myservice --secret=mysecret\n\n\
-    DESCRIPTION\n\
-        Secret is the command made for nix repos to get rid of the secret.nix when\n\
-        you are using agenix. Secret must be used with mcl-secrets and mcl-host-info\n\
-        modules from nixos-modules repository to work properly.\n\n\
-    OPTIONS\n\
-        --secrets-folder - pecifies the location where secrets are saved.\n\
-        By default, secrets are stored in /(folder of the machine)/secrets/service/\n\
-        if this directory exists, unless otherwise specified.
-        --machine - Machine for which you want to create a secret.\n\
-        --service - Service for which you want to create a secret.\n\
-        --secret  - Secret you want to encrypt.\n\
-        --vm - Make secret for the vmVariant.\n\
-        -r - Re-encrypt the secret."
-                exit 0
-                ;;
-            *)
-                echo "Unknown option: $1"
-                exit 1
-                ;;
-        esac
-        shift
-    done
-
-    if [[ "$reEncryptAll" == true && -z "$machine" ]]; then
-      echo "You must specify machine"
-      exit 1
-    elif [[ "$reEncrypt" == true && (-z "$machine" || -z "$service") ]]; then
-      echo "You must specify machine and service"
-      exit 1
-    elif [[ "$reEncrypt" == false && "$reEncryptAll" == false && (-z "$machine" || -z "$service" || -z "$secret") ]]; then
-      echo "You must specify machine, service, and secret"
-      exit 1
-    fi
-
-    machineFolder="$(nix eval ".#nixosConfigurations.$machine.config.mcl.host-info.configPath" | sed 's|^\([^/]*/\)\{4\}||; s|"||g')"
-
-    if [ "$secretsFolder" == "" ]; then
-      secretsFolder="$machineFolder/secrets/$service"
-    fi
-
-    if [[ "$vm" == true && "$reEncryptAll" == false ]]; then
-        RULES="$(nix eval --raw ".#nixosConfigurations.$machine.config.virtualisation.vmVariant.mcl.secrets.services.$service.nix-file")"
-        secretsFolder="./modules/default-vm-config/secrets/$service"
-    elif [ "$reEncryptAll" == false ]; then
-        RULES="$(nix eval --raw ".#nixosConfigurations.$machine.config.mcl.secrets.services.$service.nix-file")"
-    fi
-
-    if [ "$reEncryptAll" == true ]; then
-      for s in $(nix eval ".#nixosConfigurations.$machine.config.mcl.secrets.services" --apply builtins.attrNames | tr -d '[]"'); do
-        service=$s
-        secretsFolder="$machineFolder/secrets/$service"
-        echo "Re-encripting secrets for service $s"
-        if [ "$vm" == true ]; then
-          RULES="$(nix eval --raw ".#nixosConfigurations.$machine.config.virtualisation.vmVariant.mcl.secrets.services.$service.nix-file")"
-        else
-          RULES="$(nix eval --raw ".#nixosConfigurations.$machine.config.mcl.secrets.services.$service.nix-file")"
-        fi
-        (
-          cd "$secretsFolder"
-          "${agenix}/bin/agenix -r"
-        )
-      done
-    else
-      (
-        cd "$secretsFolder"
-        if [ "$reEncrypt" == true ]; then
-          "${agenix}/bin/agenix" -r
-        else
-          "${agenix}/bin/agenix" -e "$secret.age"
-        fi
-      )
-    fi
-  '';
-}
+    binPath = lib.makeBinPath (with pkgs; [
+      coreutils util-linux gnused
+    ]);
+  }

--- a/packages/secret/secret.sh
+++ b/packages/secret/secret.sh
@@ -1,0 +1,119 @@
+#!@shell@
+
+export PATH="@binPath@:$PATH"
+
+read -r -d '' HELP_MSG << EOM
+NAME\n\
+    secret\n\n\
+SYNOPSIS\n\
+    secret [OPTION]\n\n\
+EXAMPLE\n\
+    secret --machine=mymachine --service=myservice --secret=mysecret\n\n\
+DESCRIPTION\n\
+    Secret is the command made for nix repos to get rid of the secret.nix when\n\
+    you are using agenix. Secret must be used with mcl-secrets and mcl-host-info\n\
+    modules from nixos-modules repository to work properly.\n\n\
+
+    By default, secrets are stored in machines/\${HOST}/secrets/service/\n\
+    if this directory exists, unless otherwise specified.
+OPTIONS\n\
+    -v|--verbose          - Produce more verbose log messages.\n\
+    -f| --secrets-folder  - pecifies the location where secrets are saved.\n\
+    -m|--machine          - Machine for which you want to create a secret.\n\
+    -S|--service          - Service for which you want to create a secret.\n\
+    -s|--secret           - Secret you want to encrypt.\n\
+    -V|--vm               - Make secret for the vmVariant.\n\
+    -r|--re-encrypt       - Re-encrypt the secret.\n\
+    -a|--re-encrypt-all   - Re-encrypt all secrets."
+EOM
+
+set -euo pipefail
+
+function nix_eval_machine() {
+  target="${1}"
+  shift
+  if [[ "${vm}" == true ]]; then
+    subPath='virtualisation.vmVariant'
+  else
+    subPath='config'
+  fi
+  nix eval ${@} ".#nixosConfigurations.${machine}.${subPath}.${target}"
+}
+
+function machine_type() {
+  [[ "${vm}" == true ]] && echo "vm" || echo "server"
+}
+
+function agenix_wrapper() {
+  if [[ -z "${secretsFolder}" ]]; then
+    local secretsFolder=$(
+      nix_eval_machine mcl.secrets.services.${service}.encryptedSecretDir --raw \
+        | sed -r 's#/nix/store/[a-z0-9]+-(source|secrets)/?##'
+    )
+    # If path has no subfolders it must be that of defaults.
+    if [[ -z "${secretsFolder}" ]]; then
+      local secretsFolder="modules/default-$(machine_type)-config/secrets"
+    fi
+  fi
+  export RULES="$(nix_eval_machine "mcl.secrets.services.${service}.nix-file" --raw)"
+  # Provide custom paths to Age identity files.
+  if [[ -n "$AGE_IDENTITIES" ]]; then
+    export agenixArgs="-i $(echo "${AGE_IDENTITIES}" | sed -z '$ s/\n$//' | tr '\n' ' ' | sed -e 's/ / -i /g')"
+  fi
+  if [[ "${verbose}" == 'true' ]]; then
+    echo -e "{\n  cd ${secretsFolder}/${service};\n  export RULES=${RULES};\n  agenix ${agenixArgs} ${@};\n}" >&2
+  fi
+  ( # Block necessary to limit scope of directory change.
+    cd "${secretsFolder}/${service}";
+    exec agenix ${agenixArgs} ${@}
+  )
+}
+
+machine=""
+service=""
+secret=""
+verbose=false
+vm=false
+reEncrypt=false
+reEncryptAll=false
+secretsFolder=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--verbose)           verbose=true;;
+        -m|--machine=*)         machine="${1#*=}";;
+        -f|--secrets-folder=*)  secretsFolder="${1#*=}";;
+        -S|--service=*)         service="${1#*=}";;
+        -s|--secret=*)          secret="${1#*=}";;
+        -V|--vm)                vm=true;;
+        -r|--re-encrypt)        reEncrypt=true;;
+        -a|--re-encrypt-all)    reEncryptAll=true;;
+        -h|--help)              echo -e "${HELP_MSG}"; exit 0;;
+        *)                      echo "Unknown option: $1"; exit 1;;
+    esac
+    shift
+done
+
+if [[ "${reEncryptAll}" == true && -z "${machine}" ]]; then
+  echo "You must specify machine"
+  exit 1
+elif [[ "${reEncrypt}" == true && (-z "${machine}" || -z "${service}") ]]; then
+  echo "You must specify machine and service"
+  exit 1
+elif [[ "${reEncrypt}" == false && "${reEncryptAll}" == false && (-z "${machine}" || -z "$service" || -z "$secret") ]]; then
+  echo "You must specify machine, service, and secret"
+  exit 1
+fi
+
+if [[ "${reEncryptAll}" == true ]]; then
+  for service in $(nix_eval_machine "mcl.secrets.services" --apply builtins.attrNames --json | jq -r '.[]'); do
+    echo "Re-encripting secrets for: ${service}"
+    agenix_wrapper -r
+  done
+else
+  if [[ "${reEncrypt}" == true ]]; then
+    agenix_wrapper -r
+  else
+    agenix_wrapper -e "${secret}.age"
+  fi
+fi


### PR DESCRIPTION
The script now supports `AGE_IDENTITIES` env variable which allows specifying additional paths for files defining YubiKey identities.

Also, I made it actually readable.