### PR TITLE
feat(desktop-vms): add videoModel "none" to disable virtual display

### DIFF
--- a/modules/virtualisation/desktop-vms.nix
+++ b/modules/virtualisation/desktop-vms.nix
@@ -346,6 +346,7 @@
 
             videoModel = mkOption {
               type = types.enum [
+                "none"
                 "virtio"
                 "qxl"
                 "vga"
@@ -355,6 +356,9 @@
               description = ''
                 Video device model for the VM.
 
+                - none: No virtual video device. Use this with GPU passthrough
+                  to avoid a secondary virtual adapter that can cause cross-adapter
+                  compositing overhead in the guest OS
                 - virtio: Modern paravirtualized GPU, best performance for Linux guests
                 - qxl: SPICE-native video device, best auto-resize support with SPICE guest tools
                 - vga: Standard VGA, maximum compatibility

--- a/modules/virtualisation/desktop-vms/lib.nix
+++ b/modules/virtualisation/desktop-vms/lib.nix
@@ -568,14 +568,18 @@ rec {
       # Network
       networkXml = generateNetworkXml { };
 
-      # Video
-      videoXml = generateVideoXml {
-        type = videoModel;
-        ram = videoRam;
-        vram = videoVram;
-        vgamem = videoVgamem;
-        heads = videoHeads;
-      };
+      # Video (skip when videoModel is "none", e.g. for GPU passthrough setups)
+      videoXml =
+        if videoModel == "none" then
+          ""
+        else
+          generateVideoXml {
+            type = videoModel;
+            ram = videoRam;
+            vram = videoVram;
+            vgamem = videoVgamem;
+            heads = videoHeads;
+          };
 
       # Input devices
       inputXml = ''


### PR DESCRIPTION
## Summary

- Adds `"none"` as a valid `videoModel` option for desktop VMs
- When set, the `<video>` element is omitted entirely from the libvirt domain XML
- Intended for GPU passthrough setups where the virtual display adapter is unnecessary

## Problem

When a VM has both a passthrough GPU and a virtual video adapter (QXL, virtio, etc.), the guest OS sees two display adapters. On Windows, this causes DWM to composite across both adapters (cross-adapter resource sharing), resulting in desktop stuttering — especially with multi-monitor setups on the passthrough GPU.

## Test plan

- [ ] Set `videoModel = "none"` on a VM with GPU passthrough
- [ ] Verify the generated libvirt XML has no `<video>` element
- [ ] Confirm the guest OS only sees the passthrough GPU
- [ ] Verify existing VMs with other `videoModel` values are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)