### PR TITLE
fix(setup-nix): detect Nix availability instead of checking runner.environment

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -59,9 +59,21 @@ runs:
         gh api /rate_limit | jq || true
         echo "::endgroup::"
 
+    - name: Check if Nix is available
+      id: check-nix
+      shell: bash
+      run: |
+        if command -v nix &>/dev/null; then
+          echo "has_nix=true" >> "$GITHUB_OUTPUT"
+          echo "Nix is already installed: $(nix --version)"
+        else
+          echo "has_nix=false" >> "$GITHUB_OUTPUT"
+          echo "Nix is not installed, will install it"
+        fi
+
     - name: Install Nix
       uses: cachix/install-nix-action@v31
-      if: ${{ runner.environment == 'github-hosted' }}
+      if: steps.check-nix.outputs.has_nix != 'true'
       with:
         install_url: ${{ inputs.nix-version != '' && format('https://releases.nixos.org/nix/nix-{0}/install', inputs.nix-version) || '' }}
 


### PR DESCRIPTION
## Problem

The `Install Nix` step uses `runner.environment == 'github-hosted'` to decide whether to install Nix. This skips installation on **any** self-hosted runner, assuming Nix is already present.

Cirrus CI runners (e.g. `ghcr.io/cirruslabs/macos-runner:tahoe`) are registered as self-hosted but **don't have Nix pre-installed**, causing downstream steps to fail with `nix-env: command not found`.

## Fix

Replace the `runner.environment` check with a runtime `command -v nix` probe. Nix is now installed whenever it's not already available, regardless of runner type.

This is needed for https://github.com/blocksense-network/agent-harbor/pull/402.