### PR TITLE
Use nixpkgs overlay to pin nix version

### DIFF
--- a/checks/packages-ci-matrix.nix
+++ b/checks/packages-ci-matrix.nix
@@ -14,11 +14,44 @@
     let
       inherit (lib) optionalAttrs;
       inherit (pkgs.stdenv.hostPlatform) system isLinux;
+
+      expectedNixVersion = pkgs.nix.version;
+
+      # Eval-time check: verify that all known sources of nix version agree.
+      # pkgs.nix is set by the overlay to nix-eval-jobs.passthru.nix.
+      # Other packages (nixos-rebuild-ng, nix-fast-build, disko, nixos-anywhere)
+      # get nix from pkgs.nix via callPackage or explicit override.
+      nixVersionChecks = {
+        "pkgs.nix" = pkgs.nix.version;
+        "nix-eval-jobs" = pkgs.nix-eval-jobs.passthru.nix.version;
+      };
+
+      traceVersions = lib.foldl' (
+        acc: name:
+        let
+          version = nixVersionChecks.${name};
+          status = if version == expectedNixVersion then "OK" else "FAIL";
+        in
+        builtins.trace "${status}: ${name} -> nix ${version}" acc
+      ) true (lib.attrNames nixVersionChecks);
+
+      mismatches = lib.filterAttrs (_: v: v != expectedNixVersion) nixVersionChecks;
+
+      nix-version-consistency =
+        assert traceVersions;
+        assert
+          mismatches == { }
+          || throw (
+            "Nix version mismatch! Expected ${expectedNixVersion}, got:\n"
+            + lib.concatStrings (lib.mapAttrsToList (name: version: "  - ${name}: ${version}\n") mismatches)
+          );
+        pkgs.runCommand "nix-version-consistency" { allowSubstitutes = false; } "touch $out";
     in
     rec {
       checks =
         self'.packages
         // {
+          inherit nix-version-consistency;
           inherit (self'.legacyPackages) rustToolchain;
           inherit (self'.legacyPackages.inputs.dlang-nix) dub;
           inherit (self'.legacyPackages.inputs.nixpkgs)

--- a/checks/packages-ci-matrix.nix
+++ b/checks/packages-ci-matrix.nix
@@ -34,8 +34,7 @@
           inherit (self'.legacyPackages.inputs.ethereum-nix) geth;
         }
         // optionalAttrs isLinux {
-          disko = self'.legacyPackages.inputs.disko.default;
-          nixos-anywhere = self'.legacyPackages.inputs.nixos-anywhere.default;
+          inherit (self'.legacyPackages.inputs) disko nixos-anywhere;
         }
         // optionalAttrs (system == "x86_64-linux") {
           inherit (pkgs) terraform;

--- a/flake.nix
+++ b/flake.nix
@@ -281,6 +281,28 @@
           _module.args.pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;
+            overlays = [
+              (
+                final: prev:
+                let
+                  unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
+                in
+                {
+                  nix = prev.nix-eval-jobs.passthru.nix;
+                  cachix = unstable.cachix.override {
+                    haskellPackages = unstable.haskellPackages.override {
+                      overrides = hfinal: hprev: {
+                        hercules-ci-cnix-store = hprev.hercules-ci-cnix-store.overrideAttrs (old: {
+                          passthru = old.passthru // {
+                            nixPackage = final.nix;
+                          };
+                        });
+                      };
+                    };
+                  };
+                }
+              )
+            ];
           };
         };
 

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -11,35 +11,30 @@
       inherit (pkgs.stdenv.hostPlatform) system isLinux;
     in
     let
-      nix = pkgs.nix-eval-jobs.passthru.nix;
-      overrideNix = pkg: pkg.override { inherit nix; };
+      overrideNix = pkg: pkg.override { inherit (pkgs) nix; };
     in
     rec {
       legacyPackages = {
         inputs = {
-          nixpkgs = rec {
-            inherit (pkgs) nix-eval-jobs;
-            cachix = pkgs.haskell.lib.justStaticExecutables (
-              pkgs.haskellPackages.cachix.override { inherit nix; }
-            );
-            inherit nix;
-            nixos-rebuild-ng = overrideNix pkgs.nixos-rebuild-ng;
-            nix-fast-build = pkgs.nix-fast-build.override { inherit nix-eval-jobs; };
+          nixpkgs = {
+            inherit (pkgs)
+              cachix
+              nix
+              nix-eval-jobs
+              nix-fast-build
+              nixos-rebuild-ng
+              ;
           };
           agenix = inputs'.agenix.packages;
           devenv = inputs'.devenv.packages;
-          disko = inputs'.disko.packages // {
-            default = overrideNix inputs'.disko.packages.default;
-          };
+          disko = overrideNix inputs'.disko.packages.default;
           dlang-nix = inputs'.dlang-nix.packages;
           ethereum-nix = inputs'.ethereum-nix.packages;
           fenix = inputs'.fenix.packages;
           git-hooks-nix = inputs'.git-hooks-nix.packages;
           microvm = inputs'.microvm.packages;
           nix-fast-build = inputs'.nix-fast-build.packages;
-          nixos-anywhere = inputs'.nixos-anywhere.packages // {
-            default = overrideNix inputs'.nixos-anywhere.packages.default;
-          };
+          nixos-anywhere = overrideNix inputs'.nixos-anywhere.packages.default;
           terranix = inputs'.terranix.packages;
           treefmt-nix = inputs'.treefmt-nix.packages;
         };
@@ -65,7 +60,6 @@
         random-alerts = pkgs.callPackage ./random-alerts { };
         mcl = pkgs.callPackage ./mcl {
           dCompiler = inputs'.dlang-nix.packages."ldc-binary-1_38_0";
-          inherit (legacyPackages.inputs.nixpkgs) cachix nix nix-eval-jobs;
         };
       }
       // optionalAttrs (system == "x86_64-linux" || system == "aarch64-darwin") {


### PR DESCRIPTION
## Summary
- Add a nixpkgs overlay that sets `nix = nix-eval-jobs.passthru.nix`, ensuring all packages in `pkgs` use a consistent nix version
- Simplify `packages/default.nix` by removing individual overrides for `cachix` and `nixos-rebuild-ng` — the overlay handles them automatically
- `disko` and `nixos-anywhere` still need explicit `.override { inherit nix; }` since they construct their own `pkgs` instances
- Remove explicit `cachix`/`nix`/`nix-eval-jobs` args from `mcl` callPackage since `pkgs` now provides the correct versions

## Test plan
- [x] `nix eval .#legacyPackages.x86_64-linux.inputs.nixpkgs.nix.version` returns `"2.32.6"`
- [x] All re-exported packages (`cachix`, `nix-eval-jobs`, `nix-fast-build`, `nixos-rebuild-ng`) evaluate
- [x] `disko` and `nixos-anywhere` overrides evaluate
- [x] `mcl` package evaluates without explicit nix args