### PR TITLE
fix(desktop-vms): use model type='none' to suppress default video device

### DIFF
--- a/modules/virtualisation/desktop-vms/lib.nix
+++ b/modules/virtualisation/desktop-vms/lib.nix
@@ -570,10 +570,14 @@ rec {
       # Network
       networkXml = generateNetworkXml { mac = macAddress; };
 
-      # Video (skip when videoModel is "none", e.g. for GPU passthrough setups)
+      # Video — "none" emits <model type='none'/> to suppress libvirt's
+      # automatic default video device (important for GPU passthrough)
       videoXml =
         if videoModel == "none" then
-          ""
+          ''
+            <video>
+              <model type="none"/>
+            </video>''
         else
           generateVideoXml {
             type = videoModel;


### PR DESCRIPTION
## Summary

- Fixes `videoModel = "none"` to emit `<video><model type='none'/></video>` instead of omitting the `<video>` element
- Omitting it causes libvirt to auto-inject a default `cirrus` adapter, defeating the purpose

Follow-up fix for #428.

## Test plan

- [x] Verified: omitting `<video>` results in libvirt adding a cirrus device
- [ ] Verify `<model type='none'/>` suppresses the default video device

🤖 Generated with [Claude Code](https://claude.com/claude-code)