### PR TITLE
test(desktop-vms): add golden-file tests for XML generation

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,6 +1,7 @@
 { ... }:
 {
   imports = [
+    ./desktop-vms
     ./packages-ci-matrix.nix
     ./pre-commit.nix
     ./secret-integration

--- a/checks/desktop-vms/default.nix
+++ b/checks/desktop-vms/default.nix
@@ -1,0 +1,71 @@
+# Golden-file tests for desktop-vms XML generation.
+#
+# Builds domain XML from test fixtures and compares against checked-in
+# golden files.  Any mismatch fails the check and prints a diff.
+#
+# Golden files are stored with trailing whitespace stripped (to satisfy
+# editorconfig), so both sides are normalized before comparison.
+#
+# To update golden files after an intentional change:
+#   nix build -f checks/desktop-vms/generate-xml.nix -o /tmp/vms
+#   for f in /tmp/vms/*.xml; do sed 's/[[:space:]]*$//' "$f" > checks/desktop-vms/golden/$(basename "$f"); done
+{ lib, ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    let
+      inherit (pkgs.stdenv.hostPlatform) isLinux;
+
+      desktopVmsLib = import ../../modules/virtualisation/desktop-vms/lib.nix { inherit (pkgs) lib; };
+      fixtures = import ./fixtures.nix;
+
+      # Build each fixture's XML as a store path
+      generatedXmls = lib.mapAttrs (
+        name: params: pkgs.writeText "${name}.xml" (desktopVmsLib.generateDomainXml params)
+      ) fixtures;
+
+      goldenDir = ./golden;
+
+      # One diff command per fixture — normalize trailing whitespace on both
+      # sides so golden files can satisfy editorconfig (trim_trailing_whitespace)
+      diffCommands = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (
+          name: drv:
+          let
+            golden = "${goldenDir}/${name}.xml";
+          in
+          ''
+            echo "Checking ${name}..."
+            sed 's/[[:space:]]*$//' "${golden}" | sed -e '$a\' > "$TMPDIR/${name}.golden"
+            sed 's/[[:space:]]*$//' "${drv}"    | sed -e '$a\' > "$TMPDIR/${name}.actual"
+            if ! diff -u "$TMPDIR/${name}.golden" "$TMPDIR/${name}.actual" > "$TMPDIR/${name}.diff" 2>&1; then
+              echo "FAIL: ${name} — output differs from golden file"
+              cat "$TMPDIR/${name}.diff"
+              failed=1
+            else
+              echo "  OK"
+            fi
+          ''
+        ) generatedXmls
+      );
+    in
+    {
+      checks = lib.optionalAttrs isLinux {
+        desktop-vms-golden = pkgs.runCommand "desktop-vms-golden-test" { } ''
+          failed=0
+          ${diffCommands}
+          if [ "$failed" -ne 0 ]; then
+            echo ""
+            echo "Golden file mismatch detected."
+            echo "If the change is intentional, update golden files:"
+            echo "  nix build -f checks/desktop-vms/generate-xml.nix -o /tmp/vms"
+            echo "  for f in /tmp/vms/*.xml; do sed 's/[[:space:]]*\$//' \"\$f\" > checks/desktop-vms/golden/\$(basename \"\$f\"); done"
+            exit 1
+          fi
+          echo ""
+          echo "All ${toString (lib.length (lib.attrNames fixtures))} fixtures match golden files."
+          touch $out
+        '';
+      };
+    };
+}

--- a/checks/desktop-vms/fixtures.nix
+++ b/checks/desktop-vms/fixtures.nix
@@ -1,0 +1,119 @@
+# Test fixtures for desktop-vms XML generation.
+#
+# Each attribute is a set of parameters to generateDomainXml.
+# The generated XML is compared against golden files in ./golden/.
+{
+  # Minimal Windows VM with defaults
+  basic-windows = {
+    name = "test-windows";
+    uuid = "00000000-0000-0000-0000-000000000001";
+    memory = "8G";
+    vcpus = 4;
+    diskVolume = "test-windows.qcow2";
+    osType = "windows";
+    tpm = true;
+    secureBoot = true;
+    ovmfCodePath = "/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd";
+    ovmfVarsPath = "/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd";
+    nvramPath = "/var/lib/libvirt/qemu/nvram/test-windows_VARS.fd";
+  };
+
+  # GPU passthrough with videoModel = "none" — no virtual display adapter
+  gpu-passthrough = {
+    name = "test-gpu-passthrough";
+    uuid = "00000000-0000-0000-0000-000000000002";
+    memory = "16G";
+    vcpus = 8;
+    diskVolume = "test-gpu.qcow2";
+    osType = "windows";
+    tpm = true;
+    secureBoot = true;
+    ovmfCodePath = "/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd";
+    ovmfVarsPath = "/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd";
+    nvramPath = "/var/lib/libvirt/qemu/nvram/test-gpu_VARS.fd";
+    videoModel = "none";
+    display = "looking-glass";
+    pciDevices = [
+      "08:00.0"
+      "08:00.1"
+    ];
+    macAddress = "52:54:00:aa:bb:cc";
+    maxPhysAddrBits = 39;
+    extraQemuArgs = [
+      "-object"
+      "input-linux,id=kbd,evdev=/dev/input/event0,repeat=on,grab-toggle=ctrl-ctrl"
+    ];
+  };
+
+  # Multi-head QXL with custom VRAM
+  qxl-multi-head = {
+    name = "test-qxl";
+    uuid = "00000000-0000-0000-0000-000000000003";
+    memory = "4G";
+    vcpus = 2;
+    diskVolume = "test-qxl.qcow2";
+    osType = "windows";
+    tpm = false;
+    secureBoot = false;
+    ovmfCodePath = "/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd";
+    ovmfVarsPath = "/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd";
+    nvramPath = "/var/lib/libvirt/qemu/nvram/test-qxl_VARS.fd";
+    videoModel = "qxl";
+    videoHeads = 4;
+    videoRam = 524288;
+    videoVram = 524288;
+    videoVgamem = 262144;
+  };
+
+  # Linux VM with VirtIO video and shared folders
+  linux-virtio = {
+    name = "test-linux";
+    uuid = "00000000-0000-0000-0000-000000000004";
+    memory = "4G";
+    vcpus = 4;
+    diskVolume = "test-linux.qcow2";
+    osType = "linux";
+    tpm = false;
+    secureBoot = false;
+    ovmfCodePath = "/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd";
+    ovmfVarsPath = "/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd";
+    nvramPath = "/var/lib/libvirt/qemu/nvram/test-linux_VARS.fd";
+    videoModel = "virtio";
+    sharedFolders = {
+      projects = "/home/user/projects";
+      documents = "/home/user/documents";
+    };
+  };
+
+  # VM with CPU pinning and hugepages
+  pinned-hugepages = {
+    name = "test-pinned";
+    uuid = "00000000-0000-0000-0000-000000000005";
+    memory = "32G";
+    vcpus = 8;
+    diskVolume = "test-pinned.qcow2";
+    osType = "windows";
+    tpm = true;
+    secureBoot = true;
+    ovmfCodePath = "/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd";
+    ovmfVarsPath = "/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd";
+    nvramPath = "/var/lib/libvirt/qemu/nvram/test-pinned_VARS.fd";
+    cpuPinning = [
+      "0-1"
+      "2-3"
+      "4-5"
+      "6-7"
+      "8-9"
+      "10-11"
+      "12-13"
+      "14-15"
+    ];
+    hugepages = true;
+    memballoon = {
+      enable = true;
+      autodeflate = true;
+      freePageReporting = true;
+      statsInterval = 10;
+    };
+  };
+}

--- a/checks/desktop-vms/generate-xml.nix
+++ b/checks/desktop-vms/generate-xml.nix
@@ -1,0 +1,22 @@
+# Generates domain XML files from test fixtures using the desktop-vms lib.
+#
+# Usage:
+#   nix build -f checks/desktop-vms/generate-xml.nix -o result
+#   ls result/   # one .xml file per fixture
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+let
+  lib = pkgs.lib;
+  desktopVmsLib = import ../../modules/virtualisation/desktop-vms/lib.nix { inherit lib; };
+  fixtures = import ./fixtures.nix;
+
+  xmlFiles = lib.mapAttrs (
+    name: params: pkgs.writeText "${name}.xml" (desktopVmsLib.generateDomainXml params)
+  ) fixtures;
+in
+pkgs.runCommand "desktop-vms-test-xmls" { } ''
+  mkdir -p $out
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: drv: "cp ${drv} $out/${name}.xml") xmlFiles)}
+''

