### PR TITLE
feat(mcl/ci-matrix): Add configurable per-system GitHub runner labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,20 @@ jobs:
     uses: ./.github/workflows/reusable-flake-checks-ci-matrix.yml
     secrets: inherit
     with:
-      runner: '["self-hosted", "Linux", "x86-64-v2"]'
+      runners: |
+        {
+          "x86_64-linux": [
+            "self-hosted",
+            "nixos",
+            "x86-64-v3",
+            "bare-metal"
+          ],
+          "aarch64-darwin": [
+            "self-hosted",
+            "macOS",
+            "aarch64-darwin"
+          ]
+        }
       run-cachix-deploy: false
 
   test-act:

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -4,16 +4,29 @@ on:
   # Allow this workflow to be reused by other workflows:
   workflow_call:
     inputs:
-      runner:
-        description: 'JSON-encoded list of runner labels'
-        default: '["self-hosted"]'
+      runners:
+        description: 'JSON-encoded map of nix system to a list of runner labels'
+        default: | # json
+          {
+            "x86_64-linux": [
+              "self-hosted",
+              "nixos",
+              "x86-64-v3",
+              "bare-metal"
+            ],
+            "aarch64-darwin": [
+              "self-hosted",
+              "macOS",
+              "aarch64-darwin"
+            ]
+          }
         required: false
         type: string
       run-cachix-deploy:
         description: 'Deploy to cachix'
-        type: 'boolean'
         default: false
         required: false
+        type: 'boolean'
     secrets:
       CACHIX_AUTH_TOKEN:
         description: 'Cachix auth token'
@@ -31,7 +44,7 @@ on:
 jobs:
   compute-mcl-ref:
     name: Compute MCL Reference
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
     outputs:
       workflow_sha: ${{ steps.compute.outputs.workflow_sha }}
       mcl_flake_cmd: ${{ steps.compute.outputs.mcl_flake_cmd }}
@@ -59,7 +72,7 @@ jobs:
           echo "mcl_flake_cmd=nix run --accept-flake-config github:metacraft-labs/nixos-modules/${WORKFLOW_SHA}#mcl" >> $GITHUB_OUTPUT
 
   post-initial-comment:
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
     steps:
       - name: 'Post initial package status comment'
         uses: marocchino/sticky-pull-request-comment@v2.9.4
@@ -72,7 +85,7 @@ jobs:
 
   shard-matrix:
     needs: compute-mcl-ref
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
     steps:
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
@@ -93,6 +106,7 @@ jobs:
         env:
           CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} shard-matrix
 
       - name: Post CI matrix comment
@@ -109,7 +123,7 @@ jobs:
 
   eval-matrix:
     needs: [compute-mcl-ref, shard-matrix]
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
     if: needs.shard-matrix.outputs.eval_matrix
     strategy:
       matrix: ${{fromJSON(needs.shard-matrix.outputs.eval_matrix)}}
@@ -139,7 +153,7 @@ jobs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
 
   merge-matrices:
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
     needs: [compute-mcl-ref, shard-matrix, eval-matrix]
     name: Merge matrices
     outputs:
@@ -216,7 +230,7 @@ jobs:
           cachix push ${{ vars.CACHIX_CACHE }} ${{ matrix.output }}
 
   results:
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
     name: Final Results
     needs: [compute-mcl-ref, build, shard-matrix, merge-matrices]
     if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ result-*
 comment.md
 matrix-*.json
 shardMatrix.json
+precalc-matrix.json
 
 .vscode
 

--- a/packages/mcl/default.nix
+++ b/packages/mcl/default.nix
@@ -38,7 +38,7 @@ let
     lib.concatStringsSep "|" [
       "(nix\\.(build|run|eval))"
       "fetchJson|(coda\.)"
-      "isPackageCached"
+      "isCached"
       "generateShardMatrix"
     ]
   );

--- a/packages/mcl/src/mcl/commands/ci.d
+++ b/packages/mcl/src/mcl/commands/ci.d
@@ -11,7 +11,7 @@ import std.stdio : writefln, writeln, write;
 
 import argparse : Command, Description;
 
