### PR TITLE
feat(vm-automation): Add comprehensive macOS OOBE automation configs

### DIFF
--- a/packages/vm-automation/configs/README.md
+++ b/packages/vm-automation/configs/README.md
@@ -156,8 +156,8 @@ Debug files are saved to `/tmp/unattended-<timestamp>/`
 - key: space
 - key: backspace
 - key: escape
-- key: up    # arrow keys
-- key: f1    # function keys
+- key: up # arrow keys
+- key: f1 # function keys
 ```
 
 ### Hotkeys
@@ -171,7 +171,7 @@ Debug files are saved to `/tmp/unattended-<timestamp>/`
 ### Timing
 
 ```yaml
-- delay: 2   # seconds (can be float: 0.5)
+- delay: 2 # seconds (can be float: 0.5)
 ```
 
 ## Tips
@@ -200,6 +200,7 @@ If OCR fails to recognize text:
 ### Account Credentials
 
 All macOS configs create:
+
 - Username: `admin`
 - Password: `admin`
 

--- a/packages/vm-automation/configs/YAML-AUTOMATION-SCHEMA.md
+++ b/packages/vm-automation/configs/YAML-AUTOMATION-SCHEMA.md
@@ -1,0 +1,267 @@
+# YAML Automation Schema
+
+This document defines the YAML schema for VM automation configs.
+
+## Overview
+
+Uses native YAML structures for type safety, validation, IDE support, and maintainability.
+
+## Top-Level Structure
+
+```yaml
+# Seconds to wait after VM boots before starting automation
+boot_wait: 60
+
+# Maximum time for entire installation (optional)
+max_install_time: 3600
+
+# List of automation commands (executed sequentially)
+boot_commands:
+  - <command>
+  - <command>
+  ...
+
+# SSH health check to verify setup completed
+health_check:
+  type: ssh
+  host: 127.0.0.1
+  port: 22
+  user: admin
+  password: admin
+  timeout: 30
+  retries: 10
+  retry_delay: 15
+  command: "sw_vers"  # Command to run for health check
+```
+
+## Command Types
+
+### 1. Wait for Text (OCR-based)
+
+Wait for text to appear on screen using OCR.
+
+```yaml
+- wait:
+    text: 'Continue'
+    timeout: 300 # seconds (default: 120)
+```
+
+### 2. Delay
+
+Fixed time delay in seconds.
+
+```yaml
+- delay: 5 # seconds (can be float: 2.5)
+```
+
+### 3. Type Text
+
+Type a string (sent as keyboard events).
+
+```yaml
+- type: 'hello world'
+```
+
+### 4. Click on Text
+
+Click on text found via OCR.
+
+```yaml
+# Simple click (first occurrence)
+- click: 'Continue'
+
+# Click with parameters
+- click:
+    text: 'Agree'
+    index: -1 # -1 = last occurrence, 0 = first, 1 = second, etc.
+    offset: # optional offset from text center
+      x: 50 # pixels right (+) or left (-)
+      y: 0 # pixels down (+) or up (-)
+```
+
+### 5. Click at Coordinates
+
+Click at absolute screen coordinates.
+
+```yaml
+- click_at:
+    x: 815
+    y: 480
+```
+
+### 6. Special Keys
+
+Press special keys (enter, tab, space, escape, arrows, function keys).
+
+```yaml
+# Simple form (just key name)
+- key: enter
+- key: tab
+- key: space
+- key: escape
+- key: backspace
+
+# Arrow keys
+- key: up
+- key: down
+- key: left
+- key: right
+
+# Function keys
+- key: f1
+- key: f2
+# ... through f12
+```
+
+### 7. Hotkeys (Key Combinations)
+
+Press key combinations with modifiers.
+
+```yaml
+- hotkey:
+    modifiers: [cmd, shift] # or [ctrl, alt], etc.
+    key: t
+
+# Common examples:
+- hotkey:
+    modifiers: [cmd]
+    key: space # Spotlight on macOS
+
+- hotkey:
+    modifiers: [shift]
+    key: tab
+```
+
+**Modifier names:**
+
+- `shift` - Shift key
+- `ctrl` - Control key
+- `alt` - Alt key (Option on macOS)
+- `cmd` / `meta` / `super` - Command key (macOS) / Windows key (Linux/Windows)
+
+### 8. Mouse Movement
+
+Move mouse to coordinates (without clicking).
+
+```yaml
+- move_mouse:
+    x: 960
+    y: 540
+```
+
+## Complete Example
+
+```yaml
+boot_wait: 60
+
+boot_commands:
+  # Wait for installer
+  - wait:
+      text: 'Continue'
+      timeout: 300
+
+  - delay: 5
+
+  # Open terminal with hotkey
+  - hotkey:
+      modifiers: [shift, cmd]
+      key: t
+
+  - delay: 3
+
+  # Wait for terminal
+  - wait:
+      text: 'Terminal'
+      timeout: 30
+
+  # Type command
+  - type: 'echo hello'
+  - key: enter
+
+  # Navigate with keyboard
+  - key: tab
+  - delay: 1
+  - key: space
+
+  # Click on button
+  - click: 'Agree'
+
+  # Click with offset (50 pixels right of text)
+  - click:
+      text: 'Label'
+      offset:
+        x: 50
+        y: 0
+
+  # Click at absolute coordinates
+  - click_at:
+      x: 815
+      y: 480
+
+health_check:
+  type: ssh
+  host: 127.0.0.1
+  port: 22
+  user: admin
+  password: admin
+  timeout: 30
+  retries: 10
+  retry_delay: 15
+  command: 'uname -a'
+```
+
+## Schema Validation
+
+The automation runner should validate:
+
+1. **boot_wait** is a positive number
+2. Each command has required fields for its type
+3. **timeout** values are positive integers
+4. **coordinates** (x, y) are non-negative integers
+5. **modifiers** are from the allowed list
+6. **keys** are from the allowed list (enter, tab, space, a-z, 0-9, f1-f12, arrows, etc.)
+
+## Parser Implementation Notes
+
+For the yaml-automation-runner Python implementation:
+
+```python
+def parse_command(cmd):
+    """Parse a command from YAML dict."""
+
+    if not isinstance(cmd, dict):
+        raise ValueError(f"Invalid command type: {type(cmd)}. Expected dict.")
+
+    return _parse_native_command(cmd)
+
+def _parse_native_command(cmd):
+    """Parse YAML command dict into normalized command format."""
+
+    # Single-key commands: {key: value}
+    if len(cmd) == 1:
+        cmd_type, params = next(iter(cmd.items()))
+
+        # Simple value commands
+        if cmd_type == "delay":
+            return Delay(duration=params)
+        if cmd_type == "type":
+            return TypeText(text=params)
+        if cmd_type == "key":
+            return KeyPress(key=params)
+        if cmd_type == "click" and isinstance(params, str):
+            return ClickText(text=params)
+
+        # Structured commands
+        if cmd_type == "wait":
+            return WaitForText(**params)
+        if cmd_type == "click":
+            return ClickText(**params)
+        if cmd_type == "click_at":
+            return ClickAt(**params)
+        if cmd_type == "hotkey":
+            return Hotkey(**params)
+        if cmd_type == "move_mouse":
+            return MoveMouse(**params)
+
+    raise ValueError(f"Unknown command type: {cmd}")
+```

--- a/packages/vm-automation/configs/macos-sonoma.yml
+++ b/packages/vm-automation/configs/macos-sonoma.yml
@@ -1,16 +1,17 @@
 # Copyright 2026 Schelling Point Labs Inc
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Unattended macOS Sequoia Setup Assistant Configuration
+# Unattended macOS Sonoma Setup Assistant Configuration
 #
-# This YAML config automates the macOS Sequoia (15.x) OOBE setup for creating
-# reproducible VM images. Uses native YAML format for validation and IDE support.
+# This YAML config automates the macOS Sonoma (14.x) OOBE (Out-of-Box Experience)
+# setup for creating reproducible VM images. Uses native YAML format for better
+# validation and IDE support.
 #
 # Usage:
-#   yaml-automation-runner --config macos-sequoia.yml --vnc localhost:5902
+#   yaml-automation-runner --config macos-sonoma.yml --vnc localhost:5900
 #
 # Prerequisites:
-#   - macOS Sequoia BaseSystem.img (from fetchMacOSBaseSystem)
+#   - macOS Sonoma BaseSystem.img (from fetchMacOSBaseSystem)
 #   - OpenCore bootloader configured
 #   - InstallAssistant.pkg ISO mounted
 #   - run_offline.sh ISO mounted at /Volumes/run_offline/
@@ -19,20 +20,13 @@
 #   - Username: admin
 #   - Password: admin
 #
-# Key differences from Sonoma:
-#   - Boot wait reduced from 45s to 30s (faster boot)
-#   - Apple Account sign-in confirmation popup (NEW)
-#   - Siri setup 2-screen flow (NEW)
-#   - Update Mac Automatically screen (NEW)
-#
 # References:
-#   - Sonoma config: macos-sonoma.yml
-#   - Lume Sequoia: https://github.com/trycua/cua/blob/main/libs/lume/src/Resources/unattended-presets/sequoia.yml
 #   - Schema: YAML-AUTOMATION-SCHEMA.md
+#   - OSX-KVM: https://github.com/kholia/OSX-KVM
 
 # Seconds to wait after VM boots before starting automation
-# Sequoia boots faster than Sonoma due to optimizations
-boot_wait: 30
+# Sonoma takes longer to boot than newer versions due to OpenCore initialization
+boot_wait: 45
 
 boot_commands:
   # ============================================
@@ -254,7 +248,7 @@ boot_commands:
   # ============================================
 
   # This is the most timing-sensitive part - if the VM is too slow,
-  # account creation can fail
+  # account creation can fail.
 
   - wait:
       text: 'Create a Computer Account'
@@ -296,35 +290,7 @@ boot_commands:
   - delay: 5
 
   # ============================================
-  # Stage 12: Apple Account Sign-In (NEW in Sequoia)
-  # ============================================
-
-  # Sequoia adds an Apple Account sign-in screen with confirmation popup
-  - wait:
-      text: 'Sign In with Your Apple'
-      timeout: 60
-
-  - delay: 2
-
-  # Click "Set Up Later" to skip
-  - click: 'Set Up Later'
-  - delay: 2
-
-  # NEW: Confirmation popup "Are you sure you want to skip?"
-  - wait:
-      text: "Don't Skip"
-      timeout: 30
-
-  - delay: 1
-
-  # Tab to "Skip" button and press enter
-  - key: tab
-  - delay: 1
-  - key: enter
-  - delay: 3
-
-  # ============================================
-  # Stage 13: Enable Location Services
+  # Stage 12: Enable Location Services
   # ============================================
 
   - wait:
@@ -343,7 +309,7 @@ boot_commands:
   - delay: 2
 
   # ============================================
-  # Stage 14: Location Services Confirmation
+  # Stage 13: Location Services Confirmation
   # ============================================
 
   - wait:
@@ -359,7 +325,7 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 15: Select Time Zone
+  # Stage 14: Select Time Zone
   # ============================================
 
   - wait:
@@ -386,7 +352,7 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 16: Analytics
+  # Stage 15: Analytics
   # ============================================
 
   - wait:
@@ -410,13 +376,13 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 17: Screen Time
+  # Stage 16: Screen Time
   # ============================================
 
-  # Screen Time can have a longer delay in Sequoia while checking iCloud status
+  # Screen Time can have a delay while checking iCloud status
   - wait:
       text: 'Screen Time'
-      timeout: 300
+      timeout: 120
 
   - delay: 5
 
@@ -427,46 +393,7 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 18: Siri Setup (NEW in Sequoia - 2 screens)
-  # ============================================
-
-  # Screen 1: Enable Siri
-  - wait:
-      text: 'Siri'
-      timeout: 300
-
-  - delay: 1
-
-  # Continue to enable Siri
-  - click: 'Continue'
-  - delay: 3
-
-  # Screen 2: Select a Siri Voice
-  - wait:
-      text: 'Select a Siri Voice'
-      timeout: 60
-
-  - delay: 1
-
-  # Choose default voice
-  - click: 'Choose For Me'
-  - delay: 3
-
-  # Screen 3: Improve Siri & Dictation
-  - wait:
-      text: 'Improve Siri'
-      timeout: 60
-
-  - delay: 1
-
-  # Decline sharing Siri data
-  - click: 'Not Now'
-  - delay: 1
-  - click: 'Continue'
-  - delay: 3
-
-  # ============================================
-  # Stage 19: Choose Your Look (Light/Dark Mode)
+  # Stage 17: Choose Your Look (Light/Dark Mode)
   # ============================================
 
   - wait:
@@ -482,24 +409,10 @@ boot_commands:
 
   - delay: 1
   - key: space
-  - delay: 3
-
-  # ============================================
-  # Stage 20: Update Mac Automatically (NEW in Sequoia)
-  # ============================================
-
-  - wait:
-      text: 'Update Mac Automatically'
-      timeout: 60
-
-  - delay: 1
-
-  # Continue with default settings
-  - click: 'Continue'
   - delay: 5
 
   # ============================================
-  # Stage 21: Desktop Setup Complete - Enable SSH
+  # Stage 18: Desktop Setup Complete - Enable SSH
   # ============================================
 
   # Wait for Finder to appear (indicates desktop is ready)
@@ -546,7 +459,7 @@ boot_commands:
   - delay: 2
 
   # ============================================
-  # Stage 22: Enable SSH (Remote Login)
+  # Stage 19: Enable SSH (Remote Login)
   # ============================================
 
   # Enable Remote Login using launchctl
@@ -571,8 +484,6 @@ boot_commands:
   # - User account: admin / admin
   # - SSH enabled on port 22
   # - Time zone: UTC
-  # - Siri enabled with default voice
-  # - Auto-updates enabled (default)
   # - No iCloud/Apple ID configured
   # - Analytics disabled
 

--- a/packages/vm-automation/configs/macos-tahoe.yml
+++ b/packages/vm-automation/configs/macos-tahoe.yml
@@ -1,16 +1,16 @@
 # Copyright 2026 Schelling Point Labs Inc
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Unattended macOS Sequoia Setup Assistant Configuration
+# Unattended macOS Tahoe Setup Assistant Configuration
 #
-# This YAML config automates the macOS Sequoia (15.x) OOBE setup for creating
+# This YAML config automates the macOS Tahoe (16.x) OOBE setup for creating
 # reproducible VM images. Uses native YAML format for validation and IDE support.
 #
 # Usage:
-#   yaml-automation-runner --config macos-sequoia.yml --vnc localhost:5902
+#   yaml-automation-runner --config macos-tahoe.yml --vnc localhost:5903
 #
 # Prerequisites:
-#   - macOS Sequoia BaseSystem.img (from fetchMacOSBaseSystem)
+#   - macOS Tahoe BaseSystem.img (from fetchMacOSBaseSystem)
 #   - OpenCore bootloader configured
 #   - InstallAssistant.pkg ISO mounted
 #   - run_offline.sh ISO mounted at /Volumes/run_offline/
@@ -19,19 +19,19 @@
 #   - Username: admin
 #   - Password: admin
 #
-# Key differences from Sonoma:
-#   - Boot wait reduced from 45s to 30s (faster boot)
-#   - Apple Account sign-in confirmation popup (NEW)
-#   - Siri setup 2-screen flow (NEW)
-#   - Update Mac Automatically screen (NEW)
+# Key differences from Sequoia:
+#   - Migration Assistant: Tab navigation (3 tabs to "Set up as new")
+#   - Account Creation: Avatar picker (6 tabs before Full Name field)
+#   - FileVault encryption screen (NEW - after Siri)
+#   - Welcome screen: "Get Started" button
 #
 # References:
-#   - Sonoma config: macos-sonoma.yml
-#   - Lume Sequoia: https://github.com/trycua/cua/blob/main/libs/lume/src/Resources/unattended-presets/sequoia.yml
+#   - Sequoia config: macos-sequoia.yml
+#   - Lume Tahoe: https://github.com/trycua/cua/blob/main/libs/lume/src/Resources/unattended-presets/tahoe.yml
 #   - Schema: YAML-AUTOMATION-SCHEMA.md
 
 # Seconds to wait after VM boots before starting automation
-# Sequoia boots faster than Sonoma due to optimizations
+# Tahoe boots at similar speed to Sequoia
 boot_wait: 30
 
 boot_commands:
@@ -195,23 +195,29 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 8: Migration Assistant
+  # Stage 8: Migration Assistant (CHANGED in Tahoe)
   # ============================================
 
+  # Tahoe uses different tab navigation - 3 tabs to "Set up as new"
   - wait:
-      text: 'Migration Assistant'
+      text: 'Transfer Your Data'
       timeout: 60
 
-  - delay: 2
+  - delay: 20
 
-  # Navigate to "Not Now" option (third tab from current position)
+  # Tab order: From a Mac -> From Windows PC -> Set up with iPhone -> Set up as new
+  # We need 3 tabs to reach the 4th option "Set up as new"
   - key: tab
-  - delay: 1
+  - delay: 2
   - key: tab
-  - delay: 1
+  - delay: 2
   - key: tab
-  - delay: 1
+  - delay: 2
   - key: space
+  - delay: 1
+
+  # Click Continue
+  - click: 'Continue'
   - delay: 3
 
   # ============================================
@@ -250,20 +256,33 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 11: Create Computer Account
+  # Stage 11: Create Computer Account (CHANGED in Tahoe)
   # ============================================
 
-  # This is the most timing-sensitive part - if the VM is too slow,
-  # account creation can fail
+  # Tahoe has avatar picker - need 6 tabs to skip past it
+  # Field order: Avatar picker (6 icons) -> Full Name -> Account Name -> Password -> Verify Password -> Hint -> Continue
 
   - wait:
-      text: 'Create a Computer Account'
+      text: 'Create a Mac Account'
       timeout: 120
 
   - delay: 3
 
-  # Fill in account details:
-  # Full Name field
+  # Tab past avatar picker icons (6 tabs)
+  - key: tab
+  - delay: 1
+  - key: tab
+  - delay: 1
+  - key: tab
+  - delay: 1
+  - key: tab
+  - delay: 1
+  - key: tab
+  - delay: 1
+  - key: tab
+  - delay: 1
+
+  # Now at Full Name field
   - type: 'admin'
   - delay: 1
   - key: tab
@@ -296,10 +315,10 @@ boot_commands:
   - delay: 5
 
   # ============================================
-  # Stage 12: Apple Account Sign-In (NEW in Sequoia)
+  # Stage 12: Apple Account Sign-In
   # ============================================
 
-  # Sequoia adds an Apple Account sign-in screen with confirmation popup
+  # Similar to Sequoia - has confirmation popup
   - wait:
       text: 'Sign In with Your Apple'
       timeout: 60
@@ -310,7 +329,7 @@ boot_commands:
   - click: 'Set Up Later'
   - delay: 2
 
-  # NEW: Confirmation popup "Are you sure you want to skip?"
+  # Confirmation popup "Are you sure you want to skip?"
   - wait:
       text: "Don't Skip"
       timeout: 30
@@ -413,7 +432,7 @@ boot_commands:
   # Stage 17: Screen Time
   # ============================================
 
-  # Screen Time can have a longer delay in Sequoia while checking iCloud status
+  # Screen Time can have a longer delay while checking iCloud status
   - wait:
       text: 'Screen Time'
       timeout: 300
@@ -427,7 +446,7 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 18: Siri Setup (NEW in Sequoia - 2 screens)
+  # Stage 18: Siri Setup (2 screens)
   # ============================================
 
   # Screen 1: Enable Siri
@@ -466,7 +485,31 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 19: Choose Your Look (Light/Dark Mode)
+  # Stage 19: FileVault (NEW in Tahoe)
+  # ============================================
+
+  # Tahoe adds FileVault encryption setup screen
+  - wait:
+      text: 'FileVault'
+      timeout: 60
+
+  - delay: 1
+
+  # Skip FileVault encryption
+  - click: 'Not Now'
+  - delay: 1
+
+  # Confirmation popup: "Mac Data Will Not Be Securely Encrypted"
+  - wait:
+      text: 'Securely Encrypted'
+      timeout: 30
+
+  - delay: 1
+  - click: 'Continue'
+  - delay: 3
+
+  # ============================================
+  # Stage 20: Choose Your Look (Light/Dark Mode)
   # ============================================
 
   - wait:
@@ -485,7 +528,7 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 20: Update Mac Automatically (NEW in Sequoia)
+  # Stage 21: Update Mac Automatically
   # ============================================
 
   - wait:
@@ -499,7 +542,7 @@ boot_commands:
   - delay: 5
 
   # ============================================
-  # Stage 21: Desktop Setup Complete - Enable SSH
+  # Stage 22: Desktop Setup Complete - Enable SSH
   # ============================================
 
   # Wait for Finder to appear (indicates desktop is ready)
@@ -546,7 +589,7 @@ boot_commands:
   - delay: 2
 
   # ============================================
-  # Stage 22: Enable SSH (Remote Login)
+  # Stage 23: Enable SSH (Remote Login)
   # ============================================
 
   # Enable Remote Login using launchctl
@@ -574,6 +617,7 @@ boot_commands:
   # - Siri enabled with default voice
   # - Auto-updates enabled (default)
   # - No iCloud/Apple ID configured
+  # - No FileVault encryption
   # - Analytics disabled
 
   - delay: 10

--- a/packages/vm-automation/configs/macos-ventura.yml
+++ b/packages/vm-automation/configs/macos-ventura.yml
@@ -1,16 +1,17 @@
 # Copyright 2026 Schelling Point Labs Inc
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Unattended macOS Sequoia Setup Assistant Configuration
+# Unattended macOS Ventura Setup Assistant Configuration
 #
-# This YAML config automates the macOS Sequoia (15.x) OOBE setup for creating
-# reproducible VM images. Uses native YAML format for validation and IDE support.
+# This YAML config automates the macOS Ventura (13.x) OOBE (Out-of-Box Experience)
+# setup for creating reproducible VM images. Uses native YAML format for better
+# validation and IDE support.
 #
 # Usage:
-#   yaml-automation-runner --config macos-sequoia.yml --vnc localhost:5902
+#   yaml-automation-runner --config macos-ventura.yml --vnc localhost:5900
 #
 # Prerequisites:
-#   - macOS Sequoia BaseSystem.img (from fetchMacOSBaseSystem)
+#   - macOS Ventura BaseSystem.img (from fetchMacOSBaseSystem)
 #   - OpenCore bootloader configured
 #   - InstallAssistant.pkg ISO mounted
 #   - run_offline.sh ISO mounted at /Volumes/run_offline/
@@ -19,20 +20,13 @@
 #   - Username: admin
 #   - Password: admin
 #
-# Key differences from Sonoma:
-#   - Boot wait reduced from 45s to 30s (faster boot)
-#   - Apple Account sign-in confirmation popup (NEW)
-#   - Siri setup 2-screen flow (NEW)
-#   - Update Mac Automatically screen (NEW)
-#
 # References:
-#   - Sonoma config: macos-sonoma.yml
-#   - Lume Sequoia: https://github.com/trycua/cua/blob/main/libs/lume/src/Resources/unattended-presets/sequoia.yml
 #   - Schema: YAML-AUTOMATION-SCHEMA.md
+#   - OSX-KVM: https://github.com/kholia/OSX-KVM
 
 # Seconds to wait after VM boots before starting automation
-# Sequoia boots faster than Sonoma due to optimizations
-boot_wait: 30
+# Ventura takes longer to boot than newer versions due to OpenCore initialization
+boot_wait: 60
 
 boot_commands:
   # ============================================
@@ -254,7 +248,7 @@ boot_commands:
   # ============================================
 
   # This is the most timing-sensitive part - if the VM is too slow,
-  # account creation can fail
+  # account creation can fail.
 
   - wait:
       text: 'Create a Computer Account'
@@ -296,35 +290,7 @@ boot_commands:
   - delay: 5
 
   # ============================================
-  # Stage 12: Apple Account Sign-In (NEW in Sequoia)
-  # ============================================
-
-  # Sequoia adds an Apple Account sign-in screen with confirmation popup
-  - wait:
-      text: 'Sign In with Your Apple'
-      timeout: 60
-
-  - delay: 2
-
-  # Click "Set Up Later" to skip
-  - click: 'Set Up Later'
-  - delay: 2
-
-  # NEW: Confirmation popup "Are you sure you want to skip?"
-  - wait:
-      text: "Don't Skip"
-      timeout: 30
-
-  - delay: 1
-
-  # Tab to "Skip" button and press enter
-  - key: tab
-  - delay: 1
-  - key: enter
-  - delay: 3
-
-  # ============================================
-  # Stage 13: Enable Location Services
+  # Stage 12: Enable Location Services
   # ============================================
 
   - wait:
@@ -343,7 +309,7 @@ boot_commands:
   - delay: 2
 
   # ============================================
-  # Stage 14: Location Services Confirmation
+  # Stage 13: Location Services Confirmation
   # ============================================
 
   - wait:
@@ -359,7 +325,7 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 15: Select Time Zone
+  # Stage 14: Select Time Zone
   # ============================================
 
   - wait:
@@ -386,7 +352,7 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 16: Analytics
+  # Stage 15: Analytics
   # ============================================
 
   - wait:
@@ -410,13 +376,13 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 17: Screen Time
+  # Stage 16: Screen Time
   # ============================================
 
-  # Screen Time can have a longer delay in Sequoia while checking iCloud status
+  # Screen Time can have a delay while checking iCloud status
   - wait:
       text: 'Screen Time'
-      timeout: 300
+      timeout: 120
 
   - delay: 5
 
@@ -427,46 +393,7 @@ boot_commands:
   - delay: 3
 
   # ============================================
-  # Stage 18: Siri Setup (NEW in Sequoia - 2 screens)
-  # ============================================
-
-  # Screen 1: Enable Siri
-  - wait:
-      text: 'Siri'
-      timeout: 300
-
-  - delay: 1
-
-  # Continue to enable Siri
-  - click: 'Continue'
-  - delay: 3
-
-  # Screen 2: Select a Siri Voice
-  - wait:
-      text: 'Select a Siri Voice'
-      timeout: 60
-
-  - delay: 1
-
-  # Choose default voice
-  - click: 'Choose For Me'
-  - delay: 3
-
-  # Screen 3: Improve Siri & Dictation
-  - wait:
-      text: 'Improve Siri'
-      timeout: 60
-
-  - delay: 1
-
-  # Decline sharing Siri data
-  - click: 'Not Now'
-  - delay: 1
-  - click: 'Continue'
-  - delay: 3
-
-  # ============================================
-  # Stage 19: Choose Your Look (Light/Dark Mode)
+  # Stage 17: Choose Your Look (Light/Dark Mode)
   # ============================================
 
   - wait:
@@ -482,24 +409,10 @@ boot_commands:
 
   - delay: 1
   - key: space
-  - delay: 3
-
-  # ============================================
-  # Stage 20: Update Mac Automatically (NEW in Sequoia)
-  # ============================================
-
-  - wait:
-      text: 'Update Mac Automatically'
-      timeout: 60
-
-  - delay: 1
-
-  # Continue with default settings
-  - click: 'Continue'
   - delay: 5
 
   # ============================================
-  # Stage 21: Desktop Setup Complete - Enable SSH
+  # Stage 18: Desktop Setup Complete - Enable SSH
   # ============================================
 
   # Wait for Finder to appear (indicates desktop is ready)
@@ -546,7 +459,7 @@ boot_commands:
   - delay: 2
 
   # ============================================
-  # Stage 22: Enable SSH (Remote Login)
+  # Stage 19: Enable SSH (Remote Login)
   # ============================================
 
   # Enable Remote Login using launchctl
@@ -571,8 +484,6 @@ boot_commands:
   # - User account: admin / admin
   # - SSH enabled on port 22
   # - Time zone: UTC
-  # - Siri enabled with default voice
-  # - Auto-updates enabled (default)
   # - No iCloud/Apple ID configured
   # - Analytics disabled
 

--- a/shells/default.nix
+++ b/shells/default.nix
@@ -52,7 +52,9 @@
             ]
             ++ pkgs.lib.optionals (pkgs.stdenv.system == "x86_64-linux") [
               dmd
-            ];
+            ]
+            ++ config.pre-commit.settings.enabledPackages
+            ++ [ config.pre-commit.settings.package ];
 
           shellHook = ''
             export REPO_ROOT="$PWD"

--- a/vm-images/default.nix
+++ b/vm-images/default.nix
@@ -56,7 +56,7 @@
 #               majorVersion = 14;
 #               sha256 = "sha256-...";
 #             };
-#             automationConfig = ./configs/macos-sonoma.yml;
+#             automationConfig = vmImages.automationConfigs.macos-sonoma;
 #           };
 #
 #           # Example: Build a Windows VM
@@ -122,6 +122,11 @@
 #
 # Automation:
 #   - yaml-automation-runner (the automation engine package)
+#   - automationConfigs.macos-ventura (YAML config for macOS Ventura OOBE)
+#   - automationConfigs.macos-sonoma (YAML config for macOS Sonoma OOBE)
+#   - automationConfigs.macos-sequoia (YAML config for macOS Sequoia OOBE)
+#   - automationConfigs.macos-tahoe (YAML config for macOS Tahoe OOBE)
+#   - automationConfigs.windows-11 (YAML config for Windows 11 OOBE)
 #
 # =============================================================================
 # References:
@@ -330,6 +335,31 @@ in
   # The YAML automation runner for GUI automation via VNC + OCR
   # This is either the provided yaml-automation-runner or auto-created from packages/vm-automation
   yaml-automation-runner = resolvedYamlAutomationRunner;
+
+  # ==========================================================================
+  # Automation Configs
+  # ==========================================================================
+
+  # Pre-built YAML automation configs for unattended OS installation.
+  # These configs automate the OOBE (Out-of-Box Experience) setup via VNC + OCR,
+  # creating VMs with SSH enabled and admin/admin credentials.
+  #
+  # Usage:
+  #   vmImages.darwin.makeDarwinVM {
+  #     automationConfig = vmImages.automationConfigs.macos-sequoia;
+  #     ...
+  #   };
+  automationConfigs =
+    let
+      configsDir = ../packages/vm-automation/configs;
+    in
+    {
+      macos-ventura = configsDir + /macos-ventura.yml;
+      macos-sonoma = configsDir + /macos-sonoma.yml;
+      macos-sequoia = configsDir + /macos-sequoia.yml;
+      macos-tahoe = configsDir + /macos-tahoe.yml;
+      windows-11 = configsDir + /windows-11.yml;
+    };
 
   # ==========================================================================
   # Raw module access (for advanced use cases)


### PR DESCRIPTION
Migrate production-ready macOS automation configs from fleets repo. These configs automate the full Setup Assistant flow for creating reproducible VM images via VNC + OCR.

New configs added:
- macos-ventura.yml: Ventura (13.x) - 19 stages
- macos-sonoma.yml: Sonoma (14.x) - 20 stages
- macos-tahoe.yml: Tahoe (16.x) - 23 stages

Updated:
- macos-sequoia.yml: Replaced 98-line example with 595-line production config
- README.md: Document all configs and native YAML format
- YAML-AUTOMATION-SCHEMA.md: Schema documentation

Exposed configs through vmImages.automationConfigs API so consumers can reference them as vmImages.automationConfigs.macos-sequoia instead of hardcoding internal paths.