--- a/checks/desktop-vms/golden/basic-windows.xml
+++ b/checks/desktop-vms/golden/basic-windows.xml
@@ -1,0 +1,106 @@
+<domain type="kvm">
+  <name>test-windows</name>
+  <uuid>00000000-0000-0000-0000-000000000001</uuid>
+  <memory unit="GiB">8</memory>
+<currentMemory unit="GiB">8</currentMemory>
+  <vcpu placement="static">4</vcpu>
+  <cpu mode="host-passthrough" check="none">
+  <topology sockets="1" dies="1" clusters="1" cores="4" threads="1"/>
+</cpu>
+
+
+  <os>
+  <type arch="x86_64" machine="q35">hvm</type>
+  <loader readonly="yes" secure="yes" type="pflash">/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd</loader>
+  <nvram template="/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd">/var/lib/libvirt/qemu/nvram/test-windows_VARS.fd</nvram>
+  <boot dev="hd"/>
+</os>
+  <features>
+  <acpi/>
+  <apic/>
+  <hyperv mode="passthrough">
+    <relaxed state="on"/>
+    <vapic state="on"/>
+    <spinlocks state="on" retries="8191"/>
+    <vpindex state="on"/>
+    <runtime state="on"/>
+    <synic state="on"/>
+    <stimer state="on"/>
+    <reset state="on"/>
+    <frequencies state="on"/>
+  </hyperv>
+  <smm state="on"/>
+</features>
+  <clock offset="localtime">
+  <timer name="rtc" tickpolicy="catchup"/>
+  <timer name="pit" tickpolicy="delay"/>
+  <timer name="hpet" present="no"/>
+  <timer name="hypervclock" present="yes"/>
+</clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+  <suspend-to-mem enabled="no"/>
+  <suspend-to-disk enabled="no"/>
+</pm>
+  <devices>
+    <emulator>/run/current-system/sw/bin/qemu-system-x86_64</emulator>
+    <disk type="volume" device="disk">
+  <driver name="qemu" type="qcow2" cache="writeback"/>
+  <source pool="default" volume="test-windows.qcow2"/>
+  <target dev="vda" bus="virtio"/>
+</disk>
+    <interface type="network">
+
+  <source network="default"/>
+  <model type="virtio"/>
+</interface>
+    <graphics type="spice" port="5900" autoport="yes" listen="127.0.0.1">
+  <listen type="address" address="127.0.0.1"/>
+  <image compression="auto_glz"/>
+  <streaming mode="filter"/>
+  <gl enable="no"/>
+</graphics>
+    <video>
+  <model type="virtio"/>
+</video>
+    <input type="tablet" bus="usb">
+  <address type="usb" bus="0" port="1"/>
+</input>
+<input type="mouse" bus="ps2"/>
+<input type="keyboard" bus="ps2"/>
+    <serial type="pty">
+  <target type="isa-serial" port="0">
+    <model name="isa-serial"/>
+  </target>
+</serial>
+<console type="pty">
+  <target type="serial" port="0"/>
+</console>
+    <channel type="unix">
+  <target type="virtio" name="org.qemu.guest_agent.0"/>
+</channel>
+<channel type="spicevmc">
+  <target type="virtio" name="com.redhat.spice.0"/>
+</channel>
+    <controller type="usb" model="qemu-xhci" ports="15">
+  <address type="pci" domain="0x0000" bus="0x02" slot="0x00" function="0x0"/>
+</controller>
+    <sound model="ich9">
+  <codec type="micro"/>
+  <audio id="1"/>
+</sound>
+<audio id="1" type="spice"/>
+
+    <tpm model="tpm-crb">
+  <backend type="emulator" version="2.0"/>
+</tpm>
+    <memballoon model="virtio">
+          <stats period='5'/>
+  <address type="pci" domain="0x0000" bus="0x05" slot="0x00" function="0x0"/>
+</memballoon>
+
+
+  </devices>
+</domain>

