### PR TITLE
build(flake/inputs): Update follows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,7 +81,9 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "flake-parts": "flake-parts",
+        "flake-parts": [
+          "flake-parts"
+        ],
         "git-hooks": [
           "git-hooks-nix"
         ],
@@ -257,27 +259,6 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
-          "devenv",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
           "nixpkgs"
         ]
       },
@@ -287,27 +268,6 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_3": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "terranix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -850,7 +810,7 @@
         "ethereum-nix": "ethereum-nix",
         "fenix": "fenix",
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "flake-utils-plus": "flake-utils-plus",
         "git-hooks-nix": "git-hooks-nix",
@@ -942,7 +902,9 @@
     },
     "terranix": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": [
+          "flake-parts"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.lock
+++ b/flake.lock
@@ -887,21 +887,6 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "terranix": {
       "inputs": {
         "flake-parts": [
@@ -910,7 +895,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_2"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1757278723,

--- a/flake.lock
+++ b/flake.lock
@@ -692,7 +692,9 @@
         "nixos-images": [
           "nixos-images"
         ],
-        "nixos-stable": "nixos-stable",
+        "nixos-stable": [
+          "nixpkgs"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -734,22 +736,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixos-images",
-        "type": "github"
-      }
-    },
-    "nixos-stable": {
-      "locked": {
-        "lastModified": 1749086602,
-        "narHash": "sha256-DJcgJMekoxVesl9kKjfLPix2Nbr42i7cpEHJiTnBUwU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4792576cb003c994bd7cc1edada3129def20b27d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -109,16 +109,15 @@
     "devshell": {
       "inputs": {
         "nixpkgs": [
-          "ethereum-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
         "type": "github"
       },
       "original": {
@@ -174,7 +173,9 @@
     },
     "ethereum-nix": {
       "inputs": {
-        "devshell": "devshell",
+        "devshell": [
+          "devshell"
+        ],
         "fenix": [
           "fenix"
         ],
@@ -793,6 +794,7 @@
         "cachix": "cachix",
         "crane": "crane",
         "devenv": "devenv",
+        "devshell": "devshell",
         "disko": "disko",
         "dlang-nix": "dlang-nix",
         "ethereum-nix": "ethereum-nix",

--- a/flake.lock
+++ b/flake.lock
@@ -598,7 +598,9 @@
         ],
         "flake-root": "flake-root",
         "nixpkgs": "nixpkgs_2",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
       },
       "locked": {
         "lastModified": 1759830669,
@@ -833,7 +835,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems",
         "terranix": "terranix",
-        "treefmt-nix": "treefmt-nix_2",
+        "treefmt-nix": "treefmt-nix",
         "vscode-server": "vscode-server"
       }
     },
@@ -925,27 +927,6 @@
       }
     },
     "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixd",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1734704479,
-        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,7 @@
       url = "github:numtide/nixos-anywhere";
       inputs = {
         nixpkgs.follows = "nixpkgs";
+        nixos-stable.follows = "nixpkgs";
         nixos-images.follows = "nixos-images";
         flake-parts.follows = "flake-parts";
         disko.follows = "disko";

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
         flake-compat.follows = "flake-compat";
         treefmt-nix.follows = "treefmt-nix";
         fenix.follows = "fenix";
+        devshell.follows = "devshell";
       };
     };
 
@@ -107,6 +108,13 @@
         git-hooks.follows = "git-hooks-nix";
         flake-compat.follows = "flake-compat";
         flake-parts.follows = "flake-parts";
+      };
+    };
+
+    devshell = {
+      url = "github:numtide/devshell";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -171,6 +171,7 @@
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";
+        systems.follows = "systems";
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,7 @@
         nixpkgs.follows = "nixpkgs";
         git-hooks.follows = "git-hooks-nix";
         flake-compat.follows = "flake-compat";
+        flake-parts.follows = "flake-parts";
       };
     };
 
@@ -168,6 +169,7 @@
       url = "github:terranix/terranix";
       inputs = {
         nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,7 @@
     nixd = {
       url = "github:nix-community/nixd";
       inputs.flake-parts.follows = "flake-parts";
+      inputs.treefmt-nix.follows = "treefmt-nix";
       # Please refrain from adding the following line:
       # inputs.nixpkgs.follows = "nixpkgs";
       #


### PR DESCRIPTION
- **build(flake.nix/inputs): Unify `flake-parts` input for `devenv` and `terranix`**
- **build(flake.nix/inputs): Unify `treefmt-nix` input for `nixd`**
- **build(flake.nix/inputs): Unify `systems` input for `terranix`**
- **build(flake.nix/inputs): Unify `nixos-stable` input for `nixos-anywhere`**
- **build(flake.nix/inputs): Add `devshell` input and unify it with `ethereum-nix.inputs.devshell`**