### PR TITLE
packages(mcl): Add support for `darwin`

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -51,6 +51,10 @@
         lido-withdrawals-automation = pkgs.callPackage ./lido-withdrawals-automation { };
         pyroscope = pkgs.callPackage ./pyroscope { };
         random-alerts = pkgs.callPackage ./random-alerts { };
+        mcl = pkgs.callPackage ./mcl {
+          dCompiler = inputs'.dlang-nix.packages."ldc-binary-1_38_0";
+          inherit (legacyPackages.inputs.nixpkgs) cachix nix nix-eval-jobs;
+        };
       }
       // optionalAttrs (system == "x86_64-linux" || system == "aarch64-darwin") {
         secret = import ./secret { inherit inputs' pkgs; };
@@ -58,12 +62,6 @@
       }
       // optionalAttrs isLinux {
         folder-size-metrics = pkgs.callPackage ./folder-size-metrics { };
-      }
-      // optionalAttrs (system == "x86_64-linux") {
-        mcl = pkgs.callPackage ./mcl {
-          dCompiler = inputs'.dlang-nix.packages."ldc-binary-1_38_0";
-          inherit (legacyPackages.inputs.nixpkgs) cachix nix nix-eval-jobs;
-        };
       };
     };
 }

--- a/packages/mcl/default.nix
+++ b/packages/mcl/default.nix
@@ -18,7 +18,6 @@ let
       gitMinimal
       gawk
       jc
-      edid-decode
       coreutils-full
       util-linux
       xorg.xrandr
@@ -29,6 +28,7 @@ let
       curl
     ])
     ++ lib.optionals (isLinux && isx86) [
+      v4l-utils
       dmidecode
       mesa-demos
       nixos-install-tools
@@ -94,5 +94,8 @@ pkgs.buildDubPackage rec {
       --set LD_LIBRARY_PATH "${lib.makeLibraryPath deps}"
   '';
 
-  meta.mainProgram = pname;
+  meta = {
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = pname;
+  };
 }

--- a/packages/mcl/src/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/src/mcl/commands/ci_matrix.d
@@ -524,6 +524,7 @@ int getAvailableMemoryMB(T)(auto ref T args)
     return maxMemoryMB;
 }
 
+version(linux)
 @("getAvailableMemoryMB")
 unittest
 {

--- a/packages/mcl/src/src/mcl/utils/user_info.d
+++ b/packages/mcl/src/src/mcl/utils/user_info.d
@@ -53,9 +53,23 @@ Nullable!gid_t getGroupId(in char[] groupName)
 @("getGroupId")
 unittest
 {
-    import std.exception : assertThrown;
+    import core.sys.posix.grp : getgrgid;
+    import std.string : fromStringz;
+    auto currentGid = getgid();
+    auto currentGroup = getgrgid(currentGid);
+    assert(currentGroup !is null);
 
-    assert(getGroupId("root").get == 0);
-    assert(getGroupId("nogroup").get == 65534);
+    auto currentGroupName = currentGroup.gr_name.fromStringz;
+    auto lookedUpGid = getGroupId(currentGroupName);
+
+    assert(!lookedUpGid.isNull);
+    assert(lookedUpGid.get == currentGid);
+
+    version (OSX)
+        assert(getGroupId("wheel").get == cast(gid_t)0);
+    else
+        assert(getGroupId("root").get == cast(gid_t)0);
+
+    assert(!getGroupId("nogroup").isNull);
     assert(getGroupId("non-existant-group-12313123123123123123123").isNull);
 }


### PR DESCRIPTION
- Stop gating the `mcl` package behind `x86_64-linux`
- Define appropriate `meta.platforms` for the `mcl` package
- Gate `edid-decode` (now named `v4l-utils`) behind `Linux`
