### PR TITLE
refactor: move PR-only guard into sticky-comment action

### DIFF
--- a/.github/sticky-comment/action.yml
+++ b/.github/sticky-comment/action.yml
@@ -18,6 +18,10 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
+          if (!context.issue.number) {
+            core.info('Not a pull request — skipping sticky comment.');
+            return;
+          }
           const fs = require('fs');
           const message = `${{ inputs.message }}`;
           const path = `${{ inputs.path }}`;

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -115,7 +115,7 @@ jobs:
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} shard-matrix
 
       - name: Post CI matrix comment
-        if: github.event_name == 'pull_request' && steps.generate-matrix.outputs.full_matrix
+        if: steps.generate-matrix.outputs.full_matrix
         uses: metacraft-labs/nixos-modules/.github/sticky-comment@main
         with:
           path: comment.md
@@ -188,7 +188,6 @@ jobs:
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} print-table
 
       - name: Post CI matrix comment
-        if: github.event_name == 'pull_request'
         uses: metacraft-labs/nixos-modules/.github/sticky-comment@main
         with:
           path: comment.md
@@ -264,7 +263,6 @@ jobs:
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} print-table
 
       - name: Update GitHub Comment
-        if: github.event_name == 'pull_request'
         uses: metacraft-labs/nixos-modules/.github/sticky-comment@main
         with:
           path: comment.md


### PR DESCRIPTION
## Summary

Follows up on #414. Instead of guarding every **call site** with `if: github.event_name == 'pull_request'`, this moves the guard into the `sticky-comment` composite action itself.

### What changed

1. **`.github/sticky-comment/action.yml`** — the script now checks `context.issue.number` at the top and early-exits with an info log when there is no PR context.
2. **`.github/workflows/reusable-flake-checks-ci-matrix.yml`** — removed the 3 redundant step-level `if: github.event_name == 'pull_request'` guards from `shard-matrix`, `merge-matrices`, and `results` jobs.

### What's intentionally kept

The **job-level** `if` on `post-initial-comment` is preserved because it avoids allocating a runner entirely when there is no PR.

### Why this is better

- **DRY** — the guard lives in one place instead of being repeated at every call site.
- **Future-proof** — new callers of `sticky-comment` are automatically safe without needing to remember the `if:` boilerplate.
- **Behaviorally identical** — on non-PR events the action logs a message and returns; on PR events it works exactly as before.