--- a/checks/desktop-vms/golden/gpu-passthrough.xml
+++ b/checks/desktop-vms/golden/gpu-passthrough.xml
@@ -1,0 +1,126 @@
+<domain type="kvm" xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name>test-gpu-passthrough</name>
+  <uuid>00000000-0000-0000-0000-000000000002</uuid>
+  <memory unit="GiB">16</memory>
+<currentMemory unit="GiB">16</currentMemory>
+  <vcpu placement="static">8</vcpu>
+  <cpu mode="host-passthrough" check="none">
+  <topology sockets="1" dies="1" clusters="1" cores="8" threads="1"/>
+<maxphysaddr mode="emulate" bits="39"/>
+</cpu>
+
+
+  <os>
+  <type arch="x86_64" machine="q35">hvm</type>
+  <loader readonly="yes" secure="yes" type="pflash">/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd</loader>
+  <nvram template="/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd">/var/lib/libvirt/qemu/nvram/test-gpu_VARS.fd</nvram>
+  <boot dev="hd"/>
+</os>
+  <features>
+  <acpi/>
+  <apic/>
+  <hyperv mode="passthrough">
+    <relaxed state="on"/>
+    <vapic state="on"/>
+    <spinlocks state="on" retries="8191"/>
+    <vpindex state="on"/>
+    <runtime state="on"/>
+    <synic state="on"/>
+    <stimer state="on"/>
+    <reset state="on"/>
+    <frequencies state="on"/>
+  </hyperv>
+  <smm state="on"/>
+</features>
+  <clock offset="localtime">
+  <timer name="rtc" tickpolicy="catchup"/>
+  <timer name="pit" tickpolicy="delay"/>
+  <timer name="hpet" present="no"/>
+  <timer name="hypervclock" present="yes"/>
+</clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+  <suspend-to-mem enabled="no"/>
+  <suspend-to-disk enabled="no"/>
+</pm>
+  <devices>
+    <emulator>/run/current-system/sw/bin/qemu-system-x86_64</emulator>
+    <disk type="volume" device="disk">
+  <driver name="qemu" type="qcow2" cache="writeback"/>
+  <source pool="default" volume="test-gpu.qcow2"/>
+  <target dev="vda" bus="virtio"/>
+</disk>
+    <interface type="network">
+  <mac address="52:54:00:aa:bb:cc"/>
+  <source network="default"/>
+  <model type="virtio"/>
+</interface>
+    <graphics type="spice" port="5900" autoport="yes" listen="127.0.0.1">
+  <listen type="address" address="127.0.0.1"/>
+  <image compression="auto_glz"/>
+  <streaming mode="filter"/>
+  <gl enable="no"/>
+</graphics>
+      <shmem name="looking-glass">
+  <model type="ivshmem-plain"/>
+  <size unit="M">64</size>
+</shmem>
+    <video>
+  <model type="none"/>
+</video>
+    <input type="tablet" bus="usb">
+  <address type="usb" bus="0" port="1"/>
+</input>
+<input type="mouse" bus="ps2"/>
+<input type="keyboard" bus="ps2"/>
+    <serial type="pty">
+  <target type="isa-serial" port="0">
+    <model name="isa-serial"/>
+  </target>
+</serial>
+<console type="pty">
+  <target type="serial" port="0"/>
+</console>
+    <channel type="unix">
+  <target type="virtio" name="org.qemu.guest_agent.0"/>
+</channel>
+<channel type="spicevmc">
+  <target type="virtio" name="com.redhat.spice.0"/>
+</channel>
+    <controller type="usb" model="qemu-xhci" ports="15">
+  <address type="pci" domain="0x0000" bus="0x02" slot="0x00" function="0x0"/>
+</controller>
+    <sound model="ich9">
+  <codec type="micro"/>
+  <audio id="1"/>
+</sound>
+<audio id="1" type="spice"/>
+
+    <tpm model="tpm-crb">
+  <backend type="emulator" version="2.0"/>
+</tpm>
+    <memballoon model="virtio">
+          <stats period='5'/>
+  <address type="pci" domain="0x0000" bus="0x05" slot="0x00" function="0x0"/>
+</memballoon>
+    <hostdev mode="subsystem" type="pci" managed="yes">
+  <source>
+    <address domain="0x0000" bus="0x08" slot="0x00" function="0x0"/>
+  </source>
+</hostdev>
+<hostdev mode="subsystem" type="pci" managed="yes">
+  <source>
+    <address domain="0x0000" bus="0x08" slot="0x00" function="0x1"/>
+  </source>
+</hostdev>
+
+  </devices>
+<qemu:commandline>
+  <qemu:arg value="-global"/>
+    <qemu:arg value="host-x86_64-cpu.host-phys-bits=false"/>
+    <qemu:arg value="-object"/>
+    <qemu:arg value="input-linux,id=kbd,evdev=/dev/input/event0,repeat=on,grab-toggle=ctrl-ctrl"/>
+</qemu:commandline>
+</domain>

