### PR TITLE
feat(desktop-vms): add extraQemuArgs and macAddress options

### DIFF
--- a/modules/virtualisation/desktop-vms.nix
+++ b/modules/virtualisation/desktop-vms.nix
@@ -153,6 +153,7 @@
           extraDevices = vmCfg.extraDevices;
           extraQemuArgs = vmCfg.extraQemuArgs;
           pciDevices = vmCfg.pciDevices;
+          macAddress = vmCfg.macAddress;
           lookingGlassMemoryMB = if cfg.lookingGlass.enable then cfg.lookingGlass.sharedMemoryMB else 64;
           # Memballoon configuration
           memballoon = vmCfg.memballoon;
@@ -254,6 +255,21 @@
                 Generate with: uuidgen
               '';
               example = "550e8400-e29b-41d4-a716-446655440000";
+            };
+
+            macAddress = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = ''
+                Fixed MAC address for the VM's network interface.
+                If not specified, libvirt will generate a random one.
+
+                Use a fixed MAC address to ensure the VM gets a consistent IP
+                from DHCP static host reservations on the libvirt default network.
+
+                Find the current MAC with: virsh domiflist <vm-name>
+              '';
+              example = "52:54:00:73:d8:5d";
             };
 
             memory = mkOption {

--- a/modules/virtualisation/desktop-vms.nix
+++ b/modules/virtualisation/desktop-vms.nix
@@ -151,6 +151,7 @@
           inherit ovmfCodePath ovmfVarsPath;
           nvramPath = "/var/lib/libvirt/qemu/nvram/${name}_VARS.fd";
           extraDevices = vmCfg.extraDevices;
+          extraQemuArgs = vmCfg.extraQemuArgs;
           pciDevices = vmCfg.pciDevices;
           lookingGlassMemoryMB = if cfg.lookingGlass.enable then cfg.lookingGlass.sharedMemoryMB else 64;
           # Memballoon configuration
@@ -500,6 +501,19 @@
 
                 Reference: https://www.libvirt.org/formatdomain.html#memory-balloon-device
               '';
+            };
+
+            extraQemuArgs = mkOption {
+              type = types.listOf types.str;
+              default = [ ];
+              description = ''
+                Extra QEMU command-line arguments injected via qemu:commandline namespace.
+                Use this for evdev input passthrough, custom device options, etc.
+              '';
+              example = [
+                "-object"
+                "input-linux,id=kbd,evdev=/dev/input/event0,grab-toggle=ctrl-ctrl"
+              ];
             };
 
             extraDevices = mkOption {

--- a/modules/virtualisation/desktop-vms/lib.nix
+++ b/modules/virtualisation/desktop-vms/lib.nix
@@ -444,6 +444,7 @@ rec {
       # physical address width to place 64-bit PCI BARs, which can exceed
       # the IOMMU range and cause VFIO_MAP_DMA failures.
       maxPhysAddrBits ? null,
+      extraQemuArgs ? [ ],
     }:
     let
       memParsed = parseMemory memory;
@@ -652,16 +653,20 @@ rec {
         else
           ''<memballoon model="none"/>'';
 
-      # QEMU command-line namespace — needed for host-phys-bits workaround.
-      # Libvirt's <maxphysaddr mode="emulate"> sets phys-bits but doesn't disable
-      # host-phys-bits, which overrides it in KVM host-passthrough mode.
-      needsQemuNs = maxPhysAddrBits != null;
+      # QEMU command-line namespace — needed for host-phys-bits workaround
+      # and any extra QEMU arguments (e.g. evdev input passthrough).
+      physBitsArgs = lib.optionals (maxPhysAddrBits != null) [
+        "-global"
+        "host-x86_64-cpu.host-phys-bits=false"
+      ];
+      allQemuArgs = physBitsArgs ++ extraQemuArgs;
+      needsQemuNs = allQemuArgs != [ ];
       qemuNsAttr = optionalString needsQemuNs " xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'";
+      qemuArgsXml = concatMapStringsSep "\n    " (arg: ''<qemu:arg value="${arg}"/>'') allQemuArgs;
       qemuCommandlineXml = optionalString needsQemuNs ''
 
         <qemu:commandline>
-          <qemu:arg value="-global"/>
-          <qemu:arg value="host-x86_64-cpu.host-phys-bits=false"/>
+          ${qemuArgsXml}
         </qemu:commandline>'';
 
     in

--- a/modules/virtualisation/desktop-vms/lib.nix
+++ b/modules/virtualisation/desktop-vms/lib.nix
@@ -438,6 +438,7 @@ rec {
         statsInterval = 5;
       },
       pciDevices ? [ ],
+      macAddress ? null,
       lookingGlassMemoryMB ? 64,
       # Limit guest physical address bits to match host IOMMU address width.
       # Intel VT-d may only support 39-bit (512GB) — OVMF uses the guest's
@@ -567,7 +568,7 @@ rec {
       };
 
       # Network
-      networkXml = generateNetworkXml { };
+      networkXml = generateNetworkXml { mac = macAddress; };
 
       # Video (skip when videoModel is "none", e.g. for GPU passthrough setups)
       videoXml =


### PR DESCRIPTION
## Summary

- Adds `extraQemuArgs` option to pass custom QEMU command-line arguments (e.g., evdev input passthrough with grab-toggle)
- Adds `macAddress` option for fixed VM network identity, ensuring consistent DHCP leases across rebuilds

## Test plan

- [ ] Set `extraQemuArgs` with evdev input passthrough args, verify they appear in the libvirt domain XML `<qemu:commandline>` section
- [ ] Set `macAddress`, verify the `<mac address="..."/>` element appears in the network interface XML
- [ ] Verify VMs without these options set are unaffected (both default to null/empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)