### PR TITLE
feat(mcl.commands): Add `hosts` command for SSH scanning and remote execution

### DIFF
--- a/packages/mcl/src/mcl/commands/hosts.d
+++ b/packages/mcl/src/mcl/commands/hosts.d
@@ -1,0 +1,731 @@
+module mcl.commands.hosts;
+
+import core.time : Duration, seconds;
+import std.algorithm : filter, map;
+import std.array : array, join;
+import std.conv : to;
+import std.file : exists, readText;
+import std.format : format;
+import std.json : JSONValue, parseJSON, JSONType;
+import std.range : empty, iota, repeat, zip;
+import std.stdio : stdout, writef, writeln, writefln, stderr;
+import std.string : split, strip, startsWith, endsWith;
+
+import argparse : Command, Description, SubCommand, Default, PositionalArgument,
+    Placeholder, Optional, matchCmd, NamedArgument, Required, Parse, MutuallyExclusive;
+
+import mcl.utils.json : fromJSON, toJSON;
+import mcl.utils.log : errorAndExit;
+import mcl.utils.process : execute;
+
+// =============================================================================
+// Public Types
+// =============================================================================
+
+struct HostEntry
+{
+    string ipv4;
+    string description;
+    string user;
+    ushort port;
+
+    string toString() const
+    {
+        return description.length > 0 ? ipv4 ~ " (" ~ description ~ ")" : ipv4;
+    }
+
+    HostEntry withDefaults(string defaultUser, ushort defaultPort) const
+    {
+        return HostEntry(
+            ipv4,
+            description,
+            user.length > 0 ? user : defaultUser,
+            port > 0 ? port : defaultPort,
+        );
+    }
+}
+
+// =============================================================================
+// CLI Argument Definitions
+// =============================================================================
+
+@(Command("hosts", "host")
+    .Description("Manage remote hosts"))
+struct HostsArgs
+{
+    SubCommand!(
+        ScanArgs,
+        ExecuteArgs,
+        Default!UnknownCommandArgs
+    ) cmd;
+}
+
+@(Command("scan")
+    .Description("Scan a network for hosts with SSH service running"))
+struct ScanArgs
+{
+    @(NamedArgument(["network", "n"])
+        .Required()
+        .Placeholder("NETWORK-PREFIX")
+        .Description("IPv4 network prefix (e.g., 192.168.1)"))
+    string network;
+
+    @(NamedArgument(["start", "s"])
+        .Placeholder("NUM")
+        .Description("Start of host range (default: 1)"))
+    ubyte start = 1;
+
+    @(NamedArgument(["end", "e"])
+        .Placeholder("NUM")
+        .Description("End of host range (default: 254)"))
+    ubyte end = 254;
+
+    @(NamedArgument(["port", "p"])
+        .Placeholder("PORT")
+        .Description("SSH port to scan (default: 22)"))
+    ushort port = 22;
+
+    @(NamedArgument(["timeout", "t"])
+        .Placeholder("SECONDS")
+        .Description("Connection timeout in seconds (default: 5)")
+        .Parse((string s) => s.to!ushort.seconds))
+    Duration timeout = 5.seconds;
+
+    @(NamedArgument(["parallel", "P"])
+        .Placeholder("COUNT")
+        .Description("Number of parallel connections (default: 16)"))
+    ushort parallel = 16;
+
+    @(NamedArgument(["ssh-user", "u"])
+        .Placeholder("USER")
+        .Description("SSH user for fetching hostnames (default: root)"))
+    string sshUser = "root";
+
+    @(NamedArgument(["save-keys"])
+        .Placeholder("FILE")
+        .Description("Save SSH public keys to file"))
+    string saveKeysFile;
+
+    @(NamedArgument(["output", "o"])
+        .Placeholder("FILE")
+        .Description("Output file path for results (JSON format)"))
+    string outputFile;
+
+    @(NamedArgument(["suppress-warnings", "q"])
+        .Description("Suppress SSH warnings (e.g., post-quantum key exchange)"))
+    bool suppressWarnings = false;
+}
+
+@(Command("execute")
+    .Description("Execute a command on multiple hosts"))
+struct ExecuteArgs
+{
+    @(NamedArgument(["command", "c"])
+        .Required()
+        .Placeholder("COMMAND")
+        .Description("Command to execute on each host"))
+    string command;
+
+    @(MutuallyExclusive.Required)
+    {
+        @(NamedArgument(["hosts-file", "f"])
+            .Placeholder("FILE")
+            .Description("Path to JSON or CSV file with hosts (columns: ipv4, description)"))
+        string hostsFile;
+
+        @(NamedArgument(["scan", "s"])
+            .Placeholder("NETWORK-ID")
+            .Description("Scan this network for hosts instead of using a file"))
+        string scanNetwork;
+    }
+
+    @(NamedArgument(["port", "p"])
+        .Placeholder("PORT")
+        .Description("SSH port (default: 22)"))
+    ushort port = 22;
+
+    @(NamedArgument(["ssh-user", "u"])
+        .Placeholder("USER")
+        .Description("SSH user (default: root)"))
+    string sshUser = "root";
+
+    @(NamedArgument(["parallel", "P"])
+        .Placeholder("COUNT")
+        .Description("Number of parallel connections (default: 1)"))
+    ushort parallel = 1;
+
+    @(NamedArgument(["timeout", "t"])
+        .Placeholder("SECONDS")
+        .Description("SSH connection timeout in seconds (default: 30)")
+        .Parse((string s) => s.to!ushort.seconds))
+    Duration timeout = 30.seconds;
+
+    @(NamedArgument(["continue-on-error"])
+        .Description("Continue executing on other hosts if one fails"))
+    bool continueOnError = false;
+
+    @(NamedArgument(["output-dir", "o"])
+        .Placeholder("DIR")
+        .Description("Save output of each host to a separate file in this directory"))
+    string outputDir;
+
+    @(NamedArgument(["file-extension", "e"])
+        .Placeholder("EXT")
+        .Description("File extension for output files (default: txt, requires --output-dir)"))
+    string fileExtension = "txt";
+
+    @(NamedArgument(["suppress-warnings", "q"])
+        .Description("Suppress SSH warnings (e.g., post-quantum key exchange)"))
+    bool suppressWarnings = false;
+}
+
+@(Command(" ").Description(" "))
+struct UnknownCommandArgs { }
+
+// =============================================================================
+// Main Entry Point
+// =============================================================================
+
+/// Main entry point for the hosts command (also aliased as 'host')
+export int hosts(HostsArgs args)
+{
+    return args.cmd.matchCmd!(
+        (ScanArgs a) => scan(a),
+        (ExecuteArgs a) => executeOnHosts(a),
+        (UnknownCommandArgs a) => unknownCommand(a)
+    );
+}
+
+// =============================================================================
+// Command Handlers
+// =============================================================================
+
+/// Scan a network for hosts with SSH service running
+int scan(ScanArgs args)
+{
+    import std.parallelism : defaultPoolThreads;
+
+    if (args.start > args.end)
+    {
+        errorAndExit(format!"Invalid range: start (%s) must be <= end (%s)"(args.start, args.end));
+        return 1;
+    }
+
+    defaultPoolThreads = args.parallel;
+
+    writefln("=== Pass 1: Port scanning %s.[%s-%s] on port %s (parallel: %s) ===\n",
+        args.network, args.start, args.end, args.port, args.parallel);
+
+    // Pass 1: Parallel port scan to find hosts with SSH
+    auto hosts = scanNetworkRange(
+        networkPrefix: args.network,
+        start: args.start,
+        end: args.end,
+        port: args.port,
+        timeout: args.timeout,
+    );
+
+    if (hosts.empty)
+    {
+        writeln("\nNo hosts with SSH service found.");
+        return 0;
+    }
+
+    writefln("\n=== Found %d host(s) with SSH service ===\n", hosts.length);
+
+    // Apply CLI defaults to hosts
+    hosts = hosts.map!(h => h.withDefaults(args.sshUser, args.port)).array;
+
+    // Pass 2: Parallel hostname fetching (always done to get actual hostnames)
+    writefln("=== Pass 2: Fetching hostnames via SSH (parallel: %s) ===\n", args.parallel);
+    hosts = fetchHostnamesParallel(hosts, SshOptions(
+        command: "hostname",
+        timeout: args.timeout,
+        suppressWarnings: args.suppressWarnings,
+        acceptNewKeys: false,
+    ));
+
+    // Pass 3: Parallel SSH key collection (if requested)
+    if (args.saveKeysFile.length > 0)
+    {
+        writefln("\n=== Pass 3: Saving SSH keys to %s (parallel: %s) ===\n", args.saveKeysFile, args.parallel);
+        saveHostKeysParallel(hosts, filename: args.saveKeysFile);
+    }
+
+    writeln("\n=== Results ===\n");
+    foreach (host; hosts)
+    {
+        writefln("  %s", host);
+    }
+
+    if (args.outputFile.length > 0)
+    {
+        import std.file : write;
+        import std.json : JSONOptions;
+
+        auto json = hosts.toJSON;
+        write(args.outputFile, json.toPrettyString(JSONOptions.doNotEscapeSlashes));
+        writefln("\nResults saved to: %s", args.outputFile);
+    }
+
+    return 0;
+}
+
+/// Execute a command on multiple hosts
+int executeOnHosts(ExecuteArgs args)
+{
+    import std.parallelism : defaultPoolThreads;
+
+    defaultPoolThreads = args.parallel;
+
+    HostEntry[] hosts;
+
+    if (args.scanNetwork.length > 0)
+    {
+        writefln("Scanning network %s.[1-254] for hosts...", args.scanNetwork);
+        hosts = scanNetworkRange(
+            networkPrefix: args.scanNetwork,
+            start: 1,
+            end: 254,
+            port: args.port,
+            timeout: args.timeout,
+        );
+
+        if (hosts.empty)
+        {
+            errorAndExit("No hosts found on the network.");
+            return 1;
+        }
+
+        writefln("Found %d host(s).\n", hosts.length);
+    }
+    else
+    {
+        hosts = loadHostsFromFile(args.hostsFile);
+
+        if (hosts.empty)
+        {
+            errorAndExit("No hosts found in the file.");
+            return 1;
+        }
+
+        writefln("Loaded %d host(s) from file.\n", hosts.length);
+    }
+
+    // Apply CLI defaults to hosts
+    hosts = hosts.map!(h => h.withDefaults(args.sshUser, args.port)).array;
+
+    return executeCommandOnHosts(
+        hosts,
+        SshOptions(
+            command: args.command,
+            timeout: args.timeout,
+            suppressWarnings: args.suppressWarnings,
+            acceptNewKeys: true,
+        ),
+        continueOnError: args.continueOnError,
+        useParallel: args.parallel > 1,
+        outputDir: args.outputDir,
+        fileExtension: args.fileExtension,
+    );
+}
+
+int unknownCommand(UnknownCommandArgs)
+{
+    errorAndExit("Unknown command. Use --help for a list of available commands.");
+    return 1;
+}
+
+// =============================================================================
+// Implementation Details - File Loading
+// =============================================================================
+
+/// Load hosts from a JSON or CSV file
+private HostEntry[] loadHostsFromFile(string filePath)
+{
+    import std.csv : csvReader;
+
+    if (!exists(filePath))
+    {
+        errorAndExit("File not found: " ~ filePath);
+        return [];
+    }
+
+    string content = readText(filePath).strip();
+
+    if (content.length == 0)
+    {
+        errorAndExit("File is empty: " ~ filePath);
+        return [];
+    }
+
+    // Detect file format based on extension or content
+    if (filePath.endsWith(".json") || content.startsWith("["))
+    {
+        return parseJSON(content).fromJSON!(HostEntry[]);
+    }
+    else
+    {
+        return csvReader!HostEntry(content, null).array;
+    }
+}
+
+// =============================================================================
+// Implementation Details - Network Scanning
+// =============================================================================
+
+private struct SshProbeResult
+{
+    string ip;
+    bool success;
+}
+
+/// Scan a network range for SSH hosts using pure D sockets (parallelized)
+private HostEntry[] scanNetworkRange(string networkPrefix, ubyte start, ubyte end,
+    ushort port, Duration timeout)
+{
+    import std.parallelism : parallel;
+
+    // Generate list of IPs to scan
+    auto ips = iota(start, end + 1)
+        .map!(i => format!"%s.%d"(networkPrefix, i));
+
+    writefln("Probing %d hosts...", ips.length);
+    auto results = new SshProbeResult[](ips.length);
+    shared size_t completed = 0;
+
+    foreach (idx, ip; parallel(ips, 1))
+    {
+        results[idx] = probeSshPort(ip, port, timeout);
+        updateProgress(completed, ips.length, "hosts checked");
+    }
+
+    writeln();
+
+    // Collect successful results (description is empty, will be filled by hostname fetch)
+    return results
+        .filter!(r => r.success)
+        .map!(r => HostEntry(r.ip, ""))
+        .array;
+}
+
+/// Probe a single host for SSH service using pure D sockets
+private SshProbeResult probeSshPort(string ip, ushort port, Duration timeout)
+{
+    import std.socket : TcpSocket, InternetAddress, SocketOption, SocketOptionLevel;
+
+    SshProbeResult result;
+    result.ip = ip;
+    result.success = false;
+
+    TcpSocket socket;
+    try
+    {
+        socket = new TcpSocket();
+        scope(exit) {
+            if (socket !is null)
+                socket.close();
+        }
+
+        // Set socket timeout
+        socket.setOption(SocketOptionLevel.SOCKET, SocketOption.SNDTIMEO, timeout);
+        socket.setOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, timeout);
+
+        // Attempt connection
+        auto addr = new InternetAddress(ip, port);
+        socket.connect(addr);
+
+        // Try to read SSH banner (SSH servers send version string on connect)
+        char[256] buffer;
+        auto received = socket.receive(buffer[]);
+
+        if (received > 0)
+        {
+            // Verify it's actually SSH (banner starts with "SSH-")
+            result.success = buffer[0 .. received].startsWith("SSH-");
+        }
+    }
+    catch (Exception e)
+    {
+        // Connection failed or timed out
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Implementation Details - SSH Operations
+// =============================================================================
+
+/// Build complete SSH command arguments including the remote command
+private string[] buildSshArgs(HostEntry host, SshOptions opts)
+{
+    return [
+        "ssh",
+        "-o", "ConnectTimeout=" ~ opts.timeout.total!"seconds".to!string,
+    ] ~ (opts.acceptNewKeys
+        ? ["-o", "StrictHostKeyChecking=accept-new"]
+        : ["-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no"]
+    ) ~ (opts.suppressWarnings
+        ? ["-o", "LogLevel=ERROR"]
+        : []
+    ) ~ [
+        "-o", "BatchMode=yes",
+        "-p", host.port.to!string,
+        host.user ~ "@" ~ host.ipv4,
+        opts.command,
+    ];
+}
+
+/// Fetch hostnames for a list of hosts (parallel)
+private HostEntry[] fetchHostnamesParallel(HostEntry[] hosts, SshOptions opts)
+{
+    import std.parallelism : parallel;
+    auto results = new SshCommandResult[](hosts.length);
+    shared size_t completed = 0;
+
+    foreach (idx, host; parallel(hosts))
+    {
+        results[idx] = executeSshCommand(host, opts, suppressOutput: true);
+        updateProgress(completed, hosts.length, "hostnames fetched");
+    }
+
+    writeln();
+
+    // Build result with hostnames as description
+    return zip(hosts, results)
+        .map!(pair => HostEntry(pair[0].ipv4, pair[1].success ? pair[1].output : "", pair[0].user, pair[0].port))
+        .array;
+}
+
+/// Save SSH public keys to a file (parallel)
+private void saveHostKeysParallel(HostEntry[] hosts, string filename)
+{
+    import std.file : append;
+    import std.parallelism : parallel;
+
+    // Collect keys in parallel
+    auto allKeys = new string[](hosts.length);
+    shared size_t completed = 0;
+
+    foreach (idx, host; parallel(hosts))
+    {
+        try
+        {
+            allKeys[idx] = execute(["ssh-keyscan", "-p", host.port.to!string, "-4", host.ipv4], printCommand: false, logErrors: false);
+        }
+        catch (Exception e)
+        {
+            allKeys[idx] = "";
+        }
+
+        updateProgress(completed, hosts.length, "keys collected");
+    }
+
+    writeln();
+
+    // Write all non-empty keys to file
+    foreach (keys; allKeys.filter!(k => k.length > 0))
+    {
+        append(filename, keys ~ "\n");
+    }
+}
+
+/// Execute a command on a list of hosts via SSH
+private int executeCommandOnHosts(HostEntry[] hosts, SshOptions opts, bool continueOnError, bool useParallel, string outputDir, string fileExtension)
+{
+    import std.parallelism : parallel;
+    import core.atomic : atomicOp;
+
+    // In parallel mode with stop-on-error, fall back to sequential to ensure proper stopping
+    if (useParallel && !continueOnError)
+    {
+        stderr.writeln("Note: --continue-on-error=false requires sequential execution. Using --parallel=1.");
+        useParallel = false;
+    }
+
+    // Create output directory if specified
+    if (outputDir.length > 0 && !exists(outputDir))
+    {
+        import std.file : mkdirRecurse;
+        mkdirRecurse(outputDir);
+    }
+
+    int failureCount = 0;
+    int successCount = 0;
+
+    writefln("Executing command on %d host(s)...\n", hosts.length);
+    writefln("Command: %s\n", opts.command);
+    writeln("─".repeat(60).join);
+
+    SshCommandResult[] failures;
+
+    if (useParallel)
+    {
+        // Parallel execution with progress indicator
+        auto results = new SshCommandResult[](hosts.length);
+        shared size_t completed = 0;
+
+        foreach (idx, host; parallel(hosts))
+        {
+            results[idx] = executeSshCommand(host, opts, suppressOutput: true);
+            if (results[idx].success && outputDir.length > 0)
+                saveHostOutput(outputDir, results[idx].host, results[idx].output, fileExtension);
+            updateProgress(completed, hosts.length, "hosts completed");
+        }
+
+        writeln();
+
+        // Collect results
+        foreach (result; results)
+        {
+            if (result.success)
+                successCount++;
+            else
+                failures ~= result;
+        }
+        failureCount = cast(int) failures.length;
+    }
+    else
+    {
+        // Sequential execution
+        foreach (host; hosts)
+        {
+            auto result = executeSshCommand(host, opts, suppressOutput: false);
+
+            if (result.success)
+            {
+                successCount++;
+                if (outputDir.length > 0)
+                    saveHostOutput(outputDir, result.host, result.output, fileExtension);
+            }
+            else
+            {
+                failureCount++;
+                failures ~= result;
+                if (!continueOnError)
+                {
+                    writeln("\nStopping due to error. Use --continue-on-error to continue.");
+                    return 1;
+                }
+            }
+        }
+    }
+
+    writeln("─".repeat(60).join);
+    writefln("\nSummary: %d succeeded, %d failed out of %d total", successCount, failureCount, hosts.length);
+
+    // Print failed hosts with error output
+    if (failures.length > 0)
+    {
+        import std.process : escapeShellCommand;
+
+        writeln("\nFailed hosts:\n");
+        foreach (failure; failures)
+        {
+            writefln("[%s]", failure.host);
+            writefln("  $ %s", escapeShellCommand(failure.sshArgs));
+            if (failure.output.length > 0)
+            {
+                // Indent each line of the error output
+                foreach (line; failure.output.split("\n"))
+                {
+                    writefln("  %s", line);
+                }
+            }
+            writeln();
+        }
+    }
+
+    if (outputDir.length > 0)
+        writefln("Output saved to: %s/", outputDir);
+
+    return failureCount > 0 ? 1 : 0;
+}
+
+/// Save command output for a host to a file
+private void saveHostOutput(string outputDir, HostEntry host, string output, string fileExtension)
+{
+    import std.file : write;
+    import std.path : buildPath;
+
+    auto filename = host.description.length > 0
+        ? host.ipv4 ~ "_" ~ host.description ~ "." ~ fileExtension
+        : host.ipv4 ~ "." ~ fileExtension;
+
+    write(buildPath(outputDir, filename), output);
+}
+
+private struct SshOptions
+{
+    string command;
+    Duration timeout;
+    bool suppressWarnings;  // suppress SSH warnings (LogLevel=ERROR)
+    bool acceptNewKeys;     // use StrictHostKeyChecking=accept-new (safer for commands)
+}
+
+private struct SshCommandResult
+{
+    bool success;
+    string output;
+    HostEntry host;
+    string[] sshArgs;
+}
+
+/// Execute a single SSH command on a host
+private SshCommandResult executeSshCommand(HostEntry host, SshOptions opts, bool suppressOutput = false)
+{
+    import std.process : pipeProcess, wait, Redirect;
+
+    if (!suppressOutput)
+        writefln("\n[%s]", host);
+
+    auto args = buildSshArgs(host, opts);
+
+    try
+    {
+        auto pipes = pipeProcess(args, Redirect.stdout | Redirect.stderr);
+        auto status = wait(pipes.pid);
+
+        string stdout = pipes.stdout.byLine().join("\n").to!string;
+        string stderr = pipes.stderr.byLine().join("\n").to!string;
+
+        if (status != 0)
+        {
+            if (!suppressOutput)
+                writefln("  [FAILED]");
+            return SshCommandResult(false, stderr.length > 0 ? stderr : stdout, host, args);
+        }
+
+        if (!suppressOutput)
+        {
+            if (stdout.length > 0)
+                writeln(stdout);
+            writeln("  [OK]");
+        }
+        return SshCommandResult(true, stdout, host, args);
+    }
+    catch (Exception e)
+    {
+        if (!suppressOutput)
+            writefln("  [FAILED]");
+        return SshCommandResult(false, e.msg, host, args);
+    }
+}
+
+// =============================================================================
+// Implementation Details - Helpers
+// =============================================================================
+
+/// Thread-safe progress update helper
+private void updateProgress(ref shared size_t completed, size_t total, string action)
+{
+    import core.atomic : atomicOp;
+
+    auto current = atomicOp!"+="(completed, 1);
+    synchronized
+    {
+        writef("\rProgress: %d/%d %s", current, total, action);
+        stdout.flush();
+    }
+}

--- a/packages/mcl/src/mcl/commands/package.d
+++ b/packages/mcl/src/mcl/commands/package.d
@@ -11,6 +11,7 @@ private enum commandModulesToExport =
     "mcl.commands.host_info" : ["host_info"],
     "mcl.commands.machine" : ["machine"],
     "mcl.commands.config" : ["config"],
+    "mcl.commands.hosts" : ["hosts"],
 ];
 
 template ImportAll(alias aa)

