### PR TITLE
reo101/perSystem shards

### DIFF
--- a/modules/shard-split/default.nix
+++ b/modules/shard-split/default.nix
@@ -1,6 +1,15 @@
-{ lib, ... }:
+{
+  lib,
+  flake-parts-lib,
+  ...
+}:
 let
   inherit (import ../../lib/shard-attrs.nix lib) shardAttrs;
+
+  inherit (lib)
+    mkOption
+    types
+    ;
 in
 {
   flake.modules.flake.shardSplit =
@@ -9,35 +18,89 @@ in
       cfg = config.mcl.matrix.shard;
     in
     {
-      options.mcl.matrix.shard = with lib; {
-        size = mkOption {
-          type = types.numbers.positive;
-          default = 1;
-          description = "Number of shards to use for parallel builds";
-        };
-        attributePath = mkOption {
-          type = types.listOf types.str;
-          default = [
-            "legacyPackages"
-            "checks"
-          ];
-          description = "The attribute path to split into shards";
+      imports = [
+        (flake-parts-lib.mkTransposedPerSystemModule {
+          file = ./default.nix;
+          name = "mcl-matrices";
+          option = mkOption {
+            description = ''
+              Configuration options for `mcl shard-matrix`.
+            '';
+            default = { };
+            type = types.submodule (
+              { config, ... }:
+              {
+                options = {
+                  shards = mkOption {
+                    type = types.attrsOf (types.attrsOf types.package);
+                    description = ''
+                      An attribute set of attribute sets of derivations to be built by `nix-eval-jobs` for checking purposes
+                    '';
+                  };
+                  shardCount = mkOption {
+                    type = types.ints.unsigned;
+                    default = builtins.length (builtins.attrNames config.shards);
+                  };
+                  perSystemAttributePath = mkOption {
+                    type = types.listOf types.str;
+                  };
+                };
+              }
+            );
+          };
+        })
+      ];
+
+      options = {
+        mcl.matrix.shard = {
+          size = mkOption {
+            type = types.numbers.positive;
+            default = 1;
+            description = "Number of shards to use for parallel builds";
+          };
+          perSystemAttributePath = mkOption {
+            type = types.listOf types.str;
+            description = ''
+              Flake attribute path (with each system from `systemsToBuild` interpolated after the first attribute) to extract packages from to split into shards.
+
+              `["legacyPackages", "checks"]` -> `outputs.legacyPackages.''${system}.checks`
+            '';
+            default = [
+              "legacyPackages"
+              "checks"
+            ];
+          };
+          systemsToBuild = mkOption {
+            type = types.listOf types.str;
+            default = [
+              "x86_64-linux"
+              "aarch64-linux"
+              # NOTE: disabled because unneeded
+              # "x86_64-darwin"
+              "aarch64-darwin"
+            ];
+          };
         };
       };
 
       config = {
         perSystem =
-          { self', ... }:
+          {
+            config,
+            self',
+            system,
+            ...
+          }:
           let
-            inherit (cfg) size attributePath;
-            attrs = lib.attrByPath attributePath { } self';
-            shards = shardAttrs attrs size;
+            attrs = lib.attrByPath cfg.perSystemAttributePath { } self';
+
+            systemIsEnabled = lib.elem system cfg.systemsToBuild;
+            shards = lib.optionalAttrs systemIsEnabled (shardAttrs attrs cfg.size);
           in
           {
-            legacyPackages.mcl.matrix = {
-              shardCount = builtins.length (builtins.attrValues shards);
-              shardSize = cfg.size;
-              inherit shards attributePath;
+            mcl-matrices = {
+              shards = lib.mkOptionDefault shards;
+              perSystemAttributePath = lib.mkOptionDefault cfg.perSystemAttributePath;
             };
           };
       };

--- a/packages/mcl/src/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/src/mcl/commands/ci_matrix.d
@@ -32,17 +32,40 @@ enum GitHubOS
     @StringRepresentation("ubuntu-latest") ubuntuLatest,
     @StringRepresentation("self-hosted") selfHosted,
 
-    @StringRepresentation("macos-14") macos14
+    @StringRepresentation("macos-14") macos14,
 }
 
 enum SupportedSystem
 {
     @StringRepresentation("x86_64-linux") x86_64_linux,
 
+    @StringRepresentation("aarch64-linux") aarch64_linux,
+
     @StringRepresentation("x86_64-darwin") x86_64_darwin,
 
-    @StringRepresentation("aarch64-darwin") aarch64_darwin
+    @StringRepresentation("aarch64-darwin") aarch64_darwin,
 }
+
+version (linux)
+{
+    version (X86_64)
+        enum currentSystem = SupportedSystem.x86_64_linux;
+    else version (AArch64)
+        enum currentSystem = SupportedSystem.aarch64_linux;
+    else
+        static assert (0, "Unsupported architecture");
+}
+else version (OSX)
+{
+    version (X86_64)
+        enum currentSystem = SupportedSystem.x86_64_darwin;
+    else version (AArch64)
+        enum currentSystem = SupportedSystem.aarch64_darwin;
+    else
+        static assert (0, "Unsupported architecture");
+}
+else
+    static assert (0, "Unsupported OS");
 
 GitHubOS getGHOS(string os)
 {

--- a/packages/mcl/src/src/mcl/commands/shard_matrix.d
+++ b/packages/mcl/src/src/mcl/commands/shard_matrix.d
@@ -1,16 +1,15 @@
 module mcl.commands.shard_matrix;
 
-
 import std.algorithm : map;
 import std.array : array;
-import std.conv : to, parse;
+import std.conv : ConvException, to, parse;
+import std.exception : ifThrown;
 import std.file : append, write;
 import std.format : fmt = format;
 import std.logger : warningf, infof;
 import std.path : buildPath;
 import std.range : iota;
 import std.regex : matchFirst, regex;
-import std.stdio : writeln;
 import std.string : strip;
 
 import argparse : Command, Description, NamedArgument, Placeholder, EnvFallback;
@@ -18,6 +17,8 @@ import argparse : Command, Description, NamedArgument, Placeholder, EnvFallback;
 import mcl.utils.json : toJSON;
 import mcl.utils.nix : nix;
 import mcl.utils.path : createResultDirs, resultDir, rootDir;
+import mcl.utils.string : enumToString;
+import mcl.commands.ci_matrix : SupportedSystem, currentSystem;
 
 @(Command("shard-matrix", "shard_matrix")
     .Description("Generate a shard matrix for a flake"))
@@ -51,7 +52,7 @@ struct ShardMatrix
     Shard[] include;
 }
 
-ShardMatrix generateShardMatrix(string flakeRef = ".")
+ShardMatrix generateShardMatrix(string flakeRef = ".", SupportedSystem system = currentSystem)
 {
     import std.path : isValidPath, absolutePath, buildNormalizedPath;
 
@@ -59,17 +60,16 @@ ShardMatrix generateShardMatrix(string flakeRef = ".")
         flakeRef = flakeRef.absolutePath.buildNormalizedPath;
     }
 
-    const shardCountOutput = nix.eval("", [
-        "--impure",
-        "--expr",
-        `(builtins.getFlake "` ~ flakeRef ~ `").outputs.legacyPackages.x86_64-linux.mcl.matrix.shardCount or 0`
-    ]);
+    const shardCountOutput = nix.eval(
+        "%s#mcl-matrices.%s.shardCount".fmt(flakeRef, system.enumToString)
+    );
 
     infof("shardCount: '%s'", shardCountOutput);
 
     const shardCount = shardCountOutput
         .strip()
-        .to!uint;
+        .to!uint
+        .ifThrown!ConvException(0);
 
     if (shardCount == 0)
     {
@@ -94,11 +94,18 @@ unittest
         auto flakeRef = rootDir.buildPath("packages/mcl/src/src/mcl/utils/test/nix/shard-matrix-ok");
     }
 
-    auto shards = generateShardMatrix(flakeRef);
-    assert(shards.include.length == 11);
-    assert(shards.include[0].prefix == "legacyPackages");
-    assert(shards.include[0].postfix == "mcl.matrix.shards.0");
-    assert(shards.include[0].digit == 0);
+    {
+        auto shards = generateShardMatrix(flakeRef, SupportedSystem.aarch64_linux);
+        assert(shards.include == [Shard(prefix: "", postfix: "", digit: -1)]);
+    }
+
+    {
+        auto shards = generateShardMatrix(flakeRef, SupportedSystem.x86_64_linux);
+        assert(shards.include.length == 11);
+        assert(shards.include[0].prefix == "mcl-matrices");
+        assert(shards.include[0].postfix == "shards.0");
+        assert(shards.include[0].digit == 0);
+    }
 }
 
 @("generateShardMatrix.fail")
@@ -108,10 +115,7 @@ unittest
     auto flakeRef = rootDir.buildPath("packages/mcl/src/src/mcl/utils/test/nix/shard-matrix-no-shards");
 
     auto shards = generateShardMatrix(flakeRef);
-    assert(shards.include.length == 1);
-    assert(shards.include[0].prefix == "");
-    assert(shards.include[0].postfix == "");
-    assert(shards.include[0].digit == -1);
+    assert(shards.include == [Shard(prefix: "", postfix: "", digit: -1)]);
 }
 
 ShardMatrix splitToShards(int shardCount)
@@ -119,7 +123,7 @@ ShardMatrix splitToShards(int shardCount)
     ShardMatrix shards;
     shards.include = shardCount
         .iota
-        .map!(i => Shard("legacyPackages", "mcl.matrix.shards.%s".fmt(i), i))
+        .map!(i => Shard("mcl-matrices", "shards.%s".fmt(i), i))
         .array;
 
     return shards;
@@ -130,14 +134,14 @@ unittest
 {
     auto shards = splitToShards(3);
     assert(shards.include.length == 3);
-    assert(shards.include[0].prefix == "legacyPackages");
-    assert(shards.include[0].postfix == "mcl.matrix.shards.0");
+    assert(shards.include[0].prefix == "mcl-matrices");
+    assert(shards.include[0].postfix == "shards.0");
     assert(shards.include[0].digit == 0);
-    assert(shards.include[1].prefix == "legacyPackages");
-    assert(shards.include[1].postfix == "mcl.matrix.shards.1");
+    assert(shards.include[1].prefix == "mcl-matrices");
+    assert(shards.include[1].postfix == "shards.1");
     assert(shards.include[1].digit == 1);
-    assert(shards.include[2].prefix == "legacyPackages");
-    assert(shards.include[2].postfix == "mcl.matrix.shards.2");
+    assert(shards.include[2].prefix == "mcl-matrices");
+    assert(shards.include[2].postfix == "shards.2");
     assert(shards.include[2].digit == 2);
 
 }

--- a/packages/mcl/src/src/mcl/utils/test/disable_logging.d
+++ b/packages/mcl/src/src/mcl/utils/test/disable_logging.d
@@ -5,6 +5,9 @@ version (unittest)
     shared static this()
     {
         import std.logger : sharedLog, LogLevel, NullLogger;
-        sharedLog = cast(shared NullLogger) new NullLogger(LogLevel.all);
+
+        if ("DEBUG" !in imported!"std.process".environment) {
+            sharedLog = cast(shared NullLogger) new NullLogger(LogLevel.all);
+        }
     }
 }

--- a/packages/mcl/src/src/mcl/utils/test/nix/shard-matrix-ok/flake.lock
+++ b/packages/mcl/src/src/mcl/utils/test/nix/shard-matrix-ok/flake.lock
@@ -20,48 +20,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1720546205,
-        "narHash": "sha256-boCXsjYVxDviyzoEyAk624600f3ZBo/DKtUdvMTpbGY=",
+        "lastModified": 1762618334,
+        "narHash": "sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L+VSybPfiIgzU8lbQ=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "de96bd907d5fbc3b14fc33ad37d1b9a3cb15edc6",
+        "rev": "fcdea223397448d35d9b31f798479227e80183f6",
         "type": "github"
       },
       "original": {
         "owner": "ryantm",
         "repo": "agenix",
-        "type": "github"
-      }
-    },
-    "bats-assert": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1636059754,
-        "narHash": "sha256-ewME0l27ZqfmAwJO4h5biTALc9bDLv7Bl3ftBzBuZwk=",
-        "owner": "bats-core",
-        "repo": "bats-assert",
-        "rev": "34551b1d7f8c7b677c1a66fc0ac140d6223409e5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bats-core",
-        "repo": "bats-assert",
-        "type": "github"
-      }
-    },
-    "bats-support": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1548869839,
-        "narHash": "sha256-Gr4ntadr42F2Ks8Pte2D4wNDbijhujuoJi4OPZnTAZU=",
-        "owner": "bats-core",
-        "repo": "bats-support",
-        "rev": "d140a65044b2d6810381935ae7f0c94c7023c8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bats-core",
-        "repo": "bats-support",
         "type": "github"
       }
     },