--- a/checks/desktop-vms/golden/linux-virtio.xml
+++ b/checks/desktop-vms/golden/linux-virtio.xml
@@ -1,0 +1,102 @@
+<domain type="kvm">
+  <name>test-linux</name>
+  <uuid>00000000-0000-0000-0000-000000000004</uuid>
+  <memory unit="GiB">4</memory>
+<currentMemory unit="GiB">4</currentMemory>
+  <vcpu placement="static">4</vcpu>
+  <cpu mode="host-passthrough" check="none">
+  <topology sockets="1" dies="1" clusters="1" cores="4" threads="1"/>
+</cpu>
+  <memoryBacking>
+  <access mode="shared"/>
+</memoryBacking>
+
+  <os>
+  <type arch="x86_64" machine="q35">hvm</type>
+  <loader readonly="yes" type="pflash">/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd</loader>
+  <nvram template="/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd">/var/lib/libvirt/qemu/nvram/test-linux_VARS.fd</nvram>
+  <boot dev="hd"/>
+</os>
+  <features>
+  <acpi/>
+  <apic/>
+</features>
+  <clock offset="utc">
+  <timer name="rtc" tickpolicy="catchup"/>
+  <timer name="pit" tickpolicy="delay"/>
+  <timer name="hpet" present="no"/>
+</clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+  <suspend-to-mem enabled="no"/>
+  <suspend-to-disk enabled="no"/>
+</pm>
+  <devices>
+    <emulator>/run/current-system/sw/bin/qemu-system-x86_64</emulator>
+    <disk type="volume" device="disk">
+  <driver name="qemu" type="qcow2" cache="writeback"/>
+  <source pool="default" volume="test-linux.qcow2"/>
+  <target dev="vda" bus="virtio"/>
+</disk>
+    <interface type="network">
+
+  <source network="default"/>
+  <model type="virtio"/>
+</interface>
+    <graphics type="spice" port="5900" autoport="yes" listen="127.0.0.1">
+  <listen type="address" address="127.0.0.1"/>
+  <image compression="auto_glz"/>
+  <streaming mode="filter"/>
+  <gl enable="no"/>
+</graphics>
+    <video>
+  <model type="virtio"/>
+</video>
+    <input type="tablet" bus="usb">
+  <address type="usb" bus="0" port="1"/>
+</input>
+<input type="mouse" bus="ps2"/>
+<input type="keyboard" bus="ps2"/>
+    <serial type="pty">
+  <target type="isa-serial" port="0">
+    <model name="isa-serial"/>
+  </target>
+</serial>
+<console type="pty">
+  <target type="serial" port="0"/>
+</console>
+    <channel type="unix">
+  <target type="virtio" name="org.qemu.guest_agent.0"/>
+</channel>
+<channel type="spicevmc">
+  <target type="virtio" name="com.redhat.spice.0"/>
+</channel>
+    <controller type="usb" model="qemu-xhci" ports="15">
+  <address type="pci" domain="0x0000" bus="0x02" slot="0x00" function="0x0"/>
+</controller>
+    <sound model="ich9">
+  <codec type="micro"/>
+  <audio id="1"/>
+</sound>
+<audio id="1" type="spice"/>
+    <filesystem type="mount" accessmode="passthrough">
+  <driver type="virtiofs"/>
+  <source dir="/home/user/documents"/>
+  <target dir="documents"/>
+</filesystem>
+<filesystem type="mount" accessmode="passthrough">
+  <driver type="virtiofs"/>
+  <source dir="/home/user/projects"/>
+  <target dir="projects"/>
+</filesystem>
+
+    <memballoon model="virtio">
+          <stats period='5'/>
+  <address type="pci" domain="0x0000" bus="0x05" slot="0x00" function="0x0"/>
+</memballoon>
+
+
+  </devices>
+</domain>

