### PR TITLE
build(packages/secret): Use `age` instead of `rage`

### DIFF
--- a/packages/secret/default.nix
+++ b/packages/secret/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 let
-  agenix = inputs'.agenix.packages.agenix.override { ageBin = "${pkgs.rage}/bin/rage"; };
+  agenix = inputs'.agenix.packages.agenix;
 in
 pkgs.writeShellApplication {
   name = "secret";


### PR DESCRIPTION
This fixes the following issue:

    secret -- --machine=my-machine --service=some-service --secret=some-secret -r
    rekeying some-secret.age...
    Type passphrase for OpenSSH key '~/.ssh/id_ed25519':
    Type passphrase for OpenSSH key '~/.ssh/id_ed25519':
    rekeying some-secret.age...
    error: the argument '--output <OUTPUT>' cannot be used multiple times

    Usage: rage [--encrypt] (-r RECIPIENT | -R PATH)... [-i IDENTITY] [-a] [-o OUTPUT] [INPUT]
          rage [--encrypt] --passphrase [-a] [-o OUTPUT] [INPUT]
          rage --decrypt [-i IDENTITY] [-o OUTPUT] [INPUT]