### PR TITLE
fix(mcl/nix): Prepend dependencies to the PATH, instead of overwriting it

### DIFF
--- a/packages/mcl/default.nix
+++ b/packages/mcl/default.nix
@@ -90,8 +90,8 @@ pkgs.buildDubPackage rec {
 
   postFixup = ''
     wrapProgram $out/bin/${pname} \
-      --set PATH "${lib.makeBinPath deps}" \
-      --set LD_LIBRARY_PATH "${lib.makeLibraryPath deps}"
+      --prefix PATH : "${lib.makeBinPath deps}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath deps}"
   '';
 
   meta = {


### PR DESCRIPTION
This fixes the host-info on macOS which needs to run commands like /usr/bin/sw_vers.
