### PR TITLE
fix(terraform-ci): Skip credentialed jobs when no credentials configured

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -237,7 +237,10 @@ jobs:
   # Fork PRs are excluded entirely — this is the fork-PR guard.
   # ---------------------------------------------------------------------------
   credentialed-plan:
-    if: inputs.mode == 'pr' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      inputs.mode == 'pr'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && (inputs.credentials_env_name != '' || inputs.agenix_plan_secret_path != '')
     needs: offline-checks
     runs-on: ${{ fromJSON(inputs.runner) }}
     steps:
@@ -374,7 +377,9 @@ jobs:
   # Requires GitHub Environment "production" approval gate.
   # ---------------------------------------------------------------------------
   apply:
-    if: inputs.mode == 'apply'
+    if: >-
+      inputs.mode == 'apply'
+      && (inputs.credentials_env_name != '' || inputs.agenix_apply_secret_path != '')
     needs: offline-checks
     runs-on: ${{ fromJSON(inputs.runner) }}
     environment: production
@@ -438,7 +443,9 @@ jobs:
   # Runs tofu plan with -detailed-exitcode and opens an issue if drift found.
   # ---------------------------------------------------------------------------
   drift-check:
-    if: inputs.mode == 'drift'
+    if: >-
+      inputs.mode == 'drift'
+      && (inputs.credentials_env_name != '' || inputs.agenix_plan_secret_path != '')
     runs-on: ${{ fromJSON(inputs.runner) }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Consuming repos that only want offline checks (format, validate, denylist) can now call the reusable workflow without spurious credentialed-plan failures.

- `credentialed-plan`: skipped unless `credentials_env_name` or `agenix_plan_secret_path` is provided
- `apply`: skipped unless `credentials_env_name` or `agenix_apply_secret_path` is provided
- `drift-check`: skipped unless `credentials_env_name` or `agenix_plan_secret_path` is provided

This enables a gradual rollout where repos first enable offline CI checks (Phase 1), then add credentials later (Phase 2+).

## Test plan
- [ ] metacraft/infra PR #951 — credentialed-plan jobs should be skipped (no credentials configured)
- [ ] Existing blocksense/infra usage should be unaffected (credentials are configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)