--- a/checks/desktop-vms/golden/pinned-hugepages.xml
+++ b/checks/desktop-vms/golden/pinned-hugepages.xml
@@ -1,0 +1,117 @@
+<domain type="kvm">
+  <name>test-pinned</name>
+  <uuid>00000000-0000-0000-0000-000000000005</uuid>
+  <memory unit="GiB">32</memory>
+<currentMemory unit="GiB">32</currentMemory>
+  <vcpu placement="static">8</vcpu>
+  <cpu mode="host-passthrough" check="none">
+  <topology sockets="1" dies="1" clusters="1" cores="8" threads="1"/>
+</cpu>
+  <memoryBacking>
+  <hugepages/>
+</memoryBacking>
+  <cputune>
+  <vcpupin cpuset="0-1" vcpu="0"/>
+    <vcpupin cpuset="2-3" vcpu="1"/>
+    <vcpupin cpuset="4-5" vcpu="2"/>
+    <vcpupin cpuset="6-7" vcpu="3"/>
+    <vcpupin cpuset="8-9" vcpu="4"/>
+    <vcpupin cpuset="10-11" vcpu="5"/>
+    <vcpupin cpuset="12-13" vcpu="6"/>
+    <vcpupin cpuset="14-15" vcpu="7"/>
+</cputune>
+  <os>
+  <type arch="x86_64" machine="q35">hvm</type>
+  <loader readonly="yes" secure="yes" type="pflash">/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd</loader>
+  <nvram template="/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd">/var/lib/libvirt/qemu/nvram/test-pinned_VARS.fd</nvram>
+  <boot dev="hd"/>
+</os>
+  <features>
+  <acpi/>
+  <apic/>
+  <hyperv mode="passthrough">
+    <relaxed state="on"/>
+    <vapic state="on"/>
+    <spinlocks state="on" retries="8191"/>
+    <vpindex state="on"/>
+    <runtime state="on"/>
+    <synic state="on"/>
+    <stimer state="on"/>
+    <reset state="on"/>
+    <frequencies state="on"/>
+  </hyperv>
+  <smm state="on"/>
+</features>
+  <clock offset="localtime">
+  <timer name="rtc" tickpolicy="catchup"/>
+  <timer name="pit" tickpolicy="delay"/>
+  <timer name="hpet" present="no"/>
+  <timer name="hypervclock" present="yes"/>
+</clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+  <suspend-to-mem enabled="no"/>
+  <suspend-to-disk enabled="no"/>
+</pm>
+  <devices>
+    <emulator>/run/current-system/sw/bin/qemu-system-x86_64</emulator>
+    <disk type="volume" device="disk">
+  <driver name="qemu" type="qcow2" cache="writeback"/>
+  <source pool="default" volume="test-pinned.qcow2"/>
+  <target dev="vda" bus="virtio"/>
+</disk>
+    <interface type="network">
+
+  <source network="default"/>
+  <model type="virtio"/>
+</interface>
+    <graphics type="spice" port="5900" autoport="yes" listen="127.0.0.1">
+  <listen type="address" address="127.0.0.1"/>
+  <image compression="auto_glz"/>
+  <streaming mode="filter"/>
+  <gl enable="no"/>
+</graphics>
+    <video>
+  <model type="virtio"/>
+</video>
+    <input type="tablet" bus="usb">
+  <address type="usb" bus="0" port="1"/>
+</input>
+<input type="mouse" bus="ps2"/>
+<input type="keyboard" bus="ps2"/>
+    <serial type="pty">
+  <target type="isa-serial" port="0">
+    <model name="isa-serial"/>
+  </target>
+</serial>
+<console type="pty">
+  <target type="serial" port="0"/>
+</console>
+    <channel type="unix">
+  <target type="virtio" name="org.qemu.guest_agent.0"/>
+</channel>
+<channel type="spicevmc">
+  <target type="virtio" name="com.redhat.spice.0"/>
+</channel>
+    <controller type="usb" model="qemu-xhci" ports="15">
+  <address type="pci" domain="0x0000" bus="0x02" slot="0x00" function="0x0"/>
+</controller>
+    <sound model="ich9">
+  <codec type="micro"/>
+  <audio id="1"/>
+</sound>
+<audio id="1" type="spice"/>
+
+    <tpm model="tpm-crb">
+  <backend type="emulator" version="2.0"/>
+</tpm>
+    <memballoon model="virtio" autodeflate='on' freePageReporting='on'>
+          <stats period='10'/>
+  <address type="pci" domain="0x0000" bus="0x05" slot="0x00" function="0x0"/>
+</memballoon>
+
+
+  </devices>
+</domain>

