### PR TITLE
feat(modules/host-info): add equivalent `darwin` module

### DIFF
--- a/modules/host-info.nix
+++ b/modules/host-info.nix
@@ -1,6 +1,6 @@
 { withSystem, ... }:
-{
-  flake.modules.nixos.mcl-host-info =
+let
+  mclHostInfoModule =
     {
       config,
       lib,
@@ -47,4 +47,10 @@
         };
       };
     };
+in
+{
+  flake.modules = {
+    nixos.mcl-host-info = mclHostInfoModule;
+    darwin.mcl-host-info = mclHostInfoModule;
+  };
 }

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -1,6 +1,7 @@
 { withSystem, inputs, ... }:
-{
-  flake.modules.nixos.mcl-secrets =
+let
+  mkModule =
+    variant:
     {
       config,
       options,
@@ -34,7 +35,7 @@
     in
     {
       imports = [
-        inputs.agenix.nixosModules.default
+        inputs.agenix."${variant}Modules".default
       ];
 
       options.mcl.secrets = with lib; {
@@ -136,4 +137,10 @@
         ];
       };
     };
+in
+{
+  flake.modules = {
+    nixos.mcl-secrets = mkModule "nixos";
+    darwin.mcl-secrets = mkModule "darwin";
+  };
 }


### PR DESCRIPTION
Co-authored-by: Martin Nikov <mnikov12@gmail.com>
