### PR TITLE
Fix: skip PR comment steps on non-PR events to unblock deploys

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -77,6 +77,7 @@ jobs:
           echo "mcl_flake_cmd=nix run --accept-flake-config github:metacraft-labs/nixos-modules/${WORKFLOW_SHA}#mcl" >> $GITHUB_OUTPUT
 
   post-initial-comment:
+    if: github.event_name == 'pull_request'
     runs-on: ${{ inputs.non-nix-runner }}
     steps:
       - name: 'Post initial package status comment'
@@ -114,7 +115,7 @@ jobs:
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} shard-matrix
 
       - name: Post CI matrix comment
-        if: steps.generate-matrix.outputs.full_matrix
+        if: github.event_name == 'pull_request' && steps.generate-matrix.outputs.full_matrix
         uses: metacraft-labs/nixos-modules/.github/sticky-comment@main
         with:
           path: comment.md
@@ -187,6 +188,7 @@ jobs:
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} print-table
 
       - name: Post CI matrix comment
+        if: github.event_name == 'pull_request'
         uses: metacraft-labs/nixos-modules/.github/sticky-comment@main
         with:
           path: comment.md
@@ -262,6 +264,7 @@ jobs:
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} print-table
 
       - name: Update GitHub Comment
+        if: github.event_name == 'pull_request'
         uses: metacraft-labs/nixos-modules/.github/sticky-comment@main
         with:
           path: comment.md


### PR DESCRIPTION
## Summary
- Add `if: github.event_name == 'pull_request'` to all 4 `sticky-comment` steps in the reusable CI matrix workflow
- The `sticky-comment` action fails with `HttpError: Not Found` on push/workflow_dispatch events since there's no PR to comment on
- This failure cascades through `post-initial-comment` → `Merge matrices` → `Final Results`, blocking the `Deploy` step which lives inside the `results` job

## Impact
All repos using this reusable workflow (e.g. `metacraft-labs/infra`) have been unable to deploy via Cachix Deploy on pushes to main.

## Test plan
- [ ] Merge and re-trigger CI on `metacraft-labs/infra` main branch
- [ ] Verify deploy job runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)