### PR TITLE
fix(terraform-ci): Fix terranix invocation in reusable workflow

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -124,7 +124,9 @@ jobs:
 
       - name: Terranix
         if: inputs.terranix
-        run: nix develop --accept-flake-config --command terranix --working-directory ${{ inputs.working_directory }}
+        run: |
+          cd ${{ inputs.working_directory }}
+          nix develop --accept-flake-config --command bash -c 'terranix > config.tf.json'
 
       - name: Format check
         run: nix develop --accept-flake-config --command tofu fmt -check -recursive ${{ inputs.working_directory }}/
@@ -270,7 +272,9 @@ jobs:
 
       - name: Terranix
         if: inputs.terranix
-        run: nix develop --accept-flake-config --command terranix --working-directory ${{ inputs.working_directory }}
+        run: |
+          cd ${{ inputs.working_directory }}
+          nix develop --accept-flake-config --command bash -c 'terranix > config.tf.json'
 
       - name: Plan
         uses: dflook/tofu-plan@2b0b0a4074e31e43c19ca5a0e76d8f8956e6cc27 # v2
@@ -405,7 +409,9 @@ jobs:
 
       - name: Terranix
         if: inputs.terranix
-        run: nix develop --accept-flake-config --command terranix --working-directory ${{ inputs.working_directory }}
+        run: |
+          cd ${{ inputs.working_directory }}
+          nix develop --accept-flake-config --command bash -c 'terranix > config.tf.json'
 
       - name: Apply
         uses: dflook/tofu-apply@3d5bdd8e0ccc0e04e6b0e18f1a76e8e17a22e92a # v2


### PR DESCRIPTION
## Summary
- `terranix` does not have a `--working-directory` flag. It takes a file path as positional argument and defaults to `./config.nix`.
- The previous invocation `terranix --working-directory <dir>` was interpreted as `terranix` with file path `--working-directory`, failing with `"--working-directory does not exist"`.
- Fix: `cd` into the working directory and run `terranix` (finds `config.nix`), redirecting stdout to `config.tf.json`.
- Affects all 3 terranix steps (offline-checks, credentialed-plan, apply).

## Test plan
- [ ] Consuming repo (metacraft/infra) calls reusable workflow with `terranix: true` and per-directory modules — terranix generates `config.tf.json` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)