### PR TITLE
fix(mcl): push Cachix deployment closures before activation

### DIFF
--- a/packages/mcl/src/mcl/commands/deploy_spec.d
+++ b/packages/mcl/src/mcl/commands/deploy_spec.d
@@ -23,6 +23,28 @@ struct DeploySpecArgs {
     mixin CiMatrixBaseArgs!();
 }
 
+private void pushDeploymentClosure(DeploySpec spec, string cachixCache)
+{
+    infof(
+        "Pushing deployment closure for %s agents to Cachix cache '%s'.",
+        spec.agents.length,
+        cachixCache
+    );
+
+    spawnProcessInline([
+        "bash", "-euo", "pipefail", "-c",
+        q{
+cache="$1"
+shift
+
+nix-store -r "$@"
+nix-store -qR "$@" | cachix push "$cache"
+        },
+        "mcl-push-deployment-closure",
+        cachixCache,
+    ] ~ spec.agents.values);
+}
+
 export int deploy_spec(DeploySpecArgs args)
 {
     const deploySpecFile = resultDir.buildPath("cachix-deploy-spec.json");
@@ -62,6 +84,8 @@ export int deploy_spec(DeploySpecArgs args)
 
     if (!spec.agents.length)
         return 0;
+
+    pushDeploymentClosure(spec, args.cachixCache);
 
     spawnProcessInline([
         "cachix", "deploy", "activate", deploySpecFile, "--async"


### PR DESCRIPTION
## Summary
- restore deploy target store paths on the CI runner before activation
- push the full recursive deployment closure to the configured Cachix cache
- keep the existing `cachix deploy activate` flow after the cache has been prefilled

## Why
Cachix Deploy agents restore systems from the deploy cache during activation. Checking that the top-level NixOS system path has a narinfo is not enough: closure members may still come from another substituter, or the private cache may have incomplete objects. Prefilling the closure makes the deploy cache self-contained before agents are asked to switch.

## Testing
Not run; change is limited to the deploy command path.