@@ -75,21 +43,21 @@
           "nixos-modules",
           "flake-compat"
         ],
+        "git-hooks": [
+          "nixos-modules",
+          "git-hooks-nix"
+        ],
         "nixpkgs": [
           "nixos-modules",
           "nixpkgs-unstable"
-        ],
-        "pre-commit-hooks": [
-          "nixos-modules",
-          "git-hooks-nix"
         ]
       },
       "locked": {
-        "lastModified": 1719923519,
-        "narHash": "sha256-7Rhljj2fsklFRsu+eq7N683Z9qukmreMEj5C1GqCrSA=",
+        "lastModified": 1765277049,
+        "narHash": "sha256-+YzMHttYelF/L0HFc5tJrcRpABF/XMIgFYamTgpETs4=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "4e9e71f78b9500fa6210cf1eaa4d75bdbab777c3",
+        "rev": "8f31379263a615507fa86944149c1ceb5d7092c8",
         "type": "github"
       },
       "original": {
@@ -99,18 +67,12 @@
       }
     },
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixos-modules",
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1721322122,
-        "narHash": "sha256-a0G1NvyXGzdwgu6e1HQpmK5R5yLsfxeBe07nNDyYd+g=",
+        "lastModified": 1765145449,
+        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8a68b987c476a33e90f203f0927614a75c3f47ea",
+        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
         "type": "github"
       },
       "original": {
@@ -129,65 +91,47 @@
           "nixos-modules",
           "flake-compat"
         ],
