### PR TITLE
feat: Add nix-topology shared modules and reusable nix-diff workflow

### DIFF
--- a/.github/workflows/reusable-nix-diff.yml
+++ b/.github/workflows/reusable-nix-diff.yml
@@ -1,0 +1,77 @@
+name: 'Nix Diff'
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'JSON-encoded list of runner labels'
+        default: '["self-hosted", "Linux", "x86-64-v2"]'
+        required: false
+        type: string
+      machines-attr:
+        description: 'Flake attribute to enumerate machines (must be an attrset of derivations)'
+        default: 'legacyPackages.x86_64-linux.bareMetalMachines'
+        required: false
+        type: string
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        description: 'Cachix auth token'
+        required: true
+      NIX_GITHUB_TOKEN:
+        description: GitHub token to add as access-token in nix.conf
+        required: false
+      NIX_GITLAB_TOKEN:
+        description: GitLab token to add as access-token in nix.conf
+        required: false
+
+jobs:
+  nix-diff:
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ fromJSON(inputs.runner) }}
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Nix
+        uses: metacraft-labs/nixos-modules/.github/setup-nix@main
+        with:
+          push-to-cache: false
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
+          nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
+          nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
+
+      - name: Discover machines and generate attributes
+        id: discover
+        run: |
+          echo "::group::Discovering machines"
+          machines=$(nix eval --json --accept-flake-config \
+            --option warn-dirty false \
+            --apply builtins.attrNames \
+            '.#${{ inputs.machines-attr }}')
+          echo "Found machines: $machines"
+          echo "::endgroup::"
+
+          # Generate nix-diff-action attributes YAML
+          attrs=$(echo "$machines" | jq -r \
+            '.[] | "- displayName: " + . + "\n  attribute: nixosConfigurations." + . + ".config.system.build.toplevel"')
+
+          echo "attributes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$attrs" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Diff NixOS system closures
+        uses: natsukium/nix-diff-action@v1.0.3
+        with:
+          mode: full
+          comment-strategy: update
+          build: false
+          attributes: ${{ steps.discover.outputs.attributes }}

--- a/.github/workflows/reusable-update-flake-packages.yml
+++ b/.github/workflows/reusable-update-flake-packages.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   updateFlakePackages:
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ fromJSON(inputs.runner || '["self-hosted", "nixos", "x86-64-v2", "bare-metal"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,5 +13,6 @@
     ./pharos
     ./commands.nix
     ./virtualisation/desktop-vms.nix
+    ./nix-topology
   ];
 }

--- a/modules/nix-topology/default.nix
+++ b/modules/nix-topology/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./extractors
+    ./web.nix
+  ];
+}

--- a/modules/nix-topology/extractors/default.nix
+++ b/modules/nix-topology/extractors/default.nix
@@ -1,0 +1,91 @@
+{ withSystem, ... }:
+{
+  flake.modules.nixos.nix-topology-extractors =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      inherit (lib) mkIf mkMerge;
+
+      getFileFromZip =
+        {
+          url,
+          hash,
+          path,
+          stripRoot ? true,
+        }:
+        let
+          zip = pkgs.fetchzip {
+            inherit stripRoot url hash;
+          };
+        in
+        zip + path;
+    in
+    {
+      config.topology.self.services =
+        mkIf config.topology.extractors.services.enable
+          {
+            tailscale = mkIf config.services.tailscale.enable {
+              name = "Tailscale";
+              icon = getFileFromZip {
+                url = "https://cdn.sanity.io/files/w77i7m8x/production/a426ba5f63316745e108a18a6dbbfed6970752fd.zip";
+                hash = "sha256-dcxxIKa7d6FyGQdQ3xJBoV+sSTOYcvD//UUFqTERQsw=";
+                path = "/Tailscale Logo/svg/Wht/Tailscale_icon_wht_rgb.svg";
+                stripRoot = false;
+              };
+            };
+
+            promtail = mkIf config.services.promtail.enable {
+              name = "Promtail";
+              icon = "services.loki";
+            };
+
+            prometheus-exporters-node = mkIf config.services.prometheus.exporters.node.enable {
+              name = "Prometheus node exporter";
+              icon = "services.prometheus";
+            };
+
+            gitlab = mkIf config.services.gitlab.enable {
+              name = "GitLab";
+              icon = pkgs.fetchurl {
+                url = "https://about.gitlab.com/images/press/gitlab-logo-500-rgb.svg";
+                hash = "sha256-2FIvm7g7Nbzwq25/wloxLCYSACivMIvsHdnSDhXBphU=";
+              };
+            };
+
+            vscode-server = mkIf (config.services ? vscode-server && config.services.vscode-server.enable) {
+              name = "VSCode Server";
+              icon = getFileFromZip {
+                url = "https://code.visualstudio.com/assets/branding/visual-studio-code-icons.zip";
+                hash = "sha256-ePUcc/ePGJeMw1U3LVuPDx0XDgb4PIkfCJM3zSO9gsk=";
+                path = "/vscode.svg";
+              };
+            };
+
+            ethereum = mkIf (config.services ? ethereum) {
+              name = "Ethereum services";
+              icon = pkgs.fetchurl {
+                url = "https://ethereum.org/images/assets/svgs/eth-diamond-purple.svg";
+                hash = "sha256-cyDmTiEdt0cwjMPlRuU2DULzeQt6FPugUEVzeQ4X8SQ=";
+              };
+              details = mkMerge [
+                (mkIf (config.services.ethereum ? nimbus-eth2 && config.services.ethereum.nimbus-eth2.enable or false) {
+                  Nimbus.text = "";
+                })
+                (mkIf (config.services.ethereum ? geth && config.services.ethereum.geth.enable or false) {
+                  Geth.text = "";
+                })
+                (mkIf (config.services.ethereum ? nethermind && config.services.ethereum.nethermind.enable or false) {
+                  Nethermind.text = "";
+                })
+                (mkIf (config.services.ethereum ? erigon && config.services.ethereum.erigon.enable or false) {
+                  Erigon.text = "";
+                })
+              ];
+            };
+          };
+    };
+}

