### PR TITLE
Fix `secret --vm` and `mcl ci` commands

### DIFF
--- a/packages/mcl/src/src/mcl/commands/ci.d
+++ b/packages/mcl/src/src/mcl/commands/ci.d
@@ -32,10 +32,6 @@ export void ci(string[] args)
         {
             params.flakePre = "checks";
         }
-        if (params.flakePost != "")
-        {
-            params.flakePost = "." ~ params.flakePost;
-        }
         string cachixUrl = "https://" ~ params.cachixCache ~ ".cachix.org";
         version (AArch64) {
             string arch = "aarch64";

--- a/packages/mcl/src/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/src/mcl/commands/ci_matrix.d
@@ -2,7 +2,7 @@ module mcl.commands.ci_matrix;
 
 import std.stdio : writeln, stderr, stdout;
 import std.traits : EnumMembers;
-import std.string : indexOf, splitLines;
+import std.string : indexOf, splitLines, strip;
 import std.algorithm : map, filter, reduce, chunkBy, find, any, sort, startsWith, each, canFind, fold;
 import std.file : write, readText;
 import std.range : array, front, join, split;
@@ -378,7 +378,8 @@ Package[] nixEvalJobs(string flakeAttrPrefix, string cachixUrl, bool doCheck = t
         .filter!(line => !uselessWarnings.any!(w => line.canFind(w)))
         .join("\n");
 
-    logWarning(stderrLogs);
+    if (stderrLogs.strip != "")
+        logWarning(stderrLogs);
 
     int status = wait(pipes.pid);
 

--- a/packages/secret/default.nix
+++ b/packages/secret/default.nix
@@ -90,7 +90,8 @@ pkgs.writeShellApplication {
         secretsFolder="$machineFolder/secrets/$service"
         echo "Re-encripting secrets for service $s"
         if [ "$vm" == true ]; then
-          RULES="$(nix eval --raw ".#nixosConfigurations.$machine.config.virtualisation.vmVariant.mcl.secrets.services.$service.nix-file")"
+          RULES="$(nix eval --raw ".#nixosConfigurations.''${machine}-vm.config.mcl.secrets.services.$service.nix-file")"
+
         else
           RULES="$(nix eval --raw ".#nixosConfigurations.$machine.config.mcl.secrets.services.$service.nix-file")"
         fi


### PR DESCRIPTION
- **improve(mcl/commands/ci): Makes logs less verbose**
- **fix(mcl/commands/ci): Remove wrong flake attr path adjustment**
- **fix(pkgs/secret): Fix `--vm` nix-file attr path**