-import mcl.commands.ci_matrix: nixEvalJobs, SupportedSystem, CiMatrixBaseArgs;
+import mcl.commands.ci_matrix: nixEvalJobs, NixSystem, CiMatrixBaseArgs;
 import mcl.commands.shard_matrix: generateShardMatrix;
 import mcl.utils.path : rootDir, createResultDirs;
 import mcl.utils.process : execute, spawnProcessInline;

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -335,7 +335,7 @@ Package[] checkCacheStatus(T)(Package[] packages, auto ref T args)
         if (packages[idx].cachedAt.empty)
         {
             packages[idx].cachedAt ~= args.binaryCacheUrls
-                .filter!(url => isPackageCached(packages[idx], url, cachixAuthHeaders))
+                .filter!(url => isCached(packages[idx], url, cachixAuthHeaders))
                 .map!(url => packages[idx].getNarInfoUrl(url))
                 .array;
         }
@@ -865,7 +865,7 @@ void printTableForCacheStatus(T)(Package[] packages, auto ref T args)
     outputPath.append(fullMatrixLine);
 }
 
-bool isPackageCached(in Package pkg, string binaryCacheHttpEndpoint, in string[string] httpHeaders = null)
+bool isCached(in Package pkg, string binaryCacheHttpEndpoint, in string[string] httpHeaders = null)
 {
     import std.algorithm : canFind;
     import std.string : lineSplitter;
@@ -891,7 +891,7 @@ bool isPackageCached(in Package pkg, string binaryCacheHttpEndpoint, in string[s
     }
 }
 
-@("isPackageCached")
+@("isCached")
 unittest
 {
     const nixosCacheEndpoint = "https://cache.nixos.org/";
@@ -902,13 +902,13 @@ unittest
         output: storePath,
     );
 
-    assert(testPackage.isPackageCached(
+    assert(testPackage.isCached(
         binaryCacheHttpEndpoint: nixosCacheEndpoint,
         httpHeaders: string[string].init,
     ));
 
     testPackage.output ~= "non-existant";
-    assert(!testPackage.isPackageCached(
+    assert(!testPackage.isCached(
         binaryCacheHttpEndpoint: nixosCacheEndpoint,
         httpHeaders: string[string].init,
     ));

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -84,7 +84,7 @@ enum GitHubOS
     @StringRepresentation("macos-14") macos14,
 }
 
-enum SupportedSystem
+enum NixSystem
 {
     @StringRepresentation("x86_64-linux") x86_64_linux,
 
@@ -98,18 +98,18 @@ enum SupportedSystem
 version (linux)
 {
     version (X86_64)
-        enum currentSystem = SupportedSystem.x86_64_linux;
+        enum currentSystem = NixSystem.x86_64_linux;
     else version (AArch64)
-        enum currentSystem = SupportedSystem.aarch64_linux;
+        enum currentSystem = NixSystem.aarch64_linux;
     else
         static assert (0, "Unsupported architecture");
 }
 else version (OSX)
 {
     version (X86_64)
-        enum currentSystem = SupportedSystem.x86_64_darwin;
+        enum currentSystem = NixSystem.x86_64_darwin;
     else version (AArch64)
-        enum currentSystem = SupportedSystem.aarch64_darwin;
+        enum currentSystem = NixSystem.aarch64_darwin;
     else
         static assert (0, "Unsupported architecture");
 }
@@ -146,7 +146,7 @@ struct Package
     string attrPath;
     string[] cachedAt = [];
     GitHubOS os;
-    SupportedSystem system;
+    NixSystem system;
     string derivation;
     string output;
 
@@ -163,8 +163,8 @@ struct Package
 version (unittest)
 {
     static immutable Package[] testPackageArray = [
-        Package("testPackage", false, "testPackagePath", ["https://testPackage.com"], GitHubOS.ubuntuLatest, SupportedSystem.x86_64_linux, "testPackageOutput"),
-        Package("testPackage2", true, "testPackagePath2", [], GitHubOS.macos14, SupportedSystem.aarch64_darwin, "testPackageOutput2")
+        Package("testPackage", false, "testPackagePath", ["https://testPackage.com"], GitHubOS.ubuntuLatest, NixSystem.x86_64_linux, "testPackageOutput"),
+        Package("testPackage2", true, "testPackagePath2", [], GitHubOS.macos14, NixSystem.aarch64_darwin, "testPackageOutput2")
     ];
 }
 
@@ -315,7 +315,7 @@ export int print_table(PrintTableArgs args)
     return 0;
 }
 
-string flakeAttr(string prefix, SupportedSystem system, string[] attrs...)
+string flakeAttr(string prefix, NixSystem system, string[] attrs...)
 {
     return [prefix, system.enumToString].chain(attrs).join(".");
 }
@@ -357,17 +357,17 @@ Package[] checkCacheStatus(T)(Package[] packages, auto ref T args)
 
 
 
-GitHubOS systemToGHPlatform(SupportedSystem os)
+GitHubOS systemToGHPlatform(NixSystem os)
 {
-    return os == SupportedSystem.x86_64_linux ? GitHubOS.selfHosted : GitHubOS.macos14;
+    return os == NixSystem.x86_64_linux ? GitHubOS.selfHosted : GitHubOS.macos14;
 }
 
 @("systemToGHPlatform")
 unittest
 {
-    assert(systemToGHPlatform(SupportedSystem.x86_64_linux) == GitHubOS.selfHosted);
-    assert(systemToGHPlatform(SupportedSystem.x86_64_darwin) == GitHubOS.macos14);
-    assert(systemToGHPlatform(SupportedSystem.aarch64_darwin) == GitHubOS.macos14);
+    assert(systemToGHPlatform(NixSystem.x86_64_linux) == GitHubOS.selfHosted);
+    assert(systemToGHPlatform(NixSystem.x86_64_darwin) == GitHubOS.macos14);
+    assert(systemToGHPlatform(NixSystem.aarch64_darwin) == GitHubOS.macos14);
 }
 
 static immutable string[] uselessWarnings =
@@ -395,7 +395,7 @@ Package packageFromNixEvalJobsJson(
     string flakeAttrPath,
 )
 {
-    auto sys = json["system"].fromJSON!SupportedSystem;
+    auto sys = json["system"].fromJSON!NixSystem;
 
     // WARN: The `isCached` property coming from `nix-eval-jobs` is
     //       insufficient as it just says if the package is cached
@@ -444,7 +444,7 @@ unittest
             name: "home/bean-desktop",
             allowedToFail: false,
             attrPath: "legacyPackages.x86_64-linux.mcl.matrix.shards.0.home/bean-desktop",
-            system: SupportedSystem.x86_64_linux,
+            system: NixSystem.x86_64_linux,
             os: GitHubOS.selfHosted,
             derivation: "/nix/store/jp7qgm9mgikksypzljrbhmxa31xmmq1x-home-manager-generation.drv",
             output: "/nix/store/30qrziyj0vbg6n43bbh08ql0xbnsy76d-home-manager-generation",
@@ -539,7 +539,7 @@ Package[] nixEvalJobs(T)(string flakeAttrPath, auto ref T args)
     return result;
 }
 
-SupportedSystem[] getSupportedSystems(string flakeRef = ".")
+NixSystem[] getSupportedSystems(string flakeRef = ".")
 {
     import std.path : isValidPath, absolutePath, buildNormalizedPath;
 
@@ -553,7 +553,7 @@ SupportedSystem[] getSupportedSystems(string flakeRef = ".")
             `builtins.attrNames`
         ]))
         .ifThrown(JSONValue([ currentSystem.enumToString ]))
-        .fromJSON!(SupportedSystem[]);
+        .fromJSON!(NixSystem[]);
 }
 
 Package[] nixEvalForAllSystems(T)(auto ref T args)

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -330,23 +330,23 @@ Package[] checkCacheStatus(T)(Package[] packages, auto ref T args)
         "Authorization": "Bearer " ~ args.cachixAuthToken
     ];
 