--- a/modules/nix-topology/extractors/default.nix
+++ b/modules/nix-topology/extractors/default.nix
@@ -25,67 +25,70 @@
         zip + path;
     in
     {
-      config.topology.self.services =
-        mkIf config.topology.extractors.services.enable
-          {
-            tailscale = mkIf config.services.tailscale.enable {
-              name = "Tailscale";
-              icon = getFileFromZip {
-                url = "https://cdn.sanity.io/files/w77i7m8x/production/a426ba5f63316745e108a18a6dbbfed6970752fd.zip";
-                hash = "sha256-dcxxIKa7d6FyGQdQ3xJBoV+sSTOYcvD//UUFqTERQsw=";
-                path = "/Tailscale Logo/svg/Wht/Tailscale_icon_wht_rgb.svg";
-                stripRoot = false;
-              };
-            };
-
-            promtail = mkIf config.services.promtail.enable {
-              name = "Promtail";
-              icon = "services.loki";
-            };
-
-            prometheus-exporters-node = mkIf config.services.prometheus.exporters.node.enable {
-              name = "Prometheus node exporter";
-              icon = "services.prometheus";
-            };
-
-            gitlab = mkIf config.services.gitlab.enable {
-              name = "GitLab";
-              icon = pkgs.fetchurl {
-                url = "https://about.gitlab.com/images/press/gitlab-logo-500-rgb.svg";
-                hash = "sha256-2FIvm7g7Nbzwq25/wloxLCYSACivMIvsHdnSDhXBphU=";
-              };
-            };
-
-            vscode-server = mkIf (config.services ? vscode-server && config.services.vscode-server.enable) {
-              name = "VSCode Server";
-              icon = getFileFromZip {
-                url = "https://code.visualstudio.com/assets/branding/visual-studio-code-icons.zip";
-                hash = "sha256-ePUcc/ePGJeMw1U3LVuPDx0XDgb4PIkfCJM3zSO9gsk=";
-                path = "/vscode.svg";
-              };
-            };
-
-            ethereum = mkIf (config.services ? ethereum) {
-              name = "Ethereum services";
-              icon = pkgs.fetchurl {
-                url = "https://ethereum.org/images/assets/svgs/eth-diamond-purple.svg";
-                hash = "sha256-cyDmTiEdt0cwjMPlRuU2DULzeQt6FPugUEVzeQ4X8SQ=";
-              };
-              details = mkMerge [
-                (mkIf (config.services.ethereum ? nimbus-eth2 && config.services.ethereum.nimbus-eth2.enable or false) {
-                  Nimbus.text = "";
-                })
-                (mkIf (config.services.ethereum ? geth && config.services.ethereum.geth.enable or false) {
-                  Geth.text = "";
-                })
-                (mkIf (config.services.ethereum ? nethermind && config.services.ethereum.nethermind.enable or false) {
-                  Nethermind.text = "";
-                })
-                (mkIf (config.services.ethereum ? erigon && config.services.ethereum.erigon.enable or false) {
-                  Erigon.text = "";
-                })
-              ];
-            };
+      config.topology.self.services = mkIf config.topology.extractors.services.enable {
+        tailscale = mkIf config.services.tailscale.enable {
+          name = "Tailscale";
+          icon = getFileFromZip {
+            url = "https://cdn.sanity.io/files/w77i7m8x/production/a426ba5f63316745e108a18a6dbbfed6970752fd.zip";
+            hash = "sha256-dcxxIKa7d6FyGQdQ3xJBoV+sSTOYcvD//UUFqTERQsw=";
+            path = "/Tailscale Logo/svg/Wht/Tailscale_icon_wht_rgb.svg";
+            stripRoot = false;
           };
+        };
+
+        promtail = mkIf config.services.promtail.enable {
+          name = "Promtail";
+          icon = "services.loki";
+        };
+
+        prometheus-exporters-node = mkIf config.services.prometheus.exporters.node.enable {
+          name = "Prometheus node exporter";
+          icon = "services.prometheus";
+        };
+
+        gitlab = mkIf config.services.gitlab.enable {
+          name = "GitLab";
+          icon = pkgs.fetchurl {
+            url = "https://about.gitlab.com/images/press/gitlab-logo-500-rgb.svg";
+            hash = "sha256-2FIvm7g7Nbzwq25/wloxLCYSACivMIvsHdnSDhXBphU=";
+          };
+        };
+
+        vscode-server = mkIf (config.services ? vscode-server && config.services.vscode-server.enable) {
+          name = "VSCode Server";
+          icon = getFileFromZip {
+            url = "https://code.visualstudio.com/assets/branding/visual-studio-code-icons.zip";
+            hash = "sha256-ePUcc/ePGJeMw1U3LVuPDx0XDgb4PIkfCJM3zSO9gsk=";
+            path = "/vscode.svg";
+          };
+        };
+
+        ethereum = mkIf (config.services ? ethereum) {
+          name = "Ethereum services";
+          icon = pkgs.fetchurl {
+            url = "https://ethereum.org/images/assets/svgs/eth-diamond-purple.svg";
+            hash = "sha256-cyDmTiEdt0cwjMPlRuU2DULzeQt6FPugUEVzeQ4X8SQ=";
+          };
+          details = mkMerge [
+            (mkIf
+              (config.services.ethereum ? nimbus-eth2 && config.services.ethereum.nimbus-eth2.enable or false)
+              {
+                Nimbus.text = "";
+              }
+            )
+            (mkIf (config.services.ethereum ? geth && config.services.ethereum.geth.enable or false) {
+              Geth.text = "";
+            })
+            (mkIf (config.services.ethereum ? nethermind && config.services.ethereum.nethermind.enable or false)
+              {
+                Nethermind.text = "";
+              }
+            )
+            (mkIf (config.services.ethereum ? erigon && config.services.ethereum.erigon.enable or false) {
+              Erigon.text = "";
+            })
+          ];
+        };
+      };
     };
 }

