### PR TITLE
build(packages/mcl): Reduce nix instances in closure

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -14,8 +14,19 @@
       legacyPackages = {
         inputs = {
           nixpkgs = rec {
-            inherit (pkgs) cachix nix-eval-jobs;
+            inherit (pkgs) nix-eval-jobs;
             nix = nix-eval-jobs.passthru.nix;
+            cachix =
+              let
+                customHaskellPackages = pkgs.haskellPackages.override {
+                  overrides = hself: hsuper: {
+                    hercules-ci-cnix-store = hsuper.hercules-ci-cnix-store.override {
+                      inherit nix;
+                    };
+                  };
+                };
+              in
+              customHaskellPackages.cachix.bin;
             nix-fast-build = pkgs.nix-fast-build.override { inherit nix-eval-jobs; };
           };
           agenix = inputs'.agenix.packages;

--- a/packages/mcl/default.nix
+++ b/packages/mcl/default.nix
@@ -4,6 +4,7 @@
   pkgs,
   nix,
   nix-eval-jobs,
+  cachix,
   ...
 }:
 let
@@ -13,6 +14,7 @@ let
     [
       nix
       nix-eval-jobs
+      cachix
     ]
     ++ (with pkgs; [
       gitMinimal
@@ -21,7 +23,6 @@ let
       xorg.xrandr
       alejandra
       openssh
-      cachix
     ])
     ++ lib.optionals (isLinux && isx86) [
       dmidecode
@@ -53,7 +54,7 @@ pkgs.buildDubPackage rec {
     ) ./.;
   };
 
-  inherit dCompiler;
+  compiler = dCompiler;
 
   dubLock = ./dub-lock.json;
 


### PR DESCRIPTION
## Summary

- **Eliminate duplicate nix version**: Override `cachix` to rebuild `hercules-ci-cnix-store` against `nix-eval-jobs.passthru.nix` (nix 2.32.4) instead of the pinned `nixVersions.nix_2_28` (nix 2.28.5), removing ~36 MiB of redundant nix-2.28.5 closure entries
- **Fix D compiler include leak**: Rename `inherit dCompiler` to `compiler = dCompiler` so `buildDubPackage` uses the explicitly passed `ldc-binary-1_38_0` instead of defaulting to `pkgs.ldc` (1.41.0), whose 18.8 MiB `include` output was leaking into the runtime closure
- **Fix ignored `cachix` parameter**: Add `cachix` to explicit function args in `mcl/default.nix` so the overridden version from `packages/default.nix` is used instead of `pkgs.cachix` via `with pkgs`

## Test plan

- [ ] `nix build .#mcl` builds successfully
- [ ] `nix path-info -r .#mcl | grep 'nix-2.28'` returns nothing (nix-2.28.5 eliminated)
- [ ] `nix path-info -r .#mcl | grep 'ldc.*include'` returns nothing (ldc includes eliminated)
- [ ] Verify closure size decreased vs main (`nix path-info -sSh .#mcl`)
- [ ] Smoke-test `nix run .#mcl -- --help`