### PR TITLE
feat(mcl): Add host-info improvements and hosts nix-run command

### DIFF
--- a/packages/mcl/default.nix
+++ b/packages/mcl/default.nix
@@ -16,22 +16,15 @@ let
     ]
     ++ (with pkgs; [
       gitMinimal
-      gawk
       jc
-      coreutils-full
       util-linux
       xorg.xrandr
-      perl
       alejandra
       openssh
       cachix
-      curl
     ])
     ++ lib.optionals (isLinux && isx86) [
-      v4l-utils
       dmidecode
-      mesa-demos
-      nixos-install-tools
       systemd
     ];
   excludedTests = (

--- a/packages/mcl/src/mcl/commands/host_info.d
+++ b/packages/mcl/src/mcl/commands/host_info.d
@@ -569,7 +569,7 @@ ProcessorInfo getProcessorInfo()
     else version (linux)
     {
         // Get CPU info from /proc/cpuinfo
-        r.vendor = cpuinfo.get("vendor_id", "");
+        r.vendor = cpuinfo.get("vendor_id", "").cpuVendorName;
         r.model = cpuinfo.get("model name", "");
         r.cores = [cpuinfo.get("cpu cores", "1").to!size_t];
         r.threads = [cpuinfo.get("siblings", r.cores[0].to!string).to!size_t];
@@ -1245,6 +1245,16 @@ string pciVendorName(string vendorId)
         case "0x10de": return "NVIDIA";
         case "0x1002": return "AMD";
         case "0x8086": return "Intel";
+        default: return vendorId;
+    }
+}
+
+string cpuVendorName(string vendorId)
+{
+    switch (vendorId)
+    {
+        case "AuthenticAMD": return "AMD";
+        case "GenuineIntel": return "Intel";
         default: return vendorId;
     }
 }

--- a/packages/mcl/src/mcl/commands/host_info.d
+++ b/packages/mcl/src/mcl/commands/host_info.d
@@ -23,6 +23,7 @@ import mcl.utils.number : humanReadableSize, roundToPowerOf2;
 import mcl.utils.array : uniqIfSame;
 import mcl.utils.nix : Literal;
 import mcl.utils.coda : CodaApiClient, RowValues, CodaCell;
