### PR TITLE
fix(packages/erigon): Fix by upgrading buildGoModule from Go 1.22 to 1.23 and add it to the CI matrix

### DIFF
--- a/checks/packages-ci-matrix.nix
+++ b/checks/packages-ci-matrix.nix
@@ -48,6 +48,7 @@
             nethermind
             web3signer
             nimbus
+            erigon
             ;
         };
     };

--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756050361,
-        "narHash": "sha256-gppLXv4ALq67qhvED1FU4M85PN5/hKggRWAh3WPbiZ0=",
+        "lastModified": 1757147995,
+        "narHash": "sha256-4gGPAi6Ns7cfAh76G/kC/Kg0oXx+h6UMHyD4ML8Z+0E=",
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
-        "rev": "bb59baa0bafc6b7f1a13f67df5de23a86eb06f41",
+        "rev": "30318293f2d53069503bb69d1a0c3ded74e0569d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- **chore(flake.lock): Update `ethereum-nix` Flake input (2025-09-06)**
- **ci(flake/checks): Add `erigon` to the CI matrix**