--- a/packages/mcl/src/mcl/utils/process.d
+++ b/packages/mcl/src/mcl/utils/process.d
@@ -15,7 +15,7 @@ T execute(T = string)(string args, bool printCommand = true, bool returnErr = fa
 {
     return execute!T(args.strip.split(" "), printCommand, returnErr, redirect);
 }
-T execute(T = string)(string[] args, bool printCommand = true, bool returnErr = false, Redirect redirect = Redirect.all, bool throwOnError = false) if (is(T == string) || is(T == ProcessPipes) || is(T == JSONValue))
+T execute(T = string)(string[] args, bool printCommand = true, bool returnErr = false, Redirect redirect = Redirect.all, bool throwOnError = false, bool logErrors = true) if (is(T == string) || is(T == ProcessPipes) || is(T == JSONValue))
 {
     import std.exception : enforce;
     import std.format : format;
@@ -46,12 +46,13 @@ T execute(T = string)(string[] args, bool printCommand = true, bool returnErr = 
 
         if (status != 0)
         {
-            errorf("Command failed:
-            ---
-            $ `%s`
-            stdout: `%s`
-            stderr: `%s`
-            ---", cmd.bold, stdout.bold, stderr.bold);
+            if (logErrors)
+                errorf("Command failed:
+                ---
+                $ `%s`
+                stdout: `%s`
+                stderr: `%s`
+                ---", cmd.bold, stdout.bold, stderr.bold);
             if (throwOnError)
                 enforce(0, "Process failed.");
         }

--- a/packages/mcl/src/mcl/utils/test/nix/shard-matrix-ok/flake.lock
+++ b/packages/mcl/src/mcl/utils/test/nix/shard-matrix-ok/flake.lock
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765277049,
-        "narHash": "sha256-+YzMHttYelF/L0HFc5tJrcRpABF/XMIgFYamTgpETs4=",
+        "lastModified": 1767714506,
+        "narHash": "sha256-WaTs0t1CxhgxbIuvQ97OFhDTVUGd1HA+KzLZUZBhe0s=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "8f31379263a615507fa86944149c1ceb5d7092c8",
+        "rev": "894c649f0daaa38bbcfb21de64be47dfa7cd0ec9",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1765145449,
-        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
+        "lastModified": 1767744144,
+        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
+        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
         "type": "github"
       },
       "original": {
@@ -100,17 +100,18 @@
           "git-hooks-nix"
         ],
         "nix": "nix",
+        "nixd": "nixd",
         "nixpkgs": [
           "nixos-modules",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1765320738,
-        "narHash": "sha256-tYYtF9NRZRzVHJpism+Tv4E5/dVJZ92ECCKz1hF1BMA=",
+        "lastModified": 1768056019,
+        "narHash": "sha256-EsRLowiEQPhdAXbOw8W4sDwQ+XJDxIaH1L+Nzcd1Tjs=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "43682032927f3f5cfa5af539634985aba5c3fee3",
+        "rev": "9bfc4a64c3a798ed8fa6cee3a519a9eac5e73cb5",
         "type": "github"
       },
       "original": {
@@ -148,11 +149,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765326679,
-        "narHash": "sha256-fTLX9kDwLr9Y0rH/nG+h1XG5UU+jBcy0PFYn5eneRX8=",
+        "lastModified": 1766150702,
+        "narHash": "sha256-P0kM+5o+DKnB6raXgFEk3azw8Wqg5FL6wyl9jD+G5a4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d64e5cdca35b5fad7c504f615357a7afe6d9c49e",
+        "rev": "916506443ecd0d0b4a0f4cf9d40a3c22ce39b378",
         "type": "github"
       },
       "original": {
@@ -252,11 +253,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1765252472,
-        "narHash": "sha256-byMt/uMi7DJ8tRniFopDFZMO3leSjGp6GS4zWOFT+uQ=",
+        "lastModified": 1768027312,
+        "narHash": "sha256-MW85tjeLZHPB1y0bQaBat/4vtDVaSot2nSWre2rj9nU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8456b985f6652e3eef0632ee9992b439735c5544",
+        "rev": "334c4b4a8a2554b8dd19df8932d43345232f7f84",
         "type": "github"
       },
       "original": {
@@ -268,11 +269,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1765121682,
-        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -305,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763759067,
-        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
         "type": "github"
       },
       "original": {
@@ -319,6 +320,21 @@
       }
     },
     "flake-root": {
+      "locked": {
+        "lastModified": 1723604017,
+        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "flake-root_2": {
       "locked": {
         "lastModified": 1723604017,
         "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
@@ -394,24 +410,6 @@
       }
     },
     "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
@@ -467,11 +465,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765404074,
-        "narHash": "sha256-+ZDU2d+vzWkEJiqprvV5PR26DVFN2vgddwG5SnPZcUM=",
+        "lastModified": 1767281941,
+        "narHash": "sha256-6MkqajPICgugsuZ92OMoQcgSHnD6sJHwk8AxvMcIgTE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "2d6f58930fbcd82f6f9fd59fb6d13e37684ca529",
+        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
         "type": "github"
       },
       "original": {
@@ -514,11 +512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763182882,
-        "narHash": "sha256-jZi+9yKmeTMsJ4ZNqRei/wL16+QwYGrCl4EJ3QHfoDU=",
+        "lastModified": 1765774562,
+        "narHash": "sha256-UQhfCggNGDc7eam+EittlYmeW89CZVT1KkFIHZWBH7k=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "b0585849abe7d02a774a853f7952d07bb910fd9e",
+        "rev": "edcbb19948b6caf1700434e369fde6ff9e6a3c93",
         "type": "github"
       },
       "original": {
@@ -535,11 +533,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765384171,
-        "narHash": "sha256-FuFtkJrW1Z7u+3lhzPRau69E0CNjADku1mLQQflUORo=",
+        "lastModified": 1767910483,
+        "narHash": "sha256-MOU5YdVu4DVwuT5ztXgQpPuRRBjSjUGIdUzOQr9iQOY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44777152652bc9eacf8876976fa72cc77ca8b9d8",
+        "rev": "82fb7dedaad83e5e279127a38ef410bcfac6d77c",
         "type": "github"
       },
       "original": {
@@ -557,11 +555,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765337252,
-        "narHash": "sha256-HuWQp8fM25fyWflbuunQkQI62Hg0ecJxWD52FAgmxqY=",
+        "lastModified": 1768068402,
+        "narHash": "sha256-bAXnnJZKJiF7Xr6eNW6+PhBf1lg2P1aFUO9+xgWkXfA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "13cc1efd78b943b98c08d74c9060a5b59bf86921",
+        "rev": "8bc5473b6bc2b6e1529a9c4040411e1199c43b4c",
         "type": "github"
       },
       "original": {
@@ -572,7 +570,6 @@
     },
     "microvm": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixos-modules",
           "nixpkgs"
@@ -580,11 +577,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1765402693,
-        "narHash": "sha256-cf/Dwu5VqyFxpvLJ099yulWgOfMlQ8l1GmWU8tsNSOw=",
+        "lastModified": 1768085909,
+        "narHash": "sha256-VmLSHlimAq+em9rXX9YhBS0Shu5MBCAQi2Kd//8OOgQ=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "3e8608205a1079f415306f45009cedb1005a1fa2",
+        "rev": "4f267df275361406cda9a3f8e349035be207b307",
         "type": "github"
       },
       "original": {
@@ -625,16 +622,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1761648602,
-        "narHash": "sha256-H97KSB/luq/aGobKRuHahOvT1r7C03BgB6D5HBZsbN8=",
+        "lastModified": 1767792158,
+        "narHash": "sha256-jaFZsFDzhm5Sg6OseRW6Jans1TAm3X74zI0aeFGsitg=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "3e5644da6830ef65f0a2f7ec22830c46285bfff6",
+        "rev": "e3fbfb8486637daca6f104c49872bd2d574423a0",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "devenv-2.30.6",
+        "ref": "devenv-2.32",
         "repo": "nix",
         "type": "github"
       }
@@ -671,7 +668,7 @@
     "nix-appimage_2": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixos-modules",
           "nix-bundlers",
@@ -747,11 +744,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765066094,
-        "narHash": "sha256-0YSU35gfRFJzx/lTGgOt6ubP8K6LeW0vaywzNNqxkl4=",
+        "lastModified": 1767634391,
+        "narHash": "sha256-owcSz2ICqTSvhBbhPP+1eWzi88e54rRZtfCNE5E/wwg=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "688427b1aab9afb478ca07989dc754fa543e03d5",
+        "rev": "08585aacc3d6d6c280a02da195fdbd4b9cf083c2",
         "type": "github"
       },
       "original": {
@@ -769,11 +766,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765065051,
-        "narHash": "sha256-b7W9WsvyMOkUScNxbzS45KEJp0iiqRPyJ1I3JBE+oEE=",
+        "lastModified": 1767718503,
+        "narHash": "sha256-V+VkFs0aSG0ca8p/N3gib7FAf4cq9jyr5Gm+ZBrHQpo=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "7e22bf538aa3e0937effcb1cee73d5f1bcc26f79",
+        "rev": "9f48ffaca1f44b3e590976b4da8666a9e86e6eb1",
         "type": "github"
       },
       "original": {
@@ -784,29 +781,21 @@
     },
     "nix-topology": {
       "inputs": {
-        "devshell": [
+        "flake-parts": [
           "nixos-modules",
-          "devshell"
-        ],
-        "flake-utils": [
-          "nixos-modules",
-          "flake-utils"
+          "flake-parts"
         ],
         "nixpkgs": [
           "nixos-modules",
           "nixpkgs"
-        ],
-        "pre-commit-hooks": [
-          "nixos-modules",
-          "git-hooks-nix"
         ]
       },
       "locked": {
-        "lastModified": 1765221099,
-        "narHash": "sha256-U4cu+HkqVNuoGWbQPUOAWOY0yED4IrEEic1D9vwImfg=",
+        "lastModified": 1768068512,
+        "narHash": "sha256-pH5wkcNOiXy4MBjDTe6A1gml+7m+ULC3lYMBPMqdS1w=",
         "owner": "oddlama",
         "repo": "nix-topology",
-        "rev": "a59b65e98d0e22ae800014961eeb076815ddca20",
+        "rev": "4367a2093c5ff74fc478466aebf41d47ce0cacb4",
         "type": "github"
       },
       "original": {
@@ -817,7 +806,7 @@
     },
     "nix-utils": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
@@ -864,11 +853,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761716996,
-        "narHash": "sha256-vdOuy2pid2/DasUgb08lDOswdPJkN5qjXfBYItVy/R4=",
+        "lastModified": 1767430085,
+        "narHash": "sha256-SiXJ6xv4pS2MDUqfj0/mmG746cGeJrMQGmoFgHLS25Y=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "e5496ab66e9de9e3f67dc06f692dfbc471b6316e",
+        "rev": "66f4b8a47e92aa744ec43acbb5e9185078983909",
         "type": "github"
       },
       "original": {
@@ -881,9 +870,38 @@
       "inputs": {
         "flake-parts": [
           "nixos-modules",
+          "devenv",
           "flake-parts"
         ],
         "flake-root": "flake-root",
+        "nixpkgs": [
+          "nixos-modules",
+          "devenv",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1763964548,
+        "narHash": "sha256-JTRoaEWvPsVIMFJWeS4G2isPo15wqXY/otsiHPN0zww=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "d4bf15e56540422e2acc7bc26b20b0a0934e3f5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
+        "type": "github"
+      }
+    },
+    "nixd_2": {
+      "inputs": {
+        "flake-parts": [
+          "nixos-modules",
+          "flake-parts"
+        ],
+        "flake-root": "flake-root_2",
         "nixpkgs": "nixpkgs_3",
         "treefmt-nix": [
           "nixos-modules",
@@ -891,11 +909,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765393498,
-        "narHash": "sha256-OapXNkISC2JXOFs7c6V7puiYg4+XSJxbGNce3GNVMWo=",
+        "lastModified": 1767970103,
+        "narHash": "sha256-Qqr3IIietcAH1QM1eSD5JoHzeej+JviWX/fVwXOHR80=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "72f4dd1fc57114dd0b455d07605de899d6961f29",
+        "rev": "628824e0fe5c748de292dc2d6f34bb43f031cb90",
         "type": "github"
       },
       "original": {
@@ -906,11 +924,11 @@
     },
     "nixos-2505": {
       "locked": {
-        "lastModified": 1764939437,
-        "narHash": "sha256-4TLFHUwXraw9Df5mXC/vCrJgb50CRr3CzUzF0Mn3CII=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00d2457e2f608b4be6fe8b470b0a36816324b0ae",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
@@ -922,11 +940,11 @@
     },
     "nixos-2511": {
       "locked": {
-        "lastModified": 1765311797,
-        "narHash": "sha256-mSD5Ob7a+T2RNjvPvOA1dkJHGVrNVl8ZOrAwBjKBDQo=",
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09eb77e94fa25202af8f3e81ddc7353d9970ac1b",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
         "type": "github"
       },
       "original": {
@@ -965,11 +983,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763045507,
-        "narHash": "sha256-61zO8zsFE8C104hCTv04z6a4H8U03OEMrRAXtGsszkE=",
+        "lastModified": 1766503044,
+        "narHash": "sha256-DdJ0OIngRjekqXJauSQ8y9vyDO24dX8v7DiaWmxk7PU=",
         "owner": "numtide",
         "repo": "nixos-anywhere",
-        "rev": "bad98b0685cf47eaeadcaf6787da8b51cf025693",
+        "rev": "e86fad431cf9161ca39747972bd255897572dc3b",
         "type": "github"
       },
       "original": {
@@ -990,11 +1008,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764589946,
-        "narHash": "sha256-W8C9UnclS2IAvSuAYcvG1w+H/kVaqVE5XZNVh+fICH0=",
+        "lastModified": 1766770015,
+        "narHash": "sha256-kUmVBU+uBUPl/v3biPiWrk680b8N9rRMhtY97wsxiJc=",
         "owner": "nix-community",
         "repo": "nixos-images",
-        "rev": "ec7cd3c865f01906e6d023f8942299ad817f84cd",
+        "rev": "e4dba54ddb6b2ad9c6550e5baaed2fa27938a5d2",
         "type": "github"
       },
       "original": {
@@ -1029,7 +1047,7 @@
         "nix-darwin-unstable": "nix-darwin-unstable",
         "nix-topology": "nix-topology",
         "nix2container": "nix2container",
-        "nixd": "nixd",
+        "nixd": "nixd_2",
         "nixos-2505": "nixos-2505",
         "nixos-2511": "nixos-2511",
         "nixos-anywhere": "nixos-anywhere",
@@ -1039,9 +1057,9 @@
           "nixos-2511"
         ],
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "systems": "systems_4",
+        "systems": "systems_3",
         "terranix": "terranix",
-        "treefmt-nix": "treefmt-nix",
+        "treefmt-nix": "treefmt-nix_2",
         "vscode-server": "vscode-server"
       },
       "locked": {
@@ -1072,11 +1090,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1765186076,
-        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "lastModified": 1767892417,
+        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
         "type": "github"
       },
       "original": {
@@ -1133,11 +1151,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1765120009,
-        "narHash": "sha256-nG76b87rkaDzibWbnB5bYDm6a52b78A+fpm+03pqYIw=",
+        "lastModified": 1767961401,
+        "narHash": "sha256-7PZ/pXpRrd3JfgCSEuBeYW6nCm3UEZ1TLDztFbnjPgU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5e3e9c4e61bba8a5e72134b9ffefbef8f531d008",
+        "rev": "714d0476ae96352f09933e1d8d51e027be25e5c3",
         "type": "github"
       },
       "original": {
@@ -1208,21 +1226,6 @@
         "type": "github"
       }
     },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "terranix": {
       "inputs": {
         "flake-parts": [
@@ -1256,15 +1259,38 @@
       "inputs": {
         "nixpkgs": [
           "nixos-modules",
+          "devenv",
+          "nixd",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1762938485,
-        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
+        "lastModified": 1734704479,
+        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
+        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-modules",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768031762,
+        "narHash": "sha256-b2gJDJfi+TbA7Hu2sKip+1mWqya0GJaWrrXQjpbOVTU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "0c445aa21b01fd1d4bb58927f7b268568af87b20",
         "type": "github"
       },
       "original": {
@@ -1275,7 +1301,7 @@
     },
     "utils": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,


### PR DESCRIPTION

Subcommands:

- `hosts scan --network NETWORK-PREFIX`: Scan network range for SSH hosts
  - Fetches hostnames via SSH in parallel
  - Optionally saves SSH public keys with `--save-keys FILE`
  - Outputs results to JSON with `--output FILE`

- `hosts execute --command '...'`: Execute commands on multiple hosts
  - Load hosts from JSON/CSV file (`--hosts-file`) or scan (`--scan`)
  - Parallel execution with progress indicator (`--parallel N`)
  - Save per-host output to directory (`--output-dir`, `--file-extension`)
  - Summarizes failures with error output at the end

Host file format (CSV): `ipv4,description,user,port` (all columns except ipv4 are optional)

Also adds `logErrors` parameter to `execute()` in process.d to suppress error logging.