+import mcl.commands.match_invoices : MatchInvoicesArgs, matchInvoices;
 
 version (linux)
 {
@@ -56,6 +57,7 @@ struct HostInfoArgs
 {
     SubCommand!(
         PartsArgs,
+        MatchInvoicesArgs,
         Default!ShowArgs
     ) cmd;
 }
@@ -88,7 +90,8 @@ export int host_info(HostInfoArgs args)
 {
     return args.cmd.matchCmd!(
         (ShowArgs a) => showHostInfo(a),
-        (PartsArgs a) => showParts(a)
+        (PartsArgs a) => showParts(a),
+        (MatchInvoicesArgs a) => matchInvoices(a)
     );
 }
 

--- a/packages/mcl/src/mcl/commands/machine.d
+++ b/packages/mcl/src/mcl/commands/machine.d
@@ -270,7 +270,7 @@ void createMachine(CreateMachineArgs args, MachineType machineType, string machi
     hardwareConfiguration.boot.initrd.availableKernelModules ~= ["nvme", "xhci_pci", "usbhid", "usb_storage", "sd_mod"];
 
     // Disks
-    hardwareConfiguration.disko.DISKO.makeZfsPartitions.swapSizeGB = (info.hardwareInfo.memoryInfo.totalGB.to!double*1.5).to!int;
+    hardwareConfiguration.disko.DISKO.makeZfsPartitions.swapSizeGB = (info.hardwareInfo.memoryInfo.totalGiB.to!double*1.5).to!int;
     auto nvmeDevices = info.hardwareInfo.storageInfo.devices.filter!(a => a.dev.indexOf("nvme") != -1 || a.model.indexOf("SSD") != -1).array.map!(a => a.model.replace(" ", "_") ~ "_" ~ a.serial).array;
     string[] disks = (nvmeDevices.length == 1 ? nvmeDevices[0] : (args.disks != "" ? args.disks : prompt!string("Enter the disks to use (comma delimited)", nvmeDevices))).split(",").map!(strip).array.map!(a => "/dev/disk/by-id/nvme-" ~ a).array;
     hardwareConfiguration.disko.DISKO.makeZfsPartitions.disks = disks;

--- a/packages/mcl/src/mcl/commands/match_invoices.d
+++ b/packages/mcl/src/mcl/commands/match_invoices.d
@@ -1,0 +1,383 @@
+module mcl.commands.match_invoices;
+
+import std.stdio : writeln, File;
+import std.conv : to;
+import std.string : strip, toUpper, toLower, startsWith, endsWith;
+import std.array : array, replace;
+import std.algorithm : map, filter, canFind, min, joiner;
+import std.file : exists, dirEntries, SpanMode, readText;
+import std.path : baseName;
+import std.json : JSONOptions, parseJSON;
+import std.typecons : Nullable, nullable;
+import std.csv : csvReader, Malformed;
+import std.exception : ifThrown;
+
+import argparse : Command, Description, NamedArgument, Placeholder, Required;
+
+import mcl.utils.json : toJSON, fromJSON;
+import mcl.commands.host_info : Part, HostParts;
+
+// =============================================================================
+// Command Args
+// =============================================================================
+
+@(Command("match-invoices")
+    .Description("Match hardware parts to purchase invoices"))
+struct MatchInvoicesArgs
+{
+    @(NamedArgument(["invoices"])
+        .Placeholder("DIR")
+        .Description("Directory containing invoice CSV files")
+        .Required())
+    string invoicesDir;
+
+    @(NamedArgument(["host-info-dir"])
+        .Placeholder("DIR")
+        .Description("Directory containing host-info JSON files")
+        .Required())
+    string hostInfoDir;
+}
+
+// =============================================================================
+// Invoice Data Structures
+// =============================================================================
+
+// CSV record structure matching the invoice file columns
+struct CsvRecord
+{
+    string purchasedbid;
+    string clientdbid;
+    string date;
+    string name;
+    string mark;
+    string model;
+    string sn;
+    string price;
+    string vat;
+    string lastchange;
+    string modul;
+    string manifacturer;
+    string productid;
+    string descr;
+}
+
+struct Invoice
+{
+    string file;           // Source CSV filename (added after parsing)
+    string purchasedbid;   // Invoice ID
+    string date;           // Purchase date
+    string name;           // Category (CPU, MB, RAM, SSD, etc.)
+    string mark;           // Manufacturer/brand
+    string model;          // Product model
+    string sn;             // Serial number
+    string price;          // Price
+    string descr;          // Description
+
+    this(string file, CsvRecord r)
+    {
+        this.file = file;
+        this.purchasedbid = r.purchasedbid;
+        this.date = r.date;
+        this.name = r.name;
+        this.mark = r.mark;
+        this.model = r.model;
+        this.sn = r.sn;
+        this.price = r.price;
+        this.descr = r.descr;
+    }
+}
+
+struct PartMatch
+{
+    Part part;
+    Nullable!InvoiceInfo invoice;
+    string confidence;     // "high", "medium", "low", or ""
+    string matchType;      // "serial", "model", "model+brand", or ""
+}
+
+struct InvoiceInfo
+{
+    string file;
+    string purchasedbid;
+    string date;
+    string price;
+    string descr;
+}
+
+struct MatchResult
+{
+    string hostname;
+    PartMatch[] matches;
+    Invoice[] unmatchedInvoices;
+}
+
+// =============================================================================
+// Command Handler
+// =============================================================================
+
+int matchInvoices(MatchInvoicesArgs args)
+{
+    auto invoices = loadInvoices(args.invoicesDir);
+    auto allHostParts = loadHostParts(args.hostInfoDir);
+
+    allHostParts
+        .map!(parts => matchPartsToInvoices(parts, invoices))
+        .array
+        .toJSON(true)
+        .toPrettyString(JSONOptions.doNotEscapeSlashes)
+        .writeln();
+
+    return 0;
+}
+
+HostParts[] loadHostParts(string hostInfoDir)
+{
+    return exists(hostInfoDir)
+        ? dirEntries(hostInfoDir, "*.json", SpanMode.shallow)
+            .map!(entry => readText(entry.name).parseJSON.fromJSON!HostParts.ifThrown(HostParts.init))
+            .filter!(p => p.hostname.length > 0)
+            .array
+        : [];
+}
+
+// =============================================================================
+// Invoice Loading
+// =============================================================================
+
+Invoice[] loadInvoices(string invoicesDir)
+{
+    return exists(invoicesDir)
+        ? dirEntries(invoicesDir, "*.csv", SpanMode.shallow)
+            .map!(entry => parseInvoiceCsv(entry.name))
+            .joiner
+            .array
+        : [];
+}
+
+Invoice[] parseInvoiceCsv(string filepath)
+{
+    auto filename = baseName(filepath);
+    return ifThrown(
+        readText(filepath)
+            .csvReader!(CsvRecord, Malformed.ignore)(null)
+            .map!(record => Invoice(filename, record))
+            .array,
+        cast(Invoice[]) []
+    );
+}
+
+// =============================================================================
+// Serial Number Normalization
+// =============================================================================
+
+string normalizeSerial(string sn)
+{
+    if (sn.length == 0)
+        return "";
+
+    auto normalized = sn.toUpper.strip;
+
+    // Remove common prefixes
+    if (normalized.startsWith("JAR"))
+        normalized = normalized[3 .. $];
+    if (normalized.startsWith("S") && normalized.length > 10)
+        normalized = normalized[1 .. $];
+
+    // Remove common suffixes
+    if (normalized.endsWith("N") && normalized.length > 10)
+        normalized = normalized[0 .. $ - 1];
+
+    return normalized;
+}
+
+// Check if two serial numbers match (handles partial matches)
+bool serialsMatch(string sn1, string sn2)
+{
+    if (sn1.length == 0 || sn2.length == 0)
+        return false;
+
+    auto norm1 = normalizeSerial(sn1);
+    auto norm2 = normalizeSerial(sn2);
+
+    if (norm1 == norm2)
+        return true;
+
+    // Check suffix match (invoice may have truncated SN)
+    auto minLen = min(norm1.length, norm2.length);
+    if (minLen >= 6)
+    {
+        if (norm1.endsWith(norm2[$ - minLen .. $]) || norm2.endsWith(norm1[$ - minLen .. $]))
+            return true;
+        if (norm1.canFind(norm2) || norm2.canFind(norm1))
+            return true;
+    }
+
+    return false;
+}
+
+// =============================================================================
+// Brand/Model Normalization
+// =============================================================================
+
+string normalizeBrand(string brand)
+{
+    auto normalized = brand.toLower.strip;
+
+    // Common brand normalizations
+    normalized = normalized
+        .replace("intl", "")
+        .replace("international", "")
+        .replace("co.", "")
+        .replace("ltd.", "")
+        .replace("ltd", "")
+        .replace("inc.", "")
+        .replace("inc", "")
+        .replace("corp.", "")
+        .replace("corp", "")
+        .replace(",", "")
+        .replace(".", "")
+        .replace(" ", "");
+
+    return normalized;
+}
+
+bool brandsMatch(string brand1, string brand2)
+{
+    if (brand1.length == 0 || brand2.length == 0)
+        return false;
+
+    auto norm1 = normalizeBrand(brand1);
+    auto norm2 = normalizeBrand(brand2);
+
+    return norm1 == norm2 || norm1.canFind(norm2) || norm2.canFind(norm1);
+}
+
+string normalizeModel(string model)
+{
+    return model.toUpper.strip
+        .replace(" ", "")
+        .replace("-", "")
+        .replace("_", "");
+}
+
+bool modelsMatch(string model1, string model2)
+{
+    if (model1.length == 0 || model2.length == 0)
+        return false;
+
+    auto norm1 = normalizeModel(model1);
+    auto norm2 = normalizeModel(model2);
+
+    return norm1 == norm2 || norm1.canFind(norm2) || norm2.canFind(norm1);
+}
+
+// =============================================================================
+// Category Matching
+// =============================================================================
+
+bool categoriesMatch(string partCat, string invoiceCat)
+{
+    auto p = partCat.toLower;
+    auto i = invoiceCat.toLower;
+
+    if (p == i)
+        return true;
+
+    // Handle common category variations
+    if (p == "cpu" && i.canFind("cpu"))
+        return true;
+    if (p == "mb" && (i.canFind("mb") || i.canFind("motherboard")))
+        return true;
+    if (p == "ram" && (i.canFind("ram") || i.canFind("memory") || i.canFind("ddr")))
+        return true;
+    if (p == "ssd" && (i.canFind("ssd") || i.canFind("disk") || i.canFind("drive")))
+        return true;
+    if (p == "gpu" && (i.canFind("gpu") || i.canFind("video") || i.canFind("graphics")))
+        return true;
+
+    return false;
+}
+
+// =============================================================================
+// Matching Logic
+// =============================================================================
+
+MatchResult matchPartsToInvoices(HostParts parts, Invoice[] invoices)
+{
+    MatchResult result;
+    result.hostname = parts.hostname;
+
+    bool[] invoiceMatched = new bool[invoices.length];
+
+    foreach (part; parts.parts)
+    {
+        PartMatch match;
+        match.part = part;
+
+        // Try serial number match first (highest confidence)
+        if (part.sn.length > 0)
+        {
+            foreach (i, inv; invoices)
+            {
+                if (!invoiceMatched[i] && serialsMatch(part.sn, inv.sn))
+                {
+                    match.invoice = InvoiceInfo(
+                        inv.file, inv.purchasedbid, inv.date, inv.price, inv.descr
+                    ).nullable;
+                    match.confidence = "high";
+                    match.matchType = "serial";
+                    invoiceMatched[i] = true;
+                    break;
+                }
+            }
+        }
+
+        // Try model + brand match (medium confidence)
+        if (match.invoice.isNull && part.model.length > 0)
+        {
+            foreach (i, inv; invoices)
+            {
+                if (!invoiceMatched[i] &&
+                    categoriesMatch(part.name, inv.name) &&
+                    modelsMatch(part.model, inv.model))
+                {
+                    bool brandOk = part.mark.length == 0 || inv.mark.length == 0 ||
+                        brandsMatch(part.mark, inv.mark);
+
+                    if (brandOk)
+                    {
+                        match.invoice = InvoiceInfo(
+                            inv.file, inv.purchasedbid, inv.date, inv.price, inv.descr
+                        ).nullable;
+                        match.confidence = brandsMatch(part.mark, inv.mark) ? "medium" : "low";
+                        match.matchType = brandsMatch(part.mark, inv.mark) ? "model+brand" : "model";
+                        invoiceMatched[i] = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        result.matches ~= match;
+    }
+
+    // Collect unmatched invoices (only hardware-related)
+    foreach (i, inv; invoices)
+    {
+        if (!invoiceMatched[i] && isHardwareInvoice(inv))
+        {
+            result.unmatchedInvoices ~= inv;
+        }
+    }
+
+    return result;
+}
+
+bool isHardwareInvoice(Invoice inv)
+{
+    auto name = inv.name.toLower;
+    return name.canFind("cpu") || name.canFind("mb") || name.canFind("motherboard") ||
+        name.canFind("ram") || name.canFind("memory") || name.canFind("ddr") ||
+        name.canFind("ssd") || name.canFind("disk") || name.canFind("gpu") ||
+        name.canFind("video") || name.canFind("graphics");
+}

--- a/packages/mcl/src/mcl/utils/number.d
+++ b/packages/mcl/src/mcl/utils/number.d
@@ -18,3 +18,12 @@ string humanReadableSize(T)(T size) if (isNumeric!T)
     }
     return size.to!string ~ "B";
 }
+
+// Round up to nearest power of 2
+int roundToPowerOf2(int n)
+{
+    import core.bitop : bsr;
+    if (n <= 1) return 1;
+    auto highBit = bsr(n);
+    return (1 << highBit) == n ? n : 1 << (highBit + 1);
+}

--- a/shells/default.nix
+++ b/shells/default.nix
@@ -56,6 +56,7 @@
 
           shellHook = ''
             export REPO_ROOT="$PWD"
+            export PATH="$REPO_ROOT/packages/mcl/build:$PATH"
             figlet -t "Metacraft Nixos Modules"
           ''
           + config.pre-commit.installationScript;


### PR DESCRIPTION
## Summary

- Add `hosts nix-run` subcommand for running nix flake outputs on multiple remote hosts
- Add `--output-zip` option to `hosts execute` for collecting outputs into a zip archive
- Add `--merge-file` option to `hosts scan` for merging with existing hosts files
- Add `sshSuccess` field to track SSH connectivity status
- Improve host-info with periphery detection, GPU detection, and parts matching

## New Commands

### `mcl hosts nix-run`
Run any nix flake output on multiple remote hosts:
```bash
mcl hosts nix-run -f hosts.json \
  --flake "github:metacraft-labs/nixos-modules#mcl" \
  -o results.zip -e json \
  -- host-info
```

### `mcl hosts execute --output-zip`
Save command outputs to a zip archive:
```bash
mcl hosts execute -c "hostname" -f hosts.json -z results.zip
```