### PR TITLE
feat(desktop-vms): add QXL video memory and multi-head options

### DIFF
--- a/modules/virtualisation/desktop-vms.nix
+++ b/modules/virtualisation/desktop-vms.nix
@@ -138,6 +138,10 @@
           sharedFolders = vmCfg.sharedFolders;
           display = vmCfg.display;
           videoModel = vmCfg.videoModel;
+          videoRam = vmCfg.videoRam;
+          videoVram = vmCfg.videoVram;
+          videoVgamem = vmCfg.videoVgamem;
+          videoHeads = vmCfg.videoHeads;
           diskPool = vmCfg.storagePool;
           diskVolume = "${name}.qcow2";
           osType = vmCfg.osType;
@@ -357,6 +361,48 @@
 
                 Reference: https://libvirt.org/formatdomain.html#video-devices
               '';
+            };
+
+            videoRam = mkOption {
+              type = types.nullOr types.int;
+              default = null;
+              description = ''
+                Primary surface memory in KB for the video device.
+                Only applicable to QXL. Default (when null) is 65536 (64MB).
+                For multi-monitor setups, increase proportionally.
+              '';
+              example = 524288;
+            };
+
+            videoVram = mkOption {
+              type = types.nullOr types.int;
+              default = null;
+              description = ''
+                Secondary surface memory in KB for the video device.
+                Only applicable to QXL. Default (when null) is 65536 (64MB).
+                For 4K displays, use at least 128MB (131072) per head.
+              '';
+              example = 524288;
+            };
+
+            videoVgamem = mkOption {
+              type = types.nullOr types.int;
+              default = null;
+              description = ''
+                VGA framebuffer memory in KB for the video device.
+                Only applicable to QXL. Default (when null) is 16384 (16MB).
+              '';
+              example = 65536;
+            };
+
+            videoHeads = mkOption {
+              type = types.nullOr types.int;
+              default = null;
+              description = ''
+                Number of display outputs (monitor heads).
+                Only applicable to QXL. Default (when null) is 1.
+              '';
+              example = 4;
             };
 
             sharedFolders = mkOption {

--- a/modules/virtualisation/desktop-vms/lib.nix
+++ b/modules/virtualisation/desktop-vms/lib.nix
@@ -313,13 +313,32 @@ rec {
 
   # Generate video device configuration
   # Reference: https://libvirt.org/formatdomain.html#video-devices
+  #
+  # For QXL, the model supports these attributes (values in KB):
+  #   ram     - Primary surface memory (default 65536 = 64MB)
+  #   vram    - Secondary surface memory (default 65536 = 64MB)
+  #   vgamem  - VGA framebuffer memory (default 16384 = 16MB)
+  #   heads   - Number of display outputs (default 1)
   generateVideoXml =
     {
       type ? "virtio",
+      ram ? null,
+      vram ? null,
+      vgamem ? null,
+      heads ? null,
     }:
+    let
+      attrs = {
+        inherit type;
+      }
+      // lib.optionalAttrs (ram != null) { inherit ram; }
+      // lib.optionalAttrs (vram != null) { inherit vram; }
+      // lib.optionalAttrs (vgamem != null) { inherit vgamem; }
+      // lib.optionalAttrs (heads != null) { inherit heads; };
+    in
     ''
       <video>
-        <model type="${type}"/>
+        ${xmlElement "model" attrs null}
       </video>'';
 
   # Generate a complete libvirt domain XML for a desktop VM
@@ -363,6 +382,10 @@ rec {
       sharedFolders ? { },
       display ? "spice",
       videoModel ? "virtio",
+      videoRam ? null,
+      videoVram ? null,
+      videoVgamem ? null,
+      videoHeads ? null,
       diskPool ? "default",
       diskVolume,
       osType ? "windows",
@@ -494,7 +517,13 @@ rec {
       networkXml = generateNetworkXml { };
 
       # Video
-      videoXml = generateVideoXml { type = videoModel; };
+      videoXml = generateVideoXml {
+        type = videoModel;
+        ram = videoRam;
+        vram = videoVram;
+        vgamem = videoVgamem;
+        heads = videoHeads;
+      };
 
       # Input devices
       inputXml = ''


### PR DESCRIPTION
## Summary
- Add `videoRam`, `videoVram`, `videoVgamem`, and `videoHeads` options to the desktop-vms VM submodule
- Extend `generateVideoXml` in `lib.nix` to emit QXL-specific model attributes (ram, vram, vgamem, heads) when set
- All new options default to `null` (preserving existing behavior)

This enables configuring QXL for multi-monitor and high-resolution setups (e.g. 4x 4K displays) by increasing VRAM and head count beyond the default 64MB/1-head limits.

## Test plan
- [ ] Build with default values (all null) — should produce identical XML to before
- [ ] Set `videoHeads = 4; videoRam = 524288; videoVram = 524288;` — verify generated XML includes the attributes
- [ ] Boot a Windows VM with QXL multi-head config and confirm multi-monitor works in SPICE viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)