+        "flake-parts": [
+          "nixos-modules",
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "nixos-modules",
+          "git-hooks-nix"
+        ],
         "nix": "nix",
         "nixpkgs": [
           "nixos-modules",
           "nixpkgs"
-        ],
-        "pre-commit-hooks": [
-          "nixos-modules",
-          "git-hooks-nix"
         ]
       },
       "locked": {
-        "lastModified": 1721213664,
-        "narHash": "sha256-OqQr3ulhVGCBjW7g1DXaI3wB9YtVVUb4cyaQMAJ/2NQ=",
+        "lastModified": 1765320738,
+        "narHash": "sha256-tYYtF9NRZRzVHJpism+Tv4E5/dVJZ92ECCKz1hF1BMA=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "1d848fc26376d919458482fa0b4d0e240285a93f",
+        "rev": "43682032927f3f5cfa5af539634985aba5c3fee3",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "devenv",
-        "type": "github"
-      }
-    },
-    "devour-flake": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1709858306,
-        "narHash": "sha256-Vey9n9hIlWiSAZ6CCTpkrL6jt4r2JvT2ik9wa2bjeC0=",
-        "owner": "srid",
-        "repo": "devour-flake",
-        "rev": "17b711b9deadbbc5629cb7d2b64cf86ae72af3fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "devour-flake",
         "type": "github"
       }
     },
     "devshell": {
       "inputs": {
-        "flake-utils": [
-          "nixos-modules",
-          "ethereum-nix",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixos-modules",
-          "ethereum-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1710156081,
-        "narHash": "sha256-4PMY6aumJi5dLFjBzF5O4flKXmadMNq3AGUHKYfchh0=",
+        "lastModified": 1764011051,
+        "narHash": "sha256-M7SZyPZiqZUR/EiiBJnmyUbOi5oE/03tCeFrTiUZchI=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "bc68b058dc7e6d4d6befc4ec6c60082b6e844b7d",
+        "rev": "17ed8d9744ebe70424659b0ef74ad6d41fc87071",
         "type": "github"
       },
       "original": {
@@ -204,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721417620,
-        "narHash": "sha256-6q9b1h8fI3hXg2DG6/vrKWCeG8c5Wj2Kvv22RCgedzg=",
+        "lastModified": 1765326679,
+        "narHash": "sha256-fTLX9kDwLr9Y0rH/nG+h1XG5UU+jBcy0PFYn5eneRX8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "bec6e3cde912b8acb915fecdc509eda7c973fb42",
+        "rev": "d64e5cdca35b5fad7c504f615357a7afe6d9c49e",
         "type": "github"
       },
       "original": {
@@ -230,24 +174,30 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1714055636,
-        "narHash": "sha256-8LCyIPAK4/4ge03ohCIWpoJrMGgoCaOriALzt7gPxHE=",
+        "lastModified": 1744296746,
+        "narHash": "sha256-x9rQjZceKcCte+gZcy0EmrNw5WEXVpP130w2YIVLEnw=",
         "owner": "PetarKirov",
         "repo": "dlang.nix",
-        "rev": "dab4c199ad644dc23b0b9481e2e5a063e9492b84",
+        "rev": "e7c6c25978f5ec0a7b8ebae703dad3460d7fcceb",
         "type": "github"
       },
       "original": {
         "owner": "PetarKirov",
+        "ref": "feat/build-dub-package",
         "repo": "dlang.nix",
-        "rev": "dab4c199ad644dc23b0b9481e2e5a063e9492b84",
         "type": "github"
       }
     },
     "ethereum-nix": {
       "inputs": {
-        "devour-flake": "devour-flake",
-        "devshell": "devshell",
+        "devshell": [
+          "nixos-modules",
+          "devshell"
+        ],
+        "fenix": [
+          "nixos-modules",
+          "fenix"
+        ],
         "flake-compat": [
           "nixos-modules",
           "flake-compat"
@@ -261,10 +211,9 @@
           "flake-utils"
         ],
         "foundry-nix": "foundry-nix",
-        "lib-extras": "lib-extras",
         "nixpkgs": [
           "nixos-modules",
-          "nixos-2311"
+          "nixos-2505"
         ],
         "nixpkgs-unstable": [
           "nixos-modules",
@@ -280,15 +229,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1721292412,
-        "narHash": "sha256-U6XCMdnPJxPhA4nHfKUTe8KlV7/l1HC968P8jkKUoKU=",
+        "lastModified": 1762435945,
+        "narHash": "sha256-LgxXAiQpvNUuo9o00Dlds2Lr4bJ4lVXpE/awddJZ224=",
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
-        "rev": "53526f8b9c77ef9624ad325dfbcc82a5cdd51010",
+        "rev": "a1987c63f20a4b6c45ce3e8b5d5cd22fffb6d4ba",
         "type": "github"
       },
       "original": {
         "owner": "metacraft-labs",
+        "ref": "dev",
         "repo": "ethereum.nix",
         "type": "github"
       }
@@ -302,11 +252,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1721543262,
-        "narHash": "sha256-6m2G2pGmFjPGeXDs0FqhDfdACCCcFN3XMWHEyTTyTXo=",
+        "lastModified": 1765252472,
+        "narHash": "sha256-byMt/uMi7DJ8tRniFopDFZMO3leSjGp6GS4zWOFT+uQ=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "a01667fc71674454dd9ec2669afc0b326a275796",
+        "rev": "8456b985f6652e3eef0632ee9992b439735c5544",
         "type": "github"
       },
       "original": {
@@ -318,11 +268,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
         "type": "github"
       },
       "original": {
@@ -339,33 +289,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixos-modules",
-          "validator-ejector",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
         "type": "github"
       },
       "original": {
@@ -376,26 +304,11 @@
     },
     "flake-root": {
       "locked": {
-        "lastModified": 1692742795,
-        "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
+        "lastModified": 1723604017,
+        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
         "owner": "srid",
         "repo": "flake-root",
-        "rev": "d9a70d9c7a5fd7f3258ccf48da9335e9b47c3937",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
-    "flake-root_2": {
-      "locked": {
-        "lastModified": 1713493429,
-        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
+        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
         "type": "github"
       },
       "original": {
@@ -412,11 +325,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -433,11 +346,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719955819,
-        "narHash": "sha256-QrvC5YG+EDr7kIM5KWPMc/mZeGEcxxrkjkaTDIigkgI=",
+        "lastModified": 1738591040,
+        "narHash": "sha256-4WNeriUToshQ/L5J+dTSWC5OJIwT39SEP7V7oylndi8=",
         "owner": "gytis-ivaskevicius",
         "repo": "flake-utils-plus",
-        "rev": "e5f2a9feedc43834d80486e2ba8f6fd31a3a4f1f",
+        "rev": "afcb15b845e74ac5e998358709b2b5fe42a948d1",
         "type": "github"
       },
       "original": {
@@ -460,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709457044,
-        "narHash": "sha256-1SktmSjTjC1rhJwQ+kvqUeExKogNzserFGuoGwOerHw=",
+        "lastModified": 1759569036,
+        "narHash": "sha256-FuxbXLDArxD1NeRR8zNnsb8Xww5/+qdMwzN1m8Kow/M=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "592e8ca2e82a2c3a8d0d4dcc7f7c5b8c3842efcd",
+        "rev": "47ba6d3b02bf3faaa857d3572df82ff186d5279a",
         "type": "github"
       },
       "original": {
@@ -483,19 +396,15 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixos-modules",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixos-modules",
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1765404074,
+        "narHash": "sha256-+ZDU2d+vzWkEJiqprvV5PR26DVFN2vgddwG5SnPZcUM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "2d6f58930fbcd82f6f9fd59fb6d13e37684ca529",
         "type": "github"
       },
       "original": {
@@ -538,11 +447,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719226092,
-        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
+        "lastModified": 1763182882,
+        "narHash": "sha256-jZi+9yKmeTMsJ4ZNqRei/wL16+QwYGrCl4EJ3QHfoDU=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
+        "rev": "b0585849abe7d02a774a853f7952d07bb910fd9e",
         "type": "github"
       },
       "original": {
@@ -559,56 +468,38 @@
         ]
       },
       "locked": {
-        "lastModified": 1720042825,
-        "narHash": "sha256-A0vrUB6x82/jvf17qPCpxaM+ulJnD8YZwH9Ci0BsAzE=",
+        "lastModified": 1765384171,
+        "narHash": "sha256-FuFtkJrW1Z7u+3lhzPRau69E0CNjADku1mLQQflUORo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e1391fb22e18a36f57e6999c7a9f966dc80ac073",
+        "rev": "44777152652bc9eacf8876976fa72cc77ca8b9d8",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.05",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }
     },
-    "lib-extras": {
+    "home-manager-unstable": {
       "inputs": {
-        "devshell": [
-          "nixos-modules",
-          "ethereum-nix",
-          "devshell"
-        ],
-        "flake-parts": [
-          "nixos-modules",
-          "ethereum-nix",
-          "flake-parts"
-        ],
-        "flake-root": "flake-root",
         "nixpkgs": [
           "nixos-modules",
-          "ethereum-nix",
-          "nixpkgs"
-        ],
-        "treefmt-nix": [
-          "nixos-modules",
-          "ethereum-nix",
-          "treefmt-nix"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
-        "lastModified": 1699974671,
-        "narHash": "sha256-4EsuPiX4pGEg8ME9ONn8ebY1ZKYLOp9DRCcdTrOj8sY=",
-        "owner": "aldoborrero",
-        "repo": "lib-extras",
-        "rev": "83c8935af27738b8b155e0077522220d81865269",
+        "lastModified": 1765337252,
+        "narHash": "sha256-HuWQp8fM25fyWflbuunQkQI62Hg0ecJxWD52FAgmxqY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "13cc1efd78b943b98c08d74c9060a5b59bf86921",
         "type": "github"
       },
       "original": {
-        "owner": "aldoborrero",
-        "ref": "v0.2.2",
-        "repo": "lib-extras",
+        "owner": "nix-community",
+        "repo": "home-manager",
         "type": "github"
       }
     },
@@ -625,11 +516,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1721171275,
-        "narHash": "sha256-GKdodvwT9Suh6V0qJ0N/YWTIADWwto/x3XnFO86iXDs=",
+        "lastModified": 1765402693,
+        "narHash": "sha256-cf/Dwu5VqyFxpvLJ099yulWgOfMlQ8l1GmWU8tsNSOw=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "36e261aa2c15a4020663cef87905f436b15305f7",
+        "rev": "3e8608205a1079f415306f45009cedb1005a1fa2",
         "type": "github"
       },
       "original": {
@@ -645,24 +536,41 @@
           "devenv",
           "flake-compat"
         ],
+        "flake-parts": [
+          "nixos-modules",
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "nixos-modules",
+          "devenv",
+          "git-hooks"
+        ],
         "nixpkgs": [
           "nixos-modules",
           "devenv",
           "nixpkgs"
         ],
-        "nixpkgs-regression": "nixpkgs-regression"
+        "nixpkgs-23-11": [
+          "nixos-modules",
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "nixos-modules",
+          "devenv"
+        ]
       },
       "locked": {
-        "lastModified": 1712911606,
-        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
-        "owner": "domenkozar",
+        "lastModified": 1761648602,
+        "narHash": "sha256-H97KSB/luq/aGobKRuHahOvT1r7C03BgB6D5HBZsbN8=",
+        "owner": "cachix",
         "repo": "nix",
-        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
+        "rev": "3e5644da6830ef65f0a2f7ec22830c46285bfff6",
         "type": "github"
       },
       "original": {
-        "owner": "domenkozar",
-        "ref": "devenv-2.21",
+        "owner": "cachix",
+        "ref": "devenv-2.30.6",
         "repo": "nix",
         "type": "github"
       }
@@ -675,21 +583,47 @@
         ]
       },
       "locked": {
-        "lastModified": 1721550066,
-        "narHash": "sha256-wr6sSb+VpXy8HCvBqU6xvhpaARzWUbEK7uN5tLnqYDg=",
-        "owner": "LnL7",
+        "lastModified": 1765066094,
+        "narHash": "sha256-0YSU35gfRFJzx/lTGgOt6ubP8K6LeW0vaywzNNqxkl4=",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "33bf7df5bbfcbbb49e6559b0c96c9e3b26d14e58",
+        "rev": "688427b1aab9afb478ca07989dc754fa543e03d5",
         "type": "github"
       },
       "original": {
-        "owner": "LnL7",
+        "owner": "nix-darwin",
+        "ref": "nix-darwin-25.11",
         "repo": "nix-darwin",
         "type": "github"
       }
     },
-    "nix2container": {
+    "nix-darwin-unstable": {
       "inputs": {
+        "nixpkgs": [
+          "nixos-modules",
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765065051,
+        "narHash": "sha256-b7W9WsvyMOkUScNxbzS45KEJp0iiqRPyJ1I3JBE+oEE=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "7e22bf538aa3e0937effcb1cee73d5f1bcc26f79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nix-topology": {
+      "inputs": {
+        "devshell": [
+          "nixos-modules",
+          "devshell"
+        ],
         "flake-utils": [
           "nixos-modules",
           "flake-utils"
@@ -697,14 +631,61 @@
         "nixpkgs": [
           "nixos-modules",
           "nixpkgs"
+        ],
+        "pre-commit-hooks": [
+          "nixos-modules",
+          "git-hooks-nix"
         ]
       },
       "locked": {
-        "lastModified": 1720642556,
-        "narHash": "sha256-qsnqk13UmREKmRT7c8hEnz26X3GFFyIQrqx4EaRc1Is=",
+        "lastModified": 1765221099,
+        "narHash": "sha256-U4cu+HkqVNuoGWbQPUOAWOY0yED4IrEEic1D9vwImfg=",
+        "owner": "oddlama",
+        "repo": "nix-topology",
+        "rev": "a59b65e98d0e22ae800014961eeb076815ddca20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oddlama",
+        "repo": "nix-topology",
+        "type": "github"
+      }
+    },
+    "nix-vm-test": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-modules",
+          "nixos-anywhere",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1748765518,
+        "narHash": "sha256-vftOR+7zwnMWl5UpG32GL1VBeNGTDZZT0hv+2uNuBGw=",
+        "owner": "Mic92",
+        "repo": "nix-vm-test",
+        "rev": "d6642fbaf42fc98883d84bab66cd0ec720d9dd0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-vm-test",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-modules",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761716996,
+        "narHash": "sha256-vdOuy2pid2/DasUgb08lDOswdPJkN5qjXfBYItVy/R4=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "3853e5caf9ad24103b13aa6e0e8bcebb47649fe4",
+        "rev": "e5496ab66e9de9e3f67dc06f692dfbc471b6316e",
         "type": "github"
       },
       "original": {
@@ -719,15 +700,19 @@
           "nixos-modules",
           "flake-parts"
         ],
-        "flake-root": "flake-root_2",
-        "nixpkgs": "nixpkgs_2"
+        "flake-root": "flake-root",
+        "nixpkgs": "nixpkgs_2",
+        "treefmt-nix": [
+          "nixos-modules",
+          "treefmt-nix"
+        ]
       },
       "locked": {
-        "lastModified": 1721581528,
-        "narHash": "sha256-3esP3cMdqotokFJYxcu680r2VaSA78T03A2VwCZuWEw=",
+        "lastModified": 1765393498,
+        "narHash": "sha256-OapXNkISC2JXOFs7c6V7puiYg4+XSJxbGNce3GNVMWo=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "87135e0dfb3d56262e39de123d5741d2d892dd5e",
+        "rev": "72f4dd1fc57114dd0b455d07605de899d6961f29",
         "type": "github"
       },
       "original": {
@@ -736,34 +721,34 @@
         "type": "github"
       }
     },
-    "nixos-2311": {
+    "nixos-2505": {
       "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "lastModified": 1764939437,
+        "narHash": "sha256-4TLFHUwXraw9Df5mXC/vCrJgb50CRr3CzUzF0Mn3CII=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "rev": "00d2457e2f608b4be6fe8b470b0a36816324b0ae",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixos-2405": {
+    "nixos-2511": {
       "locked": {
-        "lastModified": 1721409541,
-        "narHash": "sha256-b6PLr0Ty7JPDBtJtjnYzlBf02bbH9alWMAgispMkTwk=",
+        "lastModified": 1765311797,
+        "narHash": "sha256-mSD5Ob7a+T2RNjvPvOA1dkJHGVrNVl8ZOrAwBjKBDQo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c53b6b8c2a3e46c68e04417e247bba660689c9d",
+        "rev": "09eb77e94fa25202af8f3e81ddc7353d9970ac1b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -778,11 +763,15 @@
           "nixos-modules",
           "flake-parts"
         ],
+        "nix-vm-test": "nix-vm-test",
         "nixos-images": [
           "nixos-modules",
           "nixos-images"
         ],
-        "nixos-stable": "nixos-stable",
+        "nixos-stable": [
+          "nixos-modules",
+          "nixpkgs"
+        ],
         "nixpkgs": [
           "nixos-modules",
           "nixpkgs"
@@ -793,11 +782,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720926282,
-        "narHash": "sha256-JOF4DNpKHzK7noVkh9tP+Rg9yZUyOBrEKPbdqKom5KI=",
+        "lastModified": 1763045507,
+        "narHash": "sha256-61zO8zsFE8C104hCTv04z6a4H8U03OEMrRAXtGsszkE=",
         "owner": "numtide",
         "repo": "nixos-anywhere",
-        "rev": "daf19effbafba2cfeac4c41e17dccdd07ca86cb3",
+        "rev": "bad98b0685cf47eaeadcaf6787da8b51cf025693",
         "type": "github"
       },
       "original": {
@@ -810,7 +799,7 @@
       "inputs": {
         "nixos-stable": [
           "nixos-modules",
-          "nixos-2405"
+          "nixpkgs"
         ],
         "nixos-unstable": [
           "nixos-modules",
@@ -818,11 +807,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721571445,
-        "narHash": "sha256-2MnlPVcNJZ9Nbu90kFyo7+lng366gswErP4FExfrUbc=",
+        "lastModified": 1764589946,
+        "narHash": "sha256-W8C9UnclS2IAvSuAYcvG1w+H/kVaqVE5XZNVh+fICH0=",
         "owner": "nix-community",
         "repo": "nixos-images",
-        "rev": "accee005735844d57b411d9969c5d0aabc6a55f6",
+        "rev": "ec7cd3c865f01906e6d023f8942299ad817f84cd",
         "type": "github"
       },
       "original": {
@@ -837,6 +826,7 @@
         "cachix": "cachix",
         "crane": "crane",
         "devenv": "devenv",
+        "devshell": "devshell",
         "disko": "disko",
         "dlang-nix": "dlang-nix",
         "ethereum-nix": "ethereum-nix",
@@ -848,55 +838,36 @@
         "git-hooks-nix": "git-hooks-nix",
         "hercules-ci-effects": "hercules-ci-effects",
         "home-manager": "home-manager",
+        "home-manager-unstable": "home-manager-unstable",
         "microvm": "microvm",
         "nix-darwin": "nix-darwin",
+        "nix-darwin-unstable": "nix-darwin-unstable",
+        "nix-topology": "nix-topology",
         "nix2container": "nix2container",
         "nixd": "nixd",
-        "nixos-2311": "nixos-2311",
-        "nixos-2405": "nixos-2405",
+        "nixos-2505": "nixos-2505",
+        "nixos-2511": "nixos-2511",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-images": "nixos-images",
         "nixpkgs": [
           "nixos-modules",
-          "nixos-2405"
+          "nixos-2511"
         ],
         "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems",
         "terranix": "terranix",
         "treefmt-nix": "treefmt-nix",
-        "validator-ejector": "validator-ejector",
         "vscode-server": "vscode-server"
       },
       "locked": {
-        "lastModified": 1721608595,
-        "narHash": "sha256-pWrqNYGDUbL+i+QRbFQ8qCpAep0OQ5E8MAYU7vyGfsI=",
-        "owner": "metacraft-labs",
-        "repo": "nixos-modules",
-        "rev": "a6302392aa47a0820d4e1fbd3e565df6c2d01084",
-        "type": "github"
+        "path": "../../../../../../../../..",
+        "type": "path"
       },
       "original": {
-        "owner": "metacraft-labs",
-        "repo": "nixos-modules",
-        "rev": "a6302392aa47a0820d4e1fbd3e565df6c2d01084",
-        "type": "github"
-      }
-    },
-    "nixos-stable": {
-      "locked": {
-        "lastModified": 1717696253,
-        "narHash": "sha256-1+ua0ggXlYYPLTmMl3YeYYsBXDSCqT+Gw3u6l4gvMhA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9b5328b7f761a7bbdc0e332ac4cf076a3eedb89b",
-        "type": "github"
+        "path": "../../../../../../../../..",
+        "type": "path"
       },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
+      "parent": []
     },
     "nixpkgs": {
       "locked": {
@@ -914,29 +885,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1721379653,
-        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
         "type": "github"
       },
       "original": {
@@ -948,11 +903,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1714562304,
-        "narHash": "sha256-Mr3U37Rh6tH0FbaDFu0aZDwk9mPAe7ASaqDOGgLqqLU=",
+        "lastModified": 1754800730,
+        "narHash": "sha256-HfVZCXic9XLBgybP0318ym3cDnGwBs/+H5MgxFVYF4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcd44e224fd68ce7d269b4f44d24c2220fd821e7",
+        "rev": "641d909c4a7538f1539da9240dedb1755c907e40",
         "type": "github"
       },
       "original": {
@@ -978,11 +933,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1721498641,
-        "narHash": "sha256-b6LaJzKxDagq1NeXf6TndjpnR+1z2pUuLJSmutQNnI8=",
+        "lastModified": 1765120009,
+        "narHash": "sha256-nG76b87rkaDzibWbnB5bYDm6a52b78A+fpm+03pqYIw=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "8d489e21eb1d288a1000dba26a721e6efd7f993a",
+        "rev": "5e3e9c4e61bba8a5e72134b9ffefbef8f531d008",
         "type": "github"
       },
       "original": {
@@ -995,11 +950,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1708358594,
-        "narHash": "sha256-e71YOotu2FYA67HoC/voJDTFsiPpZNRwmiQb4f94OxQ=",
+        "lastModified": 1759482047,
+        "narHash": "sha256-H1wiXRQHxxPyMMlP39ce3ROKCwI5/tUn36P8x6dFiiQ=",
         "ref": "refs/heads/main",
-        "rev": "6d0e73864d28794cdbd26ab7b37259ab0e1e044c",
-        "revCount": 614,
+        "rev": "c5d5786d3dc938af0b279c542d1e43bce381b4b9",
+        "revCount": 996,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },
@@ -1025,44 +980,30 @@
     },
     "terranix": {
       "inputs": {
-        "bats-assert": "bats-assert",
-        "bats-support": "bats-support",
-        "flake-utils": [
+        "flake-parts": [
           "nixos-modules",
-          "flake-utils"
+          "flake-parts"
         ],
         "nixpkgs": [
           "nixos-modules",
-          "nixos-2311"
+          "nixpkgs"
         ],
-        "terranix-examples": "terranix-examples"
+        "systems": [
+          "nixos-modules",
+          "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1695406838,
-        "narHash": "sha256-xiUfVD6rtsVWFotVtUW3Q1nQh4obKzgvpN1wqZuGXvM=",
+        "lastModified": 1762472226,
+        "narHash": "sha256-iVS4sxVgGn+T74rGJjEJbzx+kjsuaP3wdQVXBNJ79A0=",
         "owner": "terranix",
         "repo": "terranix",
-        "rev": "fc9077ca02ab5681935dbf0ecd725c4d889b9275",
+        "rev": "3b5947a48da5694094b301a3b1ef7b22ec8b19fc",
         "type": "github"
       },
       "original": {
         "owner": "terranix",
         "repo": "terranix",
-        "type": "github"
-      }
-    },
-    "terranix-examples": {
-      "locked": {
-        "lastModified": 1636300201,
-        "narHash": "sha256-0n1je1WpiR6XfCsvi8ZK7GrpEnMl+DpwhWaO1949Vbc=",
-        "owner": "terranix",
-        "repo": "terranix-examples",
-        "rev": "a934aa1cf88f6bd6c6ddb4c77b77ec6e1660bd5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "terranix",
-        "repo": "terranix-examples",
         "type": "github"
       }
     },
@@ -1074,39 +1015,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1721458737,
-        "narHash": "sha256-wNXLQ/ATs1S4Opg1PmuNoJ+Wamqj93rgZYV3Di7kxkg=",
+        "lastModified": 1762938485,
+        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "888bfb10a9b091d9ed2f5f8064de8d488f7b7c97",
+        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "validator-ejector": {
-      "inputs": {
-        "flake-parts": "flake-parts_2",
-        "nixpkgs": [
-          "nixos-modules",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1710236967,
-        "narHash": "sha256-2HJmglBoFg9h9GEAg/PT9wINa8ENtF58B13Gtz0pr/I=",
-        "owner": "metacraft-labs",
-        "repo": "validator-ejector",
-        "rev": "bfeb33e99e18a6bc9f6321e5329e7da0a55a1c2e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "metacraft-labs",
-        "ref": "add/nix-package",
-        "repo": "validator-ejector",
         "type": "github"
       }
     },
@@ -1122,17 +1040,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1694401971,
-        "narHash": "sha256-7ZaJGCK/Hwz7YtPFX9xX6HtzNozUtY0qqwe2syyA5Oo=",
+        "lastModified": 1753541826,
+        "narHash": "sha256-foGgZu8+bCNIGeuDqQ84jNbmKZpd+JvnrL2WlyU4tuU=",
         "owner": "nix-community",
         "repo": "nixos-vscode-server",
-        "rev": "7e581626a07486b1779ef02320e7e310feb11611",
+        "rev": "6d5f074e4811d143d44169ba4af09b20ddb6937d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "nixos-vscode-server",
-        "rev": "7e581626a07486b1779ef02320e7e310feb11611",
         "type": "github"
       }
     }

--- a/packages/mcl/src/src/mcl/utils/test/nix/shard-matrix-ok/flake.nix
+++ b/packages/mcl/src/src/mcl/utils/test/nix/shard-matrix-ok/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixos-modules.url = "github:metacraft-labs/nixos-modules?rev=a6302392aa47a0820d4e1fbd3e565df6c2d01084";
+    nixos-modules.url = "../../../../../../../../..";
     nixpkgs.follows = "nixos-modules/nixpkgs";
     flake-parts.follows = "nixos-modules/flake-parts";
   };
@@ -11,37 +11,51 @@
       nixos-modules,
       ...
     }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" ];
-      imports = [ nixos-modules.flakeModules.shardSplit ];
-
-      mcl.matrix.shard = {
-        size = 10;
-        attributePath = [
-          "legacyPackages"
-          "ci-checks"
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { config, lib, ... }:
+      {
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
         ];
-      };
+        imports = [ nixos-modules.modules.flake.shardSplit ];
 
-      perSystem =
-        {
-          pkgs,
-          lib,
-          ...
-        }:
-        {
-          legacyPackages.ci-checks = lib.pipe (lib.range 0 100) [
-            (map builtins.toString)
-            (
-              x:
-              lib.genAttrs x (
-                i:
-                pkgs.runCommandLocal "test-${i}" { } ''
-                  echo 'The answer is ${i}!' > $out
-                ''
-              )
-            )
+        mcl.matrix.shard = {
+          size = 10;
+          perSystemAttributePath = [
+            "legacyPackages"
+            "ci-checks"
+          ];
+          systemsToBuild = [
+            "x86_64-linux"
+            "aarch64-darwin"
           ];
         };
-    };
+
+        debug = true;
+
+        perSystem =
+          {
+            pkgs,
+            lib,
+            ...
+          }:
+          {
+            legacyPackages.ci-checks = lib.pipe (lib.range 0 100) [
+              (map (i: "test-${builtins.toString i}"))
+              (
+                x:
+                lib.genAttrs x (
+                  i:
+                  pkgs.runCommandLocal "test-${i}" { } ''
+                    echo 'The answer is ${i}!' > $out
+                  ''
+                )
+              )
+            ];
+          };
+      }
+    );
 }


### PR DESCRIPTION
# Overview

This pull request refactors the shard matrix generation logic for Nix flakes and the associated D code, improving configurability and multi-system support. The changes introduce a more flexible and explicit configuration for per-system shard matrices, update the D implementation to match, and enhance testing to cover more systems. 

# Example usage

```nix
{
  inputs = {
    nixos-modules.url = "github:metacraft-labs/nixos-modules";
    nixpkgs.follows = "nixos-modules/nixpkgs";
    flake-parts.follows = "nixos-modules/flake-parts";
  };

  outputs =
    inputs@{
      flake-parts,
      nixos-modules,
      ...
    }:
    flake-parts.lib.mkFlake { inherit inputs; } (
      { config, lib, ... }:
      {
        systems = [
          "x86_64-linux"
          "aarch64-linux"
          "x86_64-darwin"
          "aarch64-darwin"
        ];
        imports = [ nixos-modules.modules.flake.shardSplit ];

        mcl.matrix.shard = {
          size = 10;
          perSystemAttributePath = [
            "legacyPackages"
            "my-package-set"
          ];
          
          # Systems to be tested by `mcl shard-matrix` and `mcl ci-matrix`
          systemsToBuild = [
            "x86_64-linux"
            "aarch64-darwin"
          ];
        };

        # Add flake outputs to legacyPackages.my-package-set
      }
    );
}
```

# Detailed changes

The most important changes are:

**Nix module and flake configuration improvements:**

* Refactored the `shard-split` Nix module to use a `mcl-matrices` submodule with explicit `perSystemAttributePath` and `systemsToBuild` options, allowing fine-grained control over which systems and attribute paths are sharded. The configuration is now more flexible and better structured for multi-system support.
* Updated the test flake (`shard-matrix-ok/flake.nix`) to use the new options, support multiple systems, and improved attribute generation for test coverage. [[1]](diffhunk://#diff-938f490c1c534fa86ea11f4054843bdbe540c04647570b4e99c1e491f3e3ae76L14-R38) [[2]](diffhunk://#diff-938f490c1c534fa86ea11f4054843bdbe540c04647570b4e99c1e491f3e3ae76L34-R47) [[3]](diffhunk://#diff-938f490c1c534fa86ea11f4054843bdbe540c04647570b4e99c1e491f3e3ae76L46-R60)

**D code enhancements for shard matrix generation:**

* Added `SupportedSystem` and `currentSystem` enums to the D code, enabling system-aware matrix generation and making it easier to target different platforms.
* Modified `generateShardMatrix` and related logic to use the new Nix output structure (`mcl-matrices.<system>.shardCount`), and updated the prefix/postfix logic in both code and tests to match the new naming scheme. [[1]](diffhunk://#diff-8635f867d1a56a4e4ff93d9ac5e6ec1f9d78056f60d1584c27550632e3246726L54-R65) [[2]](diffhunk://#diff-8635f867d1a56a4e4ff93d9ac5e6ec1f9d78056f60d1584c27550632e3246726L122-R128) [[3]](diffhunk://#diff-8635f867d1a56a4e4ff93d9ac5e6ec1f9d78056f60d1584c27550632e3246726L133-R146) [[4]](diffhunk://#diff-8635f867d1a56a4e4ff93d9ac5e6ec1f9d78056f60d1584c27550632e3246726L97-R108)

**Testing and compatibility:**

* Enhanced the test suite to check matrix generation for multiple systems, ensuring correctness across all supported platforms.

These changes collectively make the shard matrix system more robust, maintainable, and extensible for future needs.