### PR TITLE
fix(terraform-ci): Update dflook/tofu-plan and tofu-apply pins to v2.2.3

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -279,7 +279,7 @@ jobs:
           nix develop --accept-flake-config --command bash -c "terranix --pkgs '$NIXPKGS' > config.tf.json"
 
       - name: Plan
-        uses: dflook/tofu-plan@2b0b0a4074e31e43c19ca5a0e76d8f8956e6cc27 # v2
+        uses: dflook/tofu-plan@3f5dc358343fb58cd60f83b019e810315aa8258f # v2.2.3
         id: plan
         with:
           path: ${{ inputs.working_directory }}
@@ -417,7 +417,7 @@ jobs:
           nix develop --accept-flake-config --command bash -c "terranix --pkgs '$NIXPKGS' > config.tf.json"
 
       - name: Apply
-        uses: dflook/tofu-apply@3d5bdd8e0ccc0e04e6b0e18f1a76e8e17a22e92a # v2
+        uses: dflook/tofu-apply@c254eb5b2e48978c05587373100d26b604c2182d # v2.2.3
         id: apply
         with:
           path: ${{ inputs.working_directory }}


### PR DESCRIPTION
## Summary
- The previous SHA pins for `dflook/tofu-plan` and `dflook/tofu-apply` were invalid — CI failed with "Unable to resolve action"
- Updated to latest stable release **v2.2.3** with correct commit SHA pins

| Action | Old SHA (invalid) | New SHA (v2.2.3) |
|--------|-------------------|------------------|
| `dflook/tofu-plan` | `2b0b0a40...` | `3f5dc358...` |
| `dflook/tofu-apply` | `3d5bdd8e...` | `c254eb5b...` |

## Test plan
- [ ] metacraft/infra PR #951 — credentialed-plan jobs should resolve the action (still expected to fail on missing credentials, but no longer on action resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)