### PR TITLE
docs: Overhaul `README` with workflow examples and link to detailed docs

### DIFF
--- a/docs/shard-splitting-architecture.md
+++ b/docs/shard-splitting-architecture.md
@@ -1,0 +1,165 @@
+## shardSplit Module Overview
+
+The **shardSplit** flake module is a flake-parts module that automatically divides build outputs across multiple "shards" for distributed CI/CD evaluation. It's designed to work with tools like `nix-eval-jobs` for parallel building.
+
+### Module Location & Structure
+
+The module is defined in [`modules/shard-split/default.nix`](https://github.com/metacraft-labs/nixos-modules/blob/main/modules/shard-split/default.nix) and uses the [`lib/shard-attrs.nix`](https://github.com/metacraft-labs/nixos-modules/blob/main/lib/shard-attrs.nix) helper function.
+
+### Configuration Options
+
+The module reads from `config.flake.mcl.shard-matrix` with three configurable inputs:
+
+| Option                     | Type            | Default                                               | Purpose                                                                                            |
+| -------------------------- | --------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **shardSize**              | positive number | 1                                                     | Number of items per shard (chunk size for division)                                                |
+| **systemsToBuild**         | list of strings | `["x86_64-linux", "aarch64-linux", "aarch64-darwin"]` | Systems to evaluate and shard                                                                      |
+| **perSystemAttributePath** | list of strings | `["legacyPackages", "checks"]`                        | Flake attribute path to extract packages from, with `${system}` interpolated after first attribute |
+
+### How It Works
+
+The module performs this pipeline on the evaluated flake outputs:
+
+```
+1. For each system in systemsToBuild:
+   ├─ Access flake outputs using perSystemAttributePath
+   │  └─ e.g., outputs.legacyPackages.${system}.checks
+   │
+   2. Flatten all systems' attributes into a single namespace:
+   │  └─ Each package name becomes: "${name}/${system}"
+   │
+   3. Split flattened list into shards using shardSize
+   │  └─ Shard indices are zero-padded (e.g., "shard-00", "shard-01")
+   │
+   4. Generate two output structures
+```
+
+### Outputs
+
+The module generates four read-only output attributes under `config.flake.mcl.shard-matrix.result`:
+
+#### 1. **shards** - Cross-System Shards
+
+```nix
+{
+  "shard-0" = {
+    "hello-0.0.1/aarch64-darwin" = <derivation>;
+    "hello-0.0.1/x86_64-linux" = <derivation>;
+    "hello-0.0.2/aarch64-darwin" = <derivation>;
+    # ... more packages
+  };
+  "shard-1" = {
+    "bye-0.0.1/aarch64-darwin" = <derivation>;
+    "bye-0.0.1/x86_64-linux" = <derivation>;
+    # ...
+  };
+}
+```
+
+- **Structure**: `shards.{shardId}.{packageName}/{system}`
+- **Use case**: Each shard can be built independently by nix-eval-jobs, with packages distributed across all systems in a single shard
+
+#### 2. **shardsPerSystem** - System-Organized Shards
+
+```nix
+{
+  "aarch64-darwin" = {
+    "shard-0" = {
+      "hello-0.0.1" = <derivation>;
+      "hello-0.0.2" = <derivation>;
+    };
+    "shard-1" = {
+      "bye-0.0.1" = <derivation>;
+    };
+  };
+  "x86_64-linux" = {
+    "shard-0" = { /* ... */ };
+    "shard-1" = { /* ... */ };
+  };
+}
+```
+
+- **Structure**: `shardsPerSystem.{system}.{shardId}.{packageName}`
+- **Use case**: When you need system-specific shard organization (build per-system shards in parallel)
+
+#### 3. **shardCount** - Total Cross-System Shard Count
+
+- **Type**: unsigned integer
+- **Value**: Number of shards in the `shards` output
+- Calculated as: `ceil(totalPackageCount / shardSize)`
+
+#### 4. **shardCountPerSystem** - Per-System Shard Counts
+
+- **Type**: `{system: shardCount, ...}`
+- **Value**: For each system, the number of shards that system has
+- Useful for job scheduling per-system
+
+### Data Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Flake Outputs (evaluated for all systems)                  │
+│  outputs.legacyPackages.x86_64-linux.checks                 │
+│  outputs.legacyPackages.aarch64-darwin.checks               │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+                 ┌───────────────────────┐
+                 │  Extract attributes   │
+                 │ per system using      │
+                 │ perSystemAttributePath│
+                 └───────────────────────┘
+                              │
+          ┌───────────────────┴───────────────────┐
+          ▼                                       ▼
+   ┌──────────────────┐               ┌──────────────────┐
+   │  For each system │               │  For each system │
+   │  gen attributes  │               │  shard using     │
+   │ as "{name}/{sys}"│               │  shardAttrs()    │
+   └──────────────────┘               └──────────────────┘
+          │                                     │
+          └───────────────┬─────────────────────┘
+                          ▼
+       ┌──────────────────────────────────┐
+       │  shardAttrs(attrs, shardSize)    │
+       │  ─────────────────────────────── │
+       │  1. Sort attribute names         │
+       │  2. Split into chunks            │
+       │  3. Create shards with padded ID │
+       │  4. Return {shard-N: {...}}      │
+       └──────────────────────────────────┘
+               │                    │
+               ▼                    ▼
+      ┌──────────────────┐  ┌────────────────────┐
+      │  shards (cross-  │  │ shardsPerSystem    │
+      │  system shards)  │  │ (system-grouped)   │
+      │ {shard-N:        │  │ {system: {shard-N: │
+      │  {pkg/sys: drv}} │  │  {pkg: drv}}}      │
+      └──────────────────┘  └────────────────────┘
+               │                    │
+               └────────┬───────────┘
+                        ▼
+        ┌───────────────────────────────────┐
+        │  shardCount & shardCountPerSystem │
+        │  (Metadata for scheduling)        │
+        └───────────────────────────────────┘
+```
+
+### Shard Splitting Algorithm
+
+The [`shardAttrs`](https://github.com/metacraft-labs/nixos-modules/blob/main/lib/shard-attrs.nix#L1-L25) function implements the core sharding logic:
+
+1. **Calculate shard count**: `ceil(attrCount / shardSize)`
+2. **Create fixed-width shard IDs**: Pad IDs to match the width of the highest shard number (e.g., "00", "01", "02" for 100+ shards)
+3. **Distribute attributes**: Slice attribute names into consecutive chunks of `shardSize`
+4. **Map to derivations**: For each chunk, create a shard object mapping original attribute names to their derivations
+
+### Example Usage
+
+If your flake has 25 packages and `shardSize = 10`:
+
+- 3 shards are created: "shard-0", "shard-1", "shard-2"
+- Shards contain \~10, \~10, and \~5 packages respectively
+- Each shard can be evaluated independently by nix-eval-jobs in parallel
+
+The module throws an error if `systemsToBuild` specifies systems that don't exist in the flake outputs at the configured `perSystemAttributePath`.

--- a/packages/mcl/AGENTS.md
+++ b/packages/mcl/AGENTS.md
@@ -1,0 +1,285 @@
+# MCL Agent Guidelines
+
+This document provides instructions for AI agents working on the `mcl` (Metacraft Labs CLI) codebase.
+
+## Project Overview
+
+`mcl` is a Swiss-knife CLI tool for managing NixOS deployments, written in D. It provides commands for:
+
+- Host information gathering (`host-info`)
+- Remote host management (`hosts`)
+- CI matrix generation (`ci-matrix`, `shard-matrix`)
+- Machine configuration (`machine`, `config`)
+- Deployment (`deploy-spec`)
+
+## Code Style Philosophy
+
+Prefer **functional style** with UFCS (Uniform Function Call Syntax) using `std.algorithm` and `std.range`. Use the ternary operator and direct returns rather than mutating variables with if/else.
+
+```d
+// Preferred: functional pipeline with UFCS
+auto result = items
+    .filter!(a => a.isValid)
+    .map!(a => a.name)
+    .array;
+
+// Preferred: ternary operator
+auto value = condition ? "yes" : "no";
+
+// Avoid: mutation with if/else
+string value;
+if (condition)
+    value = "yes";
+else
+    value = "no";
+```
+
+## Building
+
+```bash
+# Build the project
+dub --root ./packages/mcl/ build
+
+# The binary is output to:
+./packages/mcl/build/mcl
+```
+
+> **Note**: In the Nix devshell, `packages/mcl/build` is automatically added to `PATH` (see `shells/default.nix`). After running `dub build`, you can invoke `mcl` directly without the full path.
+
+## Testing
+
+### Run All Tests
+
+```bash
+# Exclude coda tests (requires auth token)
+dub --root ./packages/mcl/ test -- -e coda
+```
+
+### Run Specific Tests
+
+Use `-i` (include) to filter tests by regex pattern:
+
+```bash
+# Run tests matching "loadHostsFrom"
+dub --root ./packages/mcl/ test -- -i "loadHostsFrom"
+
+# Run tests matching "parseDmi"
+dub --root ./packages/mcl/ test -- -i "parseDmi"
+```
+
+### Test Options
+
+```
+-i, --include    Run tests matching regex
+-e, --exclude    Skip tests matching regex
+-v, --verbose    Show full stack traces and durations
+-t, --threads    Number of worker threads (0 = auto)
+--no-colours     Disable colored output
+```
+
+### Manual Testing
+
+Test CLI commands directly after building:
+
+```bash
+# Show host information
+mcl host-info
+
+# Show purchasable parts (for invoice matching)
+mcl host-info parts
+
+# Scan network for hosts with SSH
+mcl hosts scan --network 192.168.1
+
+# Get help for any command
+mcl host-info --help
+```
+
+## Code Style
+
+### Imports
+
+Group imports in this order:
+
+1. `std.*` modules (one per line, with specific symbols)
+2. External dependencies (`argparse`, etc.)
+3. Internal modules (`mcl.*`)
+
+```d
+import std.stdio : writeln;
+import std.conv : to;
+import std.string : strip, indexOf;
+import std.array : split, join, array;
+import std.algorithm : map, filter, startsWith;
+
+import argparse : Command, Description, NamedArgument;
+
+import mcl.utils.json : toJSON, fromJSON;
+```
+
+### Command Structure
+
+Commands use the `argparse` library with `@Command` attributes:
+
+```d
+@(Command("my-command")
+    .Description("Brief description of the command"))
+struct MyCommandArgs
+{
+    @(NamedArgument(["input", "i"])
+        .Placeholder("FILE")
+        .Description("Input file path"))
+    string inputFile;
+}
+
+export int my_command(MyCommandArgs args)
+{
+    // Implementation
+    return 0;
+}
+```
+
+### Subcommands
+
+Use `SubCommand!` template for commands with subcommands:
+
+```d
+@(Command("parent-command")
+    .Description("Parent command"))
+struct ParentArgs
+{
+    SubCommand!(
+        SubCmd1Args,
+        SubCmd2Args,
+        Default!SubCmd1Args  // Default subcommand
+    ) cmd;
+}
+
+export int parent_command(ParentArgs args)
+{
+    return args.cmd.matchCmd!(
+        (SubCmd1Args a) => handleSubCmd1(a),
+        (SubCmd2Args a) => handleSubCmd2(a)
+    );
+}
+```
+
+### Data Structures
+
+Use named parameters for struct initialization:
+
+```d
+parts ~= Part(
+    name: "CPU",
+    mark: hw.processorInfo.vendor,
+    model: hw.processorInfo.model,
+    sn: "",
+);
+```
+
+## Commit Message Convention
+
+Follow the conventional commits format used in this repo:
+
+```
+<type>(<scope>): <description>
+```
+
+### Types
+
+- `feat` - New feature
+- `fix` - Bug fix
+- `refactor` - Code refactoring
+- `chore` - Maintenance tasks
+- `build` - Build system changes
+- `ci` - CI/CD changes
+
+### Scopes
+
+- `mcl.commands.<command>` - For command-specific changes
+- `mcl.utils.<module>` - For utility module changes
+- `flake.nix` - For Nix flake changes
+
+### Examples
+
+```
+feat(mcl.commands.host-info): Add periphery section for input devices
+fix(mcl.utils.json): Handle Nullable types in serialization
+refactor(mcl.commands.host-info): Rewrite getMemoryInfo function
+chore(flake.lock): Update all Flake inputs
+```
+
+## File Structure
+
+```
+packages/mcl/
+├── src/mcl/
+│   ├── commands/       # CLI command implementations
+│   │   ├── host_info.d # host-info command
+│   │   ├── hosts.d     # hosts command
+│   │   ├── machine.d   # machine command
+│   │   └── ...
+│   ├── utils/          # Utility modules
+│   │   ├── json.d      # JSON serialization
+│   │   ├── process.d   # Process execution
+│   │   └── ...
+│   └── package.d       # Module exports
+├── build/              # Build output directory
+├── dub.sdl             # D package configuration
+└── AGENTS.md           # This file
+```
+
+## Common Patterns
+
+### Type-safe Parsing / Serde
+
+Use `fromJSON!T` for deserialization and `toJSON` for serialization:
+
+```d
+// Deserialize JSON to struct
+auto json = parseJSON(jsonText);
+auto data = json.fromJSON!MyStruct;
+
+// Serialize struct to JSON with pretty printing
+data
+    .toJSON(true)
+    .toPrettyString(JSONOptions.doNotEscapeSlashes)
+    .writeln();
+```
+
+Use `std.csv.csvReader!T` for type-safe CSV parsing:
+
+```d
+import std.csv : csvReader, Malformed;
+
+struct Record
+{
+    string name;
+    string value;
+    int count;
+}
+
+auto content = readText("data.csv");
+auto records = csvReader!(Record, Malformed.ignore)(content, null);
+foreach (record; records)
+{
+    // record is a Record struct
+}
+```
+
+## Debugging Tips
+
+1. **Build with debug info**: The default build includes debug symbols
+2. **Use verbose test output**: `dub test -- -v` shows full stack traces
+3. **Test single functions**: Use `-i "functionName"` to isolate tests
+4. **Check JSON output**: Pipe commands through `jq` for readable output:
+   ```bash
+   mcl host-info | jq .
+   ```
+
+## Dependencies
+
+- `argparse` - CLI argument parsing
+- `silly` - Test runner
+
+All dependencies are managed via `dub.sdl` and Nix flake.


### PR DESCRIPTION
- Add Documentation section linking to shard-splitting-architecture.md
- Add GitHub Workflows section with CI and Reusable Workflows subsections
- Add usage examples for all 5 reusable workflows
- Consolidate MCL CLI documentation into a table, referencing AGENTS.md
- Remove verbose per-command documentation (now in `mcl --help`)
