### PR TITLE
feat(bundlers)!: Export `deb`, `rpm` and `AppImage` bundlers

### DIFF
--- a/bundlers/default.nix
+++ b/bundlers/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  flake-parts-lib,
+  inputs,
+  ...
+}:
+{
+  imports = [
+    (flake-parts-lib.mkTransposedPerSystemModule {
+      name = "bundlers";
+      option = lib.mkOption {
+        type = lib.types.lazyAttrsOf (lib.types.functionTo lib.types.package);
+        default = { };
+      };
+      file = ./flake.nix;
+    })
+  ];
+
+  perSystem =
+    {
+      pkgs,
+      inputs',
+      config,
+      ...
+    }:
+    let
+      nfpmConfig =
+        pkg:
+        pkgs.writeText "${pkg.pname}-nfpm-config.yaml" (
+          builtins.toJSON {
+            name = pkg.pname;
+            inherit (pkg)
+              version
+              ;
+            inherit (pkg.meta)
+              homepage
+              description
+              ;
+            license = pkg.meta.license.spdxId or null;
+            contents = [
+              {
+                src = lib.getExe pkg;
+                dst = "/usr/bin/${pkg.meta.mainProgram or (lib.getName pkg)}";
+              }
+            ];
+          }
+        );
+
+      installerFor =
+        packager: pkg:
+        pkgs.runCommand "${pkg.pname}-${packager}-pkg" { } ''
+          mkdir -p "$out"
+          cd "$out"
+          ${lib.getExe pkgs.nfpm} package \
+            --config ${nfpmConfig pkg} \
+            --packager ${packager} \
+            --target "$out"
+        '';
+
+      installers = [
+        "deb"       # Debian/Ubuntu
+        "rpm"       # Fedora/RHEL/SUSE
+        "apk"       # Alpine
+        "archlinux" # Arch
+      ];
+
+      nfpmBundlers = lib.pipe installers [
+        (lib.map (i: {
+          name = "to${lib.toUpper (lib.substring 0 1 i)}${lib.substring 1 (-1) i}";
+          value = installerFor i;
+        }))
+        lib.listToAttrs
+      ];
+    in
+    {
+      bundlers = {
+        toAppimage = inputs'.nix-appimage.bundlers.default;
+      } // nfpmBundlers;
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -329,21 +329,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "foundry-nix": {
       "inputs": {
         "flake-utils": [
@@ -566,50 +551,6 @@
         "type": "github"
       }
     },
-    "nix-bundle": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-bundlers",
-          "nixpkgs"
-        ],
-        "utils": "utils"
-      },
-      "locked": {
-        "lastModified": 1756736056,
-        "narHash": "sha256-8YFhvulVX3iS4TYnKisA9zSImJeFN21G75HOUUFjzuE=",
-        "owner": "nix-community",
-        "repo": "nix-bundle",
-        "rev": "eff01593f62794d458ec714090091419194ab64d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-bundle",
-        "type": "github"
-      }
-    },
-    "nix-bundlers": {
-      "inputs": {
-        "nix-bundle": "nix-bundle",
-        "nix-utils": "nix-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1756736145,
-        "narHash": "sha256-gKlLhzQ6PUTeC0Mi7aaX0tZ0wl6QB/slHLlk7jy0IN4=",
-        "owner": "NixOS",
-        "repo": "bundlers",
-        "rev": "dce9249b74500ef75110153e6da455ffec2532ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "bundlers",
-        "type": "github"
-      }
-    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -680,25 +621,6 @@
         "type": "github"
       }
     },
-    "nix-utils": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1744222205,
-        "narHash": "sha256-di1eNHQdpvvyXv6i7Z+S79KF7cQyhTs7AdFHp7q1e3Q=",
-        "owner": "juliosueiras-nix",
-        "repo": "nix-utils",
-        "rev": "53282197ad090c8cf47c96e99bf6c6c3b2cdc7c0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "juliosueiras-nix",
-        "repo": "nix-utils",
-        "type": "github"
-      }
-    },
     "nix-vm-test": {
       "inputs": {
         "nixpkgs": [
@@ -746,7 +668,7 @@
           "flake-parts"
         ],
         "flake-root": "flake-root",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "treefmt-nix": [
           "treefmt-nix"
         ]
@@ -890,21 +812,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1629252929,
-        "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3788c68def67ca7949e0864c27638d484389363d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1754800730,
         "narHash": "sha256-HfVZCXic9XLBgybP0318ym3cDnGwBs/+H5MgxFVYF4I=",
         "owner": "NixOS",
@@ -940,7 +847,6 @@
         "home-manager-unstable": "home-manager-unstable",
         "microvm": "microvm",
         "nix-appimage": "nix-appimage",
-        "nix-bundlers": "nix-bundlers",
         "nix-darwin": "nix-darwin",
         "nix-darwin-unstable": "nix-darwin-unstable",
         "nix-topology": "nix-topology",
@@ -954,7 +860,7 @@
           "nixos-2511"
         ],
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "systems": "systems_2",
+        "systems": "systems",
         "terranix": "terranix",
         "treefmt-nix": "treefmt-nix",
         "vscode-server": "vscode-server"
@@ -994,21 +900,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1066,24 +957,6 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -229,15 +229,6 @@
       };
     };
 
-    nix-bundlers = {
-      url = "github:NixOS/bundlers";
-      inputs.nixpkgs.follows = "nixpkgs";
-      # TODO: re-add when CI's `nix` starts supporting transitive overrides
-      # inputs.nix-utils.inputs.nixpkgs.follows = "nixpkgs";
-      # inputs.nix-utils.inputs.flake-utils.follows = "flake-utils";
-      # inputs.nix-bundle.inputs.utils.follows = "flake-utils";
-    };
-
     nix-appimage = {
       url = "github:ralismark/nix-appimage";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -263,6 +254,7 @@
         ./modules
         ./packages
         ./shells
+        ./bundlers
       ];
       systems = [
         "x86_64-linux"


### PR DESCRIPTION
- All logic is contained in a new `./bundlers/default.nix` module
- Add a `bundlers` `perSystem` output
- Export `deb` and `rpm` bundlers from our fork of `juliosueiras-nix/nix-utils`
  (used by `NixOS/bundlers`, which we originally used)
- Export the `AppImage` bundler from `ralismark/nix-appimage`
