### PR TITLE
ci(gh-actions/install-nix): Enable binary substitution fallback

### DIFF
--- a/.github/install-nix/action.yml
+++ b/.github/install-nix/action.yml
@@ -51,7 +51,13 @@ runs:
               format('access-tokens = {0}=PAT:{1}', inputs.nix-gitlab-domain, inputs.nix-gitlab-token)) ||
             ''
           }}
+
+          fallback = true
+          download-attempts = 2
+          connect-timeout = 5
+          narinfo-cache-negative-ttl = 120
           allow-import-from-derivation = true
+
           substituters = https://cache.nixos.org ${{inputs.substituters}}
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{inputs.trusted-public-keys}}
           netrc-file = $HOME/.config/nix/netrc"


### PR DESCRIPTION
Recently, we noticed both locally and in CI jobs errors like:

    warning: error: unable to download
    'https://blocksense.cachix.org/nar/be9530185b5e3d2f9fab587aa1bde52335bbd60b8e5efb79897a739577fdc482.nar.zst':
    HTTP error 500 response body: Cannot serve NAR; retrying in 517 ms

which, in end the end result in:

    error: some substitutes for the outputs of derivation
    '/nix/store/xpmfjqgr0hdiwf8jiyqr7qs9f4v2r351-cargo-package-eth-keystore-0.5.0.drv'
    failed (usually happens due to networking issues);
    try '--fallback' to build derivation from source

To address this issue globally in the CI, we adjust the nix.conf file generated by `metacraft-labs/nixos-modules/.github/install-nix` GH action by:

* Enabling fallback for when binary substitution fails 
* Reduce the number of retries from 5 to 2
* Set a `connect-timeout` to 30 seconds (before it was unlimited?!)
* Reduce `narinfo-cache-negative-ttl` from 3600 to 120 - allowing CI runners to check more often if something built by one machine is now available to others (via Cachix)