--- a/checks/desktop-vms/golden/qxl-multi-head.xml
+++ b/checks/desktop-vms/golden/qxl-multi-head.xml
@@ -1,0 +1,104 @@
+<domain type="kvm">
+  <name>test-qxl</name>
+  <uuid>00000000-0000-0000-0000-000000000003</uuid>
+  <memory unit="GiB">4</memory>
+<currentMemory unit="GiB">4</currentMemory>
+  <vcpu placement="static">2</vcpu>
+  <cpu mode="host-passthrough" check="none">
+  <topology sockets="1" dies="1" clusters="1" cores="2" threads="1"/>
+</cpu>
+
+
+  <os>
+  <type arch="x86_64" machine="q35">hvm</type>
+  <loader readonly="yes" type="pflash">/nix/store/placeholder-ovmf/FV/OVMF_CODE.fd</loader>
+  <nvram template="/nix/store/placeholder-ovmf/FV/OVMF_VARS.fd">/var/lib/libvirt/qemu/nvram/test-qxl_VARS.fd</nvram>
+  <boot dev="hd"/>
+</os>
+  <features>
+  <acpi/>
+  <apic/>
+  <hyperv mode="passthrough">
+    <relaxed state="on"/>
+    <vapic state="on"/>
+    <spinlocks state="on" retries="8191"/>
+    <vpindex state="on"/>
+    <runtime state="on"/>
+    <synic state="on"/>
+    <stimer state="on"/>
+    <reset state="on"/>
+    <frequencies state="on"/>
+  </hyperv>
+  <smm state="on"/>
+</features>
+  <clock offset="localtime">
+  <timer name="rtc" tickpolicy="catchup"/>
+  <timer name="pit" tickpolicy="delay"/>
+  <timer name="hpet" present="no"/>
+  <timer name="hypervclock" present="yes"/>
+</clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+  <suspend-to-mem enabled="no"/>
+  <suspend-to-disk enabled="no"/>
+</pm>
+  <devices>
+    <emulator>/run/current-system/sw/bin/qemu-system-x86_64</emulator>
+    <disk type="volume" device="disk">
+  <driver name="qemu" type="qcow2" cache="writeback"/>
+  <source pool="default" volume="test-qxl.qcow2"/>
+  <target dev="vda" bus="virtio"/>
+</disk>
+    <interface type="network">
+
+  <source network="default"/>
+  <model type="virtio"/>
+</interface>
+    <graphics type="spice" port="5900" autoport="yes" listen="127.0.0.1">
+  <listen type="address" address="127.0.0.1"/>
+  <image compression="auto_glz"/>
+  <streaming mode="filter"/>
+  <gl enable="no"/>
+</graphics>
+    <video>
+  <model heads="4" ram="524288" type="qxl" vgamem="262144" vram="524288"/>
+</video>
+    <input type="tablet" bus="usb">
+  <address type="usb" bus="0" port="1"/>
+</input>
+<input type="mouse" bus="ps2"/>
+<input type="keyboard" bus="ps2"/>
+    <serial type="pty">
+  <target type="isa-serial" port="0">
+    <model name="isa-serial"/>
+  </target>
+</serial>
+<console type="pty">
+  <target type="serial" port="0"/>
+</console>
+    <channel type="unix">
+  <target type="virtio" name="org.qemu.guest_agent.0"/>
+</channel>
+<channel type="spicevmc">
+  <target type="virtio" name="com.redhat.spice.0"/>
+</channel>
+    <controller type="usb" model="qemu-xhci" ports="15">
+  <address type="pci" domain="0x0000" bus="0x02" slot="0x00" function="0x0"/>
+</controller>
+    <sound model="ich9">
+  <codec type="micro"/>
+  <audio id="1"/>
+</sound>
+<audio id="1" type="spice"/>
+
+
+    <memballoon model="virtio">
+          <stats period='5'/>
+  <address type="pci" domain="0x0000" bus="0x05" slot="0x00" function="0x0"/>
+</memballoon>
+
+
+  </devices>
+</domain>