-    foreach (idx; packages.length.iota.parallel) {
+    foreach (ref pkg; packages.parallel) {
         // Skip cache check if already has cached URLs
-        if (packages[idx].cachedAt.empty)
+        if (pkg.cachedAt.empty)
         {
-            packages[idx].cachedAt ~= args.binaryCacheUrls
-                .filter!(url => isCached(packages[idx], url, cachixAuthHeaders))
-                .map!(url => packages[idx].getNarInfoUrl(url))
+            pkg.cachedAt ~= args.binaryCacheUrls
+                .filter!(url => pkg.isCached(url, cachixAuthHeaders))
+                .map!(url => pkg.getNarInfoUrl(url))
                 .array;
         }
 
         static struct Output { string ok, name, storePath, cachedAt; }
         writeRecordAsTable(
             Output(
-                ok: !packages[idx].cachedAt.empty ? "✅" : "❌",
-                name: packages[idx].name,
-                storePath: packages[idx].output,
-                cachedAt: packages[idx].cachedAt.join(", "),
+                ok: !pkg.cachedAt.empty ? "✅" : "❌",
+                name: pkg.name,
+                storePath: pkg.output,
+                cachedAt: pkg.cachedAt.join(", "),
             ),
             stderr.lockingTextWriter,
         );

--- a/packages/mcl/src/mcl/commands/deploy_spec.d
+++ b/packages/mcl/src/mcl/commands/deploy_spec.d
@@ -14,7 +14,7 @@ import mcl.utils.cachix : DeploySpec, createMachineDeploySpec;
 import mcl.utils.tui : bold;
 import mcl.utils.json : tryDeserializeFromJsonFile, writeJsonFile;
 
-import mcl.commands.ci_matrix : nixEvalJobs, SupportedSystem,CiMatrixBaseArgs;
+import mcl.commands.ci_matrix : nixEvalJobs, NixSystem,CiMatrixBaseArgs;
 
 
 @(Command("deploy-spec", "deploy_spec")

--- a/packages/mcl/src/mcl/commands/shard_matrix.d
+++ b/packages/mcl/src/mcl/commands/shard_matrix.d
@@ -20,7 +20,7 @@ import mcl.utils.json : toJSON;
 import mcl.utils.nix : nix;
 import mcl.utils.path : createResultDirs, resultDir, rootDir;
 import mcl.utils.string : enumToString, writeRecordAsTable;
-import mcl.commands.ci_matrix : SupportedSystem, currentSystem, ci_matrix, CiMatrixArgs, CiMatrixBaseArgs;
+import mcl.commands.ci_matrix : NixSystem, currentSystem, ci_matrix, CiMatrixArgs, CiMatrixBaseArgs;
 
 @(Command("shard-matrix", "shard_matrix")
     .Description("Generate a shard matrix for a flake"))
@@ -70,7 +70,7 @@ struct ShardMatrix
     Shard[] include;
 }
 
-ShardMatrix generateShardMatrix(string flakeRef = ".", Nullable!SupportedSystem system = Nullable!SupportedSystem.init)
+ShardMatrix generateShardMatrix(string flakeRef = ".", Nullable!NixSystem system = Nullable!NixSystem.init)
 {
     import std.path : isValidPath, absolutePath, buildNormalizedPath;
 
@@ -121,7 +121,7 @@ unittest
     }
 
     {
-        auto shards = generateShardMatrix(flakeRef, nullable(SupportedSystem.x86_64_linux));
+        auto shards = generateShardMatrix(flakeRef, nullable(NixSystem.x86_64_linux));
         assert(shards.include.length == 11);
         assert(shards.include[0] == Shard(flakeAttrPath: "mcl.shard-matrix.result.shardsPerSystem.x86_64_linux.shard-00", filename: "matrix-pre-shard-00.json"));
     }
@@ -129,7 +129,7 @@ unittest
     {
         // `aarch64_linux` is not in `flake.mcl.shard-matrix.systemsToBuild`,
         // so no shards should be generated
-        auto shards = generateShardMatrix(flakeRef, nullable(SupportedSystem.aarch64_linux));
+        auto shards = generateShardMatrix(flakeRef, nullable(NixSystem.aarch64_linux));
         assert(shards.include == []);
     }
 }
@@ -144,7 +144,7 @@ unittest
     assert(shards.include == []);
 }
 
