### PR TITLE
  chore(flake.lock): Update all Flake inputs (2025-08-07)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750173260,
-        "narHash": "sha256-9P1FziAwl5+3edkfFcr5HeGtQUtrSdk/MksX39GieoA=",
+        "lastModified": 1754433428,
+        "narHash": "sha256-NA/FT2hVhKDftbHSwVnoRTFhes62+7dxZbxj5Gxvghs=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "531beac616433bac6f9e2a19feb8e99a22a66baf",
+        "rev": "9edb1787864c4f59ae5074ad498b6272b3ec308d",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752264895,
-        "narHash": "sha256-1zBPE/PNAkPNUsOWFET4J0cjlvziH8DOekesDmjND+w=",
+        "lastModified": 1754424619,
+        "narHash": "sha256-Hmi3h1Ubch3inxfQ6HMpFnZsIQMX/90Gc1qS7SILlsc=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "47053aef762f452e816e44eb9a23fbc3827b241a",
+        "rev": "205416649abb9c1faae9228803116b0f4e0a2eca",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1752946753,
-        "narHash": "sha256-g5uP3jIj+STUcfTJDKYopxnSijs2agRg13H0SGL5iE4=",
+        "lastModified": 1754269165,
+        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "544d09fecc8c2338542c57f3f742f1a0c8c71e13",
+        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752951785,
-        "narHash": "sha256-wJ2ArUwkLkg7DRbve7INSPMixnSTUl8mH+gdfY4vOb0=",
+        "lastModified": 1754517073,
+        "narHash": "sha256-z3sem6h0kNjRprT9rPj9fvSdxlHjbH33x+vU6rpDQqg=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "3d4f8b778378a0e3f29ba779af0ff1717cf1fa00",
+        "rev": "d04ead83e67d8475c5bc9bf06f0adbd4ea99c599",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752718651,
-        "narHash": "sha256-PkaR0qmyP9q/MDN3uYa+RLeBA0PjvEQiM0rTDDBXkL8=",
+        "lastModified": 1753140376,
+        "narHash": "sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb+mYCodI5uuB8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d5ad4485e6f2edcc06751df65c5e16572877db88",
+        "rev": "545aba02960caa78a31bd9a8709a0ad4b6320a5c",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1752907304,
-        "narHash": "sha256-rSw0b/ahoZebcp+AZG7uoScB5Q59TYEE5Kx8k0pZp9E=",
+        "lastModified": 1754549159,
+        "narHash": "sha256-47e1Ar09kZlv2HvZilaNRFzRybIiJYNQ2MSvofbiw5o=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e91719882d0e4366202cc9058eb21df74c0bdb92",
+        "rev": "5fe110751342a023d8c7ddce7fbf8311dca9f58d",
         "type": "github"
       },
       "original": {
@@ -300,11 +300,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1754416808,
+        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
         "type": "github"
       },
       "original": {
@@ -505,11 +505,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752780124,
-        "narHash": "sha256-5dn97vIYxn6VozKePOQSDxVCsrl38nDdMJXx86KIJH0=",
+        "lastModified": 1753592768,
+        "narHash": "sha256-oV695RvbAE4+R9pcsT9shmp6zE/+IZe6evHWX63f2Qg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c718918222bdb104397762dea67e6b397a7927fe",
+        "rev": "fc3add429f21450359369af74c2375cb34a2d204",
         "type": "github"
       },
       "original": {
@@ -526,11 +526,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752814804,
-        "narHash": "sha256-irfg7lnfEpJY+3Cffkluzp2MTVw1Uq9QGxFp6qadcXI=",
+        "lastModified": 1754575993,
+        "narHash": "sha256-0ut8TM76DeMnexgwNyMx2c5flhp4IPtqQ79XR0hpmY0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0300c8808e41da81d6edfc202f3d3833c157daf",
+        "rev": "d8a475e179888553b6863204a93295da6ee13eb4",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1752843889,
-        "narHash": "sha256-WSvdkO80w6fwtKAj3ePTnl9zD8+0i12fd7hL9Enj9Gg=",
+        "lastModified": 1753388547,
+        "narHash": "sha256-zbjlS9sa2BbtE80YA9C9DMXwCADba3NjUROw/7Rpt7Y=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "bde4522ae5eb358c05d1dfd6b23abaa9988be3ff",
+        "rev": "9694139d7c761e857ac9d025f9110a92cd8f7686",
         "type": "github"
       },
       "original": {
@@ -730,11 +730,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1749437307,
-        "narHash": "sha256-sSeplJJBnGKa/PLXZN1OVhD40DvgZjnFeVrreq31llg=",
+        "lastModified": 1754193386,
+        "narHash": "sha256-FHD7fXA77RIF0J/eQHL0MS2+E3sZeiKN1BWC2UpY6xE=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "474df09a7af97baa71250dc8527b4cfd143fb7e8",
+        "rev": "89332c35fe968902f582e5c1a3b409f6da5f9315",
         "type": "github"
       },
       "original": {
@@ -793,11 +793,11 @@
     },
     "nixos-2505": {
       "locked": {
-        "lastModified": 1752620740,
-        "narHash": "sha256-f3pO+9lg66mV7IMmmIqG4PL3223TYMlnlw+pnpelbss=",
+        "lastModified": 1754292888,
+        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32a4e87942101f1c9f9865e04dc3ddb175f5f32e",
+        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
         "type": "github"
       },
       "original": {
@@ -828,11 +828,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752577009,
-        "narHash": "sha256-QUZrqq6qEs3ZfM6a2C1QLUiHgp3k71A1Z4F5LKAHvnE=",
+        "lastModified": 1754132464,
+        "narHash": "sha256-NQFNwVApU7T8f/8203RkRNtuYTy5aWhI2PbcDwXsWIE=",
         "owner": "numtide",
         "repo": "nixos-anywhere",
-        "rev": "d00d5b73af8b777561b83b62519c315cfd7a69b7",
+        "rev": "bc653a8ca6a2ba854ff1371081862828b75c9af6",
         "type": "github"
       },
       "original": {
@@ -851,11 +851,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751890720,
-        "narHash": "sha256-jkEsFCFfRnOTHIrt5Gl9wIW5khxqGP3nfyM1yOUZAGk=",
+        "lastModified": 1753097384,
+        "narHash": "sha256-KC6rJEQXLcpLj8M5l1SeBfwaNdMI5FpGjF14302NsGw=",
         "owner": "nix-community",
         "repo": "nixos-images",
-        "rev": "e87eca4cb56435a7533c7be97579cbe3fdfd4937",
+        "rev": "191fa069d80da85bf1cf085743f39361b2b856a8",
         "type": "github"
       },
       "original": {
@@ -898,11 +898,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
         "type": "github"
       },
       "original": {
@@ -968,11 +968,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1752817855,
-        "narHash": "sha256-YnG3d44oX+g2ooUsNWT+Ii24w6T+b0dj86k0HkIFUj4=",
+        "lastModified": 1754496778,
+        "narHash": "sha256-fPDLP3z9XaYQBfSCemEdloEONz/uPyr35RHPRy9Vx8M=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "330c4ed11c4e1eef0999a2cd629703a601da1436",
+        "rev": "529d3b935d68bdf9120fe4d7f8eded7b56271697",
         "type": "github"
       },
       "original": {
@@ -1078,11 +1078,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752909129,
-        "narHash": "sha256-Eh8FkMvGRaY71BU/oyZTTzt9RsBIq2E6j0r3eLZ/2kY=",
+        "lastModified": 1754492133,
+        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0043b95d80b5bf6d61e84d237e2007727f4dd38d",
+        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
         "type": "github"
       },
       "original": {
@@ -1101,11 +1101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750353031,
-        "narHash": "sha256-Bx7DOPLhkr8Z60U9Qw4l0OidzHoqLDKQH5rDV5ef59A=",
+        "lastModified": 1753541826,
+        "narHash": "sha256-foGgZu8+bCNIGeuDqQ84jNbmKZpd+JvnrL2WlyU4tuU=",
         "owner": "nix-community",
         "repo": "nixos-vscode-server",
-        "rev": "4ec4859b12129c0436b0a471ed1ea6dd8a317993",
+        "rev": "6d5f074e4811d143d44169ba4af09b20ddb6937d",
         "type": "github"
       },
       "original": {

--- a/modules/mcl-disko/primaryZfsPartition.nix
+++ b/modules/mcl-disko/primaryZfsPartition.nix
@@ -10,86 +10,85 @@
 {
   type = "disk";
   device = disk;
-  content =
-    {
-      type = if legacyBoot then "table" else "gpt";
-      partitions =
-        if !legacyBoot then
+  content = {
+    type = if legacyBoot then "table" else "gpt";
+    partitions =
+      if !legacyBoot then
+        {
+          "ESP" = {
+            device = "${disk}-part1";
+            size = espSize;
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = if isSecondary then null else "/boot";
+              mountOptions = [ "umask=0077" ];
+            };
+          };
+
+          "zfs" = {
+            device = "${disk}-part2";
+            end = "-${swapSize}";
+            type = "BF00";
+            content = {
+              type = "zfs";
+              pool = "${poolName}";
+            };
+          };
+
+          "swap" = {
+            device = "${disk}-part3";
+            size = swapSize;
+            content = {
+              type = "swap";
+              randomEncryption = true;
+            };
+          };
+        }
+      else
+        [
           {
-            "ESP" = {
-              device = "${disk}-part1";
-              size = espSize;
-              type = "EF00";
-              content = {
-                type = "filesystem";
-                format = "vfat";
-                mountpoint = if isSecondary then null else "/boot";
-                mountOptions = [ "umask=0077" ];
-              };
-            };
-
-            "zfs" = {
-              device = "${disk}-part2";
-              end = "-${swapSize}";
-              type = "BF00";
-              content = {
-                type = "zfs";
-                pool = "${poolName}";
-              };
-            };
-
-            "swap" = {
-              device = "${disk}-part3";
-              size = swapSize;
-              content = {
-                type = "swap";
-                randomEncryption = true;
-              };
+            name = "boot";
+            start = "1MiB";
+            end = "2MiB";
+            part-type = "primary";
+            flags = [ "bios_grub" ];
+          }
+          {
+            name = "ESP";
+            start = "2MiB";
+            end = espSize;
+            bootable = true;
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = if isSecondary then null else "/boot";
             };
           }
-        else
-          [
-            {
-              name = "boot";
-              start = "1MiB";
-              end = "2MiB";
-              part-type = "primary";
-              flags = [ "bios_grub" ];
-            }
-            {
-              name = "ESP";
-              start = "2MiB";
-              end = espSize;
-              bootable = true;
-              content = {
-                type = "filesystem";
-                format = "vfat";
-                mountpoint = if isSecondary then null else "/boot";
-              };
-            }
-            {
-              name = "zfs";
-              start = espSize;
-              end = "-${swapSize}";
-              part-type = "primary";
-              content = {
-                type = "zfs";
-                pool = "${poolName}";
-              };
-            }
-            {
-              name = "swap";
-              start = "-${swapSize}";
-              end = "100%";
-              part-type = "primary";
-              content = {
-                type = "swap";
-                randomEncryption = true;
-              };
-            }
-          ];
-    }
-    // lib.optionalAttrs legacyBoot {
-      format = "gpt";
-    };
+          {
+            name = "zfs";
+            start = espSize;
+            end = "-${swapSize}";
+            part-type = "primary";
+            content = {
+              type = "zfs";
+              pool = "${poolName}";
+            };
+          }
+          {
+            name = "swap";
+            start = "-${swapSize}";
+            end = "100%";
+            part-type = "primary";
+            content = {
+              type = "swap";
+              randomEncryption = true;
+            };
+          }
+        ];
+  }
+  // lib.optionalAttrs legacyBoot {
+    format = "gpt";
+  };
 }