--- a/modules/virtualisation/desktop-vms/lib.nix
+++ b/modules/virtualisation/desktop-vms/lib.nix
@@ -570,10 +570,14 @@ rec {
       # Network
       networkXml = generateNetworkXml { mac = macAddress; };
 
-      # Video (skip when videoModel is "none", e.g. for GPU passthrough setups)
+      # Video — "none" emits <model type='none'/> to suppress libvirt's
+      # automatic default video device (important for GPU passthrough)
       videoXml =
         if videoModel == "none" then
-          ""
+          ''
+            <video>
+              <model type="none"/>
+            </video>''
         else
           generateVideoXml {
             type = videoModel;


### PR DESCRIPTION
## Summary

- Adds golden-file CI check for desktop-vms XML generation
- 5 test fixtures covering key scenarios: basic Windows, GPU passthrough (`videoModel = "none"`), multi-head QXL, Linux VirtIO with shared folders, CPU pinning with hugepages
- Generated XML is compared against checked-in golden files — any unintentional change to the output is caught in CI

Depends on #432 (uses `<model type='none'/>` in the GPU passthrough fixture).

## How it works

- `checks/desktop-vms/fixtures.nix` — test parameters for `generateDomainXml`
- `checks/desktop-vms/golden/*.xml` — expected output
- `checks/desktop-vms/default.nix` — flake check that builds XML and diffs against golden files
- `checks/desktop-vms/generate-xml.nix` — standalone helper to regenerate golden files

## Updating golden files

After an intentional change to XML generation:

```bash
nix build -f checks/desktop-vms/generate-xml.nix -o /tmp/vms
for f in /tmp/vms/*.xml; do sed 's/[[:space:]]*$//' "$f" > checks/desktop-vms/golden/$(basename "$f"); done
```

## Test plan

- [x] Check passes with current golden files
- [x] Check fails when a golden file is modified (shows diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)