### PR TITLE
fix(ci): update existing sticky comment instead of deleting and recreating

### DIFF
--- a/.github/sticky-comment/action.yml
+++ b/.github/sticky-comment/action.yml
@@ -36,15 +36,17 @@ runs:
           });
           const existing = comments.find(c => c.body.includes(marker));
           if (existing) {
-            await github.rest.issues.deleteComment({
+            await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
             });
           }
-          await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-            body,
-          });


### PR DESCRIPTION
## Summary

- Use `updateComment` when a sticky comment already exists instead of deleting and creating a new one
- This preserves the comment's position in the PR timeline

## Test plan

- [x] Trigger a CI run on a test PR and verify the sticky comment is updated in-place rather than deleted and recreated