--- a/modules/nix-topology/web.nix
+++ b/modules/nix-topology/web.nix
@@ -1,0 +1,41 @@
+{ ... }:
+{
+  flake.modules.nixos.nix-topology-web =
+    {
+      config,
+      lib,
+      ...
+    }:
+    let
+      cfg = config.mcl.nix-topology-web;
+    in
+    {
+      options.mcl.nix-topology-web = with lib; {
+        enable = mkEnableOption "nix-topology web interface";
+        domain = mkOption {
+          type = types.str;
+          description = "Domain name for the topology web interface";
+        };
+        topologyOutput = mkOption {
+          type = types.package;
+          description = "The nix-topology output derivation to serve";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        services.nginx = {
+          enable = true;
+          virtualHosts.${cfg.domain} = {
+            enableACME = true;
+            forceSSL = true;
+            locations."/".root = cfg.topologyOutput;
+          };
+        };
+
+        networking.firewall.allowedTCPPorts = lib.mkBefore [
+          80
+          443
+        ];
+      };
+    };
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -19,9 +19,10 @@
         inputs = {
           nixpkgs = rec {
             inherit (pkgs) nix-eval-jobs;
-            cachix = pkgs.haskell.lib.justStaticExecutables (
-              pkgs.haskellPackages.cachix.override { inherit nix; }
-            );
+            # NOTE: Do not override `nix` here — hercules-ci-cnix-store (a
+            # transitive dep) is compiled against nixpkgs' default Nix and the
+            # C++ ABI breaks when a different version is spliced in.
+            cachix = pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.cachix;
             inherit nix;
             nixos-rebuild-ng = overrideNix pkgs.nixos-rebuild-ng;
             nix-fast-build = pkgs.nix-fast-build.override { inherit nix-eval-jobs; };


### PR DESCRIPTION
## Summary

- **nix-topology-extractors**: shared NixOS module with generic service extractors (Tailscale, Promtail, Prometheus node-exporter, GitLab, VSCode Server, Ethereum) for use with [oddlama/nix-topology](https://github.com/oddlama/nix-topology)
- **nix-topology-web**: configurable nginx module (`mcl.nix-topology-web.{enable,domain,topologyOutput}`) for hosting topology visualization
- **reusable-nix-diff.yml**: reusable workflow wrapping [nix-diff-action](https://github.com/natsukium/nix-diff-action) v1.0.3 — dynamically discovers bare-metal machines via `nix eval`, then posts per-machine closure diffs as PR comments using `dix`

These modules enable both `metacraft-labs/infra` and `blocksense-network/infra` to share topology visualization and PR diff tooling. Infra-specific config (networks, physical devices) stays in each infra repo.

## Test plan

- [ ] `nix flake check` passes
- [ ] Infra repos can import `modules.nixos.nix-topology-extractors` and `modules.nixos.nix-topology-web`
- [ ] Reusable nix-diff workflow can be called from infra CI
- [ ] Verified locally: extractors detect services (tailscale, promtail, prometheus-node-exporter, vscode-server) on infra machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)