-ShardMatrix splitToShards(int shardCount, Nullable!SupportedSystem system = Nullable!SupportedSystem.init)
+ShardMatrix splitToShards(int shardCount, Nullable!NixSystem system = Nullable!NixSystem.init)
 {
     import core.internal.string : numDigits;
     const padWidth = shardCount.numDigits;

--- a/packages/mcl/src/mcl/commands/shard_matrix.d
+++ b/packages/mcl/src/mcl/commands/shard_matrix.d
@@ -48,6 +48,7 @@ export int shard_matrix(ShardMatrixArgs args)
             extraCacheUrls: args.extraCacheUrls,
             cachixAuthToken: args.cachixAuthToken,
             precalcMatrix: null,
+            nixSystemToGHRunner: args.nixSystemToGHRunner,
             githubOutput: args.githubOutput,
         ));
     }

--- a/packages/mcl/src/mcl/utils/json.d
+++ b/packages/mcl/src/mcl/utils/json.d
@@ -1,6 +1,5 @@
 module mcl.utils.json;
-import mcl.utils.test;
-import mcl.utils.string;
+
 import std.traits: isNumeric, isArray, isSomeChar, EnumMembers, ForeachType, isBoolean, isAssociativeArray;
 import std.json: parseJSON, JSONValue, JSONOptions, JSONType;
 import std.conv: to;
