### PR TITLE
Override nix in disko and nixos-anywhere packages

### DIFF
--- a/checks/packages-ci-matrix.nix
+++ b/checks/packages-ci-matrix.nix
@@ -32,6 +32,10 @@
         // optionalAttrs (system == "x86_64-linux" || system == "aarch64-darwin") {
           inherit (self'.legacyPackages.inputs.ethereum-nix) geth;
         }
+        // optionalAttrs isLinux {
+          disko = self'.legacyPackages.inputs.disko.default;
+          nixos-anywhere = self'.legacyPackages.inputs.nixos-anywhere.default;
+        }
         // optionalAttrs (system == "x86_64-linux") {
           inherit (pkgs) terraform;
           inherit (self'.legacyPackages.inputs.terranix) terranix;

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -10,24 +10,32 @@
       inherit (lib) optionalAttrs versionAtLeast;
       inherit (pkgs.stdenv.hostPlatform) system isLinux;
     in
+    let
+      nix = pkgs.nix-eval-jobs.passthru.nix;
+      overrideNix = pkg: pkg.override { inherit nix; };
+    in
     rec {
       legacyPackages = {
         inputs = {
           nixpkgs = rec {
             inherit (pkgs) cachix nix-eval-jobs;
-            nix = nix-eval-jobs.passthru.nix;
+            inherit nix;
             nix-fast-build = pkgs.nix-fast-build.override { inherit nix-eval-jobs; };
           };
           agenix = inputs'.agenix.packages;
           devenv = inputs'.devenv.packages;
-          disko = inputs'.disko.packages;
+          disko = inputs'.disko.packages // {
+            default = overrideNix inputs'.disko.packages.default;
+          };
           dlang-nix = inputs'.dlang-nix.packages;
           ethereum-nix = inputs'.ethereum-nix.packages;
           fenix = inputs'.fenix.packages;
           git-hooks-nix = inputs'.git-hooks-nix.packages;
           microvm = inputs'.microvm.packages;
           nix-fast-build = inputs'.nix-fast-build.packages;
-          nixos-anywhere = inputs'.nixos-anywhere.packages;
+          nixos-anywhere = inputs'.nixos-anywhere.packages // {
+            default = overrideNix inputs'.nixos-anywhere.packages.default;
+          };
           terranix = inputs'.terranix.packages;
           treefmt-nix = inputs'.treefmt-nix.packages;
         };


### PR DESCRIPTION
## Summary
- Pin disko and nixos-anywhere to use the same nix version as `nix-eval-jobs` (via `nix-eval-jobs.passthru.nix`)
- Prevents version mismatch where these packages would bring their own nix onto `$PATH` (e.g. in devshells)

## Test plan
- [x] `nix eval .#legacyPackages.x86_64-linux.inputs.disko.default.name` evaluates successfully
- [x] `nix eval .#legacyPackages.x86_64-linux.inputs.nixos-anywhere.default.name` evaluates successfully