### PR TITLE
build(mcl): Enable local development on macOS'

### DIFF
--- a/packages/mcl/src/src/mcl/commands/host_info.d
+++ b/packages/mcl/src/src/mcl/commands/host_info.d
@@ -301,10 +301,13 @@ struct ProcessorInfo
 ProcessorInfo getProcessorInfo()
 {
     ProcessorInfo r;
-    r.vendor = cpuid.x86_any.vendor;
-    char[48] modelCharArr;
-    cpuid.x86_any.brand(modelCharArr);
-    r.model = modelCharArr.idup[0 .. (strlen(modelCharArr.ptr) - 1)];
+    version (x86)
+    {
+        r.vendor = cpuid.x86_any.vendor;
+        char[48] modelCharArr;
+        cpuid.x86_any.brand(modelCharArr);
+        r.model = modelCharArr.idup[0 .. (strlen(modelCharArr.ptr) - 1)];
+    }
     r.cpus = cpuid.unified.cpus();
     r.cores = [r.cpus * cpuid.unified.cores()];
     r.threads = [cpuid.unified.threads()];

--- a/shells/default.nix
+++ b/shells/default.nix
@@ -37,10 +37,11 @@
               nix-output-monitor
               repl
               rage
-              inputs'.dlang-nix.packages.dub
+              dub
+              ldc
             ]
             ++ pkgs.lib.optionals (pkgs.stdenv.system == "x86_64-linux") [
-              inputs'.dlang-nix.packages.dmd
+              dmd
             ];
 
           shellHook = ''


### PR DESCRIPTION
- **build(shells): Use `dub`, `ldc`, `dmd` from Nixpkgs**
- **build(mcl): Access `cpuid.x86_any` only in `version (x86)`**