--- a/modules/mcl-disko/zpool.nix
+++ b/modules/mcl-disko/zpool.nix
@@ -12,7 +12,8 @@ let
       options = {
         "com.sun:auto-snapshot" = if dataset.snapshot then "on" else "off";
         canmount = "on";
-      } // (if (refreservation != null) then { inherit refreservation; } else { });
+      }
+      // (if (refreservation != null) then { inherit refreservation; } else { });
     };
 
   restructuredDatasets = builtins.mapAttrs (

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -53,25 +53,24 @@
           ];
       };
 
-      packages =
-        {
-          lido-withdrawals-automation = pkgs.callPackage ./lido-withdrawals-automation { };
-          pyroscope = pkgs.callPackage ./pyroscope { };
-          random-alerts = pkgs.callPackage ./random-alerts { };
-        }
-        // optionalAttrs (system == "x86_64-linux" || system == "aarch64-darwin") {
-          secret = import ./secret { inherit inputs' pkgs; };
-        }
-        // optionalAttrs isLinux {
-          folder-size-metrics = pkgs.callPackage ./folder-size-metrics { };
-        }
-        // optionalAttrs (system == "x86_64-linux") {
-          mcl = pkgs.callPackage ./mcl {
-            buildDubPackage = inputs'.dlang-nix.legacyPackages.buildDubPackage.override {
-              dCompiler = inputs'.dlang-nix.packages."ldc-binary-1_38_0";
-            };
-            inherit (legacyPackages.inputs.nixpkgs) cachix nix nix-eval-jobs;
+      packages = {
+        lido-withdrawals-automation = pkgs.callPackage ./lido-withdrawals-automation { };
+        pyroscope = pkgs.callPackage ./pyroscope { };
+        random-alerts = pkgs.callPackage ./random-alerts { };
+      }
+      // optionalAttrs (system == "x86_64-linux" || system == "aarch64-darwin") {
+        secret = import ./secret { inherit inputs' pkgs; };
+      }
+      // optionalAttrs isLinux {
+        folder-size-metrics = pkgs.callPackage ./folder-size-metrics { };
+      }
+      // optionalAttrs (system == "x86_64-linux") {
+        mcl = pkgs.callPackage ./mcl {
+          buildDubPackage = inputs'.dlang-nix.legacyPackages.buildDubPackage.override {
+            dCompiler = inputs'.dlang-nix.packages."ldc-binary-1_38_0";
           };
+          inherit (legacyPackages.inputs.nixpkgs) cachix nix nix-eval-jobs;
         };
+      };
     };
 }

--- a/shells/default.nix
+++ b/shells/default.nix
@@ -43,12 +43,11 @@
               inputs'.dlang-nix.packages.dmd
             ];
 
-          shellHook =
-            ''
-              export REPO_ROOT="$PWD"
-              figlet -t "Metacraft Nixos Modules"
-            ''
-            + config.pre-commit.installationScript;
+          shellHook = ''
+            export REPO_ROOT="$PWD"
+            figlet -t "Metacraft Nixos Modules"
+          ''
+          + config.pre-commit.installationScript;
         };
     };
 }


### PR DESCRIPTION
  ```
• Updated input 'agenix':
    'github:ryantm/agenix/531beac616433bac6f9e2a19feb8e99a22a66baf?narHash=sha256-9P1FziAwl5%2B3edkfFcr5HeGtQUtrSdk/MksX39GieoA%3D' (2025-06-17)
  → 'github:ryantm/agenix/9edb1787864c4f59ae5074ad498b6272b3ec308d?narHash=sha256-NA/FT2hVhKDftbHSwVnoRTFhes62%2B7dxZbxj5Gxvghs%3D' (2025-08-05)
• Updated input 'cachix':
    'github:cachix/cachix/47053aef762f452e816e44eb9a23fbc3827b241a?narHash=sha256-1zBPE/PNAkPNUsOWFET4J0cjlvziH8DOekesDmjND%2Bw%3D' (2025-07-11)
  → 'github:cachix/cachix/205416649abb9c1faae9228803116b0f4e0a2eca?narHash=sha256-Hmi3h1Ubch3inxfQ6HMpFnZsIQMX/90Gc1qS7SILlsc%3D' (2025-08-05)
• Updated input 'crane':
    'github:ipetkov/crane/544d09fecc8c2338542c57f3f742f1a0c8c71e13?narHash=sha256-g5uP3jIj%2BSTUcfTJDKYopxnSijs2agRg13H0SGL5iE4%3D' (2025-07-19)
  → 'github:ipetkov/crane/444e81206df3f7d92780680e45858e31d2f07a08?narHash=sha256-0tcS8FHd4QjbCVoxN9jI%2BPjHgA4vc/IjkUSp%2BN3zy0U%3D' (2025-08-04)
• Updated input 'devenv':
    'github:cachix/devenv/3d4f8b778378a0e3f29ba779af0ff1717cf1fa00?narHash=sha256-wJ2ArUwkLkg7DRbve7INSPMixnSTUl8mH%2BgdfY4vOb0%3D' (2025-07-19)
  → 'github:cachix/devenv/d04ead83e67d8475c5bc9bf06f0adbd4ea99c599?narHash=sha256-z3sem6h0kNjRprT9rPj9fvSdxlHjbH33x%2BvU6rpDQqg%3D' (2025-08-06)
• Updated input 'disko':
    'github:nix-community/disko/d5ad4485e6f2edcc06751df65c5e16572877db88?narHash=sha256-PkaR0qmyP9q/MDN3uYa%2BRLeBA0PjvEQiM0rTDDBXkL8%3D' (2025-07-17)
  → 'github:nix-community/disko/545aba02960caa78a31bd9a8709a0ad4b6320a5c?narHash=sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb%2BmYCodI5uuB8%3D' (2025-07-21)
• Updated input 'fenix':
    'github:nix-community/fenix/e91719882d0e4366202cc9058eb21df74c0bdb92?narHash=sha256-rSw0b/ahoZebcp%2BAZG7uoScB5Q59TYEE5Kx8k0pZp9E%3D' (2025-07-19)
  → 'github:nix-community/fenix/5fe110751342a023d8c7ddce7fbf8311dca9f58d?narHash=sha256-47e1Ar09kZlv2HvZilaNRFzRybIiJYNQ2MSvofbiw5o%3D' (2025-08-07)
• Updated input 'fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/330c4ed11c4e1eef0999a2cd629703a601da1436?narHash=sha256-YnG3d44oX%2Bg2ooUsNWT%2BIi24w6T%2Bb0dj86k0HkIFUj4%3D' (2025-07-18)
  → 'github:rust-lang/rust-analyzer/529d3b935d68bdf9120fe4d7f8eded7b56271697?narHash=sha256-fPDLP3z9XaYQBfSCemEdloEONz/uPyr35RHPRy9Vx8M%3D' (2025-08-06)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
  → 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
• Updated input 'git-hooks-nix':
    'github:cachix/git-hooks.nix/16ec914f6fb6f599ce988427d9d94efddf25fe6d?narHash=sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg%3D' (2025-06-24)
  → 'github:cachix/git-hooks.nix/9c52372878df6911f9afc1e2a1391f55e4dfc864?narHash=sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef%2B6fRcofA%3D' (2025-08-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c718918222bdb104397762dea67e6b397a7927fe?narHash=sha256-5dn97vIYxn6VozKePOQSDxVCsrl38nDdMJXx86KIJH0%3D' (2025-07-17)
  → 'github:nix-community/home-manager/fc3add429f21450359369af74c2375cb34a2d204?narHash=sha256-oV695RvbAE4%2BR9pcsT9shmp6zE/%2BIZe6evHWX63f2Qg%3D' (2025-07-27)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/d0300c8808e41da81d6edfc202f3d3833c157daf?narHash=sha256-irfg7lnfEpJY%2B3Cffkluzp2MTVw1Uq9QGxFp6qadcXI%3D' (2025-07-18)
  → 'github:nix-community/home-manager/d8a475e179888553b6863204a93295da6ee13eb4?narHash=sha256-0ut8TM76DeMnexgwNyMx2c5flhp4IPtqQ79XR0hpmY0%3D' (2025-08-07)
• Updated input 'microvm':
    'github:astro/microvm.nix/bde4522ae5eb358c05d1dfd6b23abaa9988be3ff?narHash=sha256-WSvdkO80w6fwtKAj3ePTnl9zD8%2B0i12fd7hL9Enj9Gg%3D' (2025-07-18)
  → 'github:astro/microvm.nix/9694139d7c761e857ac9d025f9110a92cd8f7686?narHash=sha256-zbjlS9sa2BbtE80YA9C9DMXwCADba3NjUROw/7Rpt7Y%3D' (2025-07-24)
• Updated input 'nixd':
    'github:nix-community/nixd/474df09a7af97baa71250dc8527b4cfd143fb7e8?narHash=sha256-sSeplJJBnGKa/PLXZN1OVhD40DvgZjnFeVrreq31llg%3D' (2025-06-09)
  → 'github:nix-community/nixd/89332c35fe968902f582e5c1a3b409f6da5f9315?narHash=sha256-FHD7fXA77RIF0J/eQHL0MS2%2BE3sZeiKN1BWC2UpY6xE%3D' (2025-08-03)
• Updated input 'nixos-2505':
    'github:NixOS/nixpkgs/32a4e87942101f1c9f9865e04dc3ddb175f5f32e?narHash=sha256-f3pO%2B9lg66mV7IMmmIqG4PL3223TYMlnlw%2Bpnpelbss%3D' (2025-07-15)
  → 'github:NixOS/nixpkgs/ce01daebf8489ba97bd1609d185ea276efdeb121?narHash=sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I%2B5OPGEmIE%3D' (2025-08-04)
• Updated input 'nixos-anywhere':
    'github:numtide/nixos-anywhere/d00d5b73af8b777561b83b62519c315cfd7a69b7?narHash=sha256-QUZrqq6qEs3ZfM6a2C1QLUiHgp3k71A1Z4F5LKAHvnE%3D' (2025-07-15)
  → 'github:numtide/nixos-anywhere/bc653a8ca6a2ba854ff1371081862828b75c9af6?narHash=sha256-NQFNwVApU7T8f/8203RkRNtuYTy5aWhI2PbcDwXsWIE%3D' (2025-08-02)
• Updated input 'nixos-images':
    'github:nix-community/nixos-images/e87eca4cb56435a7533c7be97579cbe3fdfd4937?narHash=sha256-jkEsFCFfRnOTHIrt5Gl9wIW5khxqGP3nfyM1yOUZAGk%3D' (2025-07-07)
  → 'github:nix-community/nixos-images/191fa069d80da85bf1cf085743f39361b2b856a8?narHash=sha256-KC6rJEQXLcpLj8M5l1SeBfwaNdMI5FpGjF14302NsGw%3D' (2025-07-21)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/6e987485eb2c77e5dcc5af4e3c70843711ef9251?narHash=sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo%3D' (2025-07-16)
  → 'github:NixOS/nixpkgs/5b09dc45f24cf32316283e62aec81ffee3c3e376?narHash=sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY%3D' (2025-08-03)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/0043b95d80b5bf6d61e84d237e2007727f4dd38d?narHash=sha256-Eh8FkMvGRaY71BU/oyZTTzt9RsBIq2E6j0r3eLZ/2kY%3D' (2025-07-19)
  → 'github:numtide/treefmt-nix/1298185c05a56bff66383a20be0b41a307f52228?narHash=sha256-B%2B3g9%2B76KlGe34Yk9za8AF3RL%2BlnbHXkLiVHLjYVOAc%3D' (2025-08-06)
• Updated input 'vscode-server':
    'github:nix-community/nixos-vscode-server/4ec4859b12129c0436b0a471ed1ea6dd8a317993?narHash=sha256-Bx7DOPLhkr8Z60U9Qw4l0OidzHoqLDKQH5rDV5ef59A%3D' (2025-06-19)
  → 'github:nix-community/nixos-vscode-server/6d5f074e4811d143d44169ba4af09b20ddb6937d?narHash=sha256-foGgZu8%2BbCNIGeuDqQ84jNbmKZpd%2BJvnrL2WlyU4tuU%3D' (2025-07-26)
```