@@ -12,6 +11,9 @@ import std.datetime: SysTime;
 import std.sumtype: SumType, isSumType;
 import std.typecons: Ternary;
 import core.stdc.string: strlen;
+
+import mcl.utils.test;
+import mcl.utils.string: enumToString, enumFromString, StringRepresentation;
 
 bool tryDeserializeJson(T)(in JSONValue value, out T result)
 {
@@ -31,12 +33,7 @@ T fromJSON(T)(in JSONValue value) {
         return value;
     }
     else static if (is(T == enum)) {
-        switch (value.get!string) {
-            static foreach (variant; EnumMembers!T)
-                case variant.enumToString: return variant;
-            default:
-                assert(0, "Expected JSON string, actual: " ~ value.toPrettyString() ~ " while deserializing type " ~ T.stringof);
-        }
+        return value.get!string.enumFromString!T;
     }
     else static if (is(T == bool) || is(T == string) || isSomeChar!T || isNumeric!T) {
         return value.get!T;

--- a/packages/mcl/src/mcl/utils/string.d
+++ b/packages/mcl/src/mcl/utils/string.d
@@ -1,6 +1,5 @@
 module mcl.utils.string;
 
-import mcl.utils.test;
 import std.conv : to;
 import std.exception : assertThrown;
 
@@ -139,6 +138,46 @@ unittest
     assert(enumToString(TestEnumWithRepr.a) == "field1");
     assert(enumToString(TestEnumWithRepr.b) == "field_2");
     assert(enumToString(TestEnumWithRepr.c) == "field-3");
+}
+
+E enumFromString(E)(in string value) if (is(E == enum))
+{
+    import std.traits : EnumMembers;
+
+    switch (value) {
+        static foreach (variant; EnumMembers!E)
+            case variant.enumToString: return variant;
+        default:
+            assert(0, "Expected JSON string, actual: " ~ value ~ " while deserializing type " ~ E.stringof);
+    }
+}
+
+@("enumFromString")
+unittest
+{
+    enum TestEnum
+    {
+        a1,
+        b2,
+        c3
+    }
+
+    assert(enumFromString!TestEnum("a1") == TestEnum.a1);
+    assert(enumFromString!TestEnum("b2") == TestEnum.b2);
+    assert(enumFromString!TestEnum("c3") == TestEnum.c3);
+
+    enum TestEnumWithRepr
+    {
+        @StringRepresentation("field1") a,
+        @StringRepresentation("field_2") b,
+        @StringRepresentation("field-3") c
+    }
+
+    assert(enumFromString!TestEnumWithRepr("field1") == TestEnumWithRepr.a);
+    assert(enumFromString!TestEnumWithRepr("field_2") == TestEnumWithRepr.b);
+    assert(enumFromString!TestEnumWithRepr("field-3") == TestEnumWithRepr.c);
+
+    assertThrown!Error(enumFromString!TestEnum("invalid"));
 }
 
 enum size_t getMaxEnumMemberNameLength(E) = ()

--- a/packages/mcl/src/mcl/utils/test/nix/shard-matrix-ok/flake.lock
+++ b/packages/mcl/src/mcl/utils/test/nix/shard-matrix-ok/flake.lock
@@ -860,7 +860,7 @@
       "inputs": {
         "nixpkgs": [
           "nixos-modules",
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {

--- a/packages/mcl/src/mcl/utils/tui.d
+++ b/packages/mcl/src/mcl/utils/tui.d
@@ -1,3 +1,12 @@
 module mcl.utils.tui;
 
 string bold(const char[] s) => cast(string)("\033[1m" ~ s ~ "\033[0m");
+
+bool supportsOscLinks()
+{
+    import std.process : environment;
+    import core.sys.posix.unistd : isatty;
+    import core.stdc.stdio : fileno, stderr;
+
+    return !("CI" in environment) && isatty(fileno(stderr)) != 0;
+}


### PR DESCRIPTION
This pull request refactors the CI matrix infrastructure to support a more flexible mapping between Nix systems and GitHub runner labels, replacing the previous approach that used a single list of runner labels. The changes propagate this new mapping through workflow YAML files and the D codebase, simplifying and generalizing system/runner handling in both the workflows and the supporting scripts.

**CI Workflow and System/Runner Mapping Refactor:**

* Updated `.github/workflows/ci.yml` and `.github/workflows/reusable-flake-checks-ci-matrix.yml` to accept a JSON-encoded map of Nix systems to lists of runner labels (instead of a flat list), and refactored all references from `runner` to `runners` accordingly. This allows specifying different runners for each system type. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL62-R75) [[2]](diffhunk://#diff-f22cabc6c55a3bebe93a18e3b8355f4fd3ee94a53733736c6984fd107086a818L7-R29) [[3]](diffhunk://#diff-f22cabc6c55a3bebe93a18e3b8355f4fd3ee94a53733736c6984fd107086a818L34-R47) [[4]](diffhunk://#diff-f22cabc6c55a3bebe93a18e3b8355f4fd3ee94a53733736c6984fd107086a818L62-R75) [[5]](diffhunk://#diff-f22cabc6c55a3bebe93a18e3b8355f4fd3ee94a53733736c6984fd107086a818L75-R88) [[6]](diffhunk://#diff-f22cabc6c55a3bebe93a18e3b8355f4fd3ee94a53733736c6984fd107086a818R109) [[7]](diffhunk://#diff-f22cabc6c55a3bebe93a18e3b8355f4fd3ee94a53733736c6984fd107086a818L112-R126) [[8]](diffhunk://#diff-f22cabc6c55a3bebe93a18e3b8355f4fd3ee94a53733736c6984fd107086a818L142-R156) [[9]](diffhunk://#diff-f22cabc6c55a3bebe93a18e3b8355f4fd3ee94a53733736c6984fd107086a818L219-R233)

**D Codebase Modernization and Cleanup:**

* Replaced the `SupportedSystem` and `GitHubOS` enums with a single `NixSystem` enum and a new `NixSystemToGHRunner` struct, enabling direct mapping from Nix system to runner labels. Removed now-unnecessary conversion functions and related unittests. [[1]](diffhunk://#diff-67d729742e293d6977233c7c97cbaf337f8467e00df984270cc567d148b39656L14-R14) [[2]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7L79-R93) [[3]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7L101-R132) [[4]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7L190-R150) [[5]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7R189-R196) [[6]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7L342-R312) [[7]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7R392-R406) [[8]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7R439-R448) [[9]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7L527-L546) [[10]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7L564-R542)

* Updated all usages of system/runner information in struct definitions, function signatures, and logic to use the new mapping, including test code and argument parsing. [[1]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7L22-R22) [[2]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7R263-R269)

**Miscellaneous Improvements:**

* Improved cache status output formatting, including support for OSC 8 hyperlinks in terminals that support them, and updated output table columns to reflect the new runner mapping. [[1]](diffhunk://#diff-fc0028e5ffcc7533d70054aaebd90808a69ac2f6c9c871ed67522d21608403f3L41-R41) [[2]](diffhunk://#diff-9e54e29b32c8e041595226ab4eb41eee223c0969c1e717980c62d2f160e1e8f7R322-L396)

These changes together make the CI matrix system more robust and extensible, especially for supporting multiple platforms with different runner requirements.
