### PR TITLE
fix: rename agenix network modules

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,9 +6,10 @@
     ./aztec
     ./cachix-deploy
     ./folder-size-metrics
-    ./netbird
+    ./netbird-with-agenix
     ./shard-split
     ./random-alerts
+    ./tailscale-with-agenix
     ./host-info.nix
     ./secrets.nix
     ./mcl-disko

--- a/modules/netbird-with-agenix/default.nix
+++ b/modules/netbird-with-agenix/default.nix
@@ -1,6 +1,6 @@
-{ ... }:
+{ inputs, ... }:
 {
-  flake.modules.nixos.mcl-netbird =
+  flake.modules.nixos."netbird-with-agenix" =
     {
       config,
       lib,
@@ -8,7 +8,7 @@
       ...
     }:
     let
-      cfg = config.mcl.netbird;
+      cfg = config.services."netbird-with-agenix";
       client = config.services.netbird.clients.${cfg.clientName};
       optionalArrayArg =
         flag: value:
@@ -17,13 +17,28 @@
         '';
     in
     {
-      options.mcl.netbird = with lib; {
+      imports = [
+        inputs.agenix.nixosModules.default
+      ];
+
+      options.services."netbird-with-agenix" = with lib; {
         enable = mkEnableOption (mdDoc "NetBird client enrolled with an agenix-managed setup key");
 
         clientName = mkOption {
           type = types.str;
-          default = "agent-harbor";
+          default = "default";
           description = mdDoc "Name of the NetBird client instance.";
+        };
+
+        setupKeySecretFile = mkOption {
+          type = types.path;
+          description = mdDoc "Encrypted age file containing the NetBird setup key.";
+        };
+
+        setupKeySecretName = mkOption {
+          type = types.str;
+          default = "netbird/default/setup-key";
+          description = mdDoc "Name of the agenix secret that materializes the NetBird setup key.";
         };
 
         port = mkOption {
@@ -34,14 +49,8 @@
 
         interface = mkOption {
           type = types.str;
-          default = "nb-agent-harbor";
+          default = "nb-default";
           description = mdDoc "Network interface managed by this NetBird client.";
-        };
-
-        setupKeyPath = mkOption {
-          type = types.path;
-          default = "/etc/netbird-agent-harbor/setup-key";
-          description = mdDoc "Path where the NetBird setup key is materialized.";
         };
 
         hostnameOverride = mkOption {
@@ -103,7 +112,7 @@
       };
 
       config = lib.mkIf cfg.enable {
-        mcl.secrets.services."netbird-${cfg.clientName}".secrets.setup-key.path = cfg.setupKeyPath;
+        age.secrets.${cfg.setupKeySecretName}.file = cfg.setupKeySecretFile;
 
         services.netbird = {
           enable = false;
@@ -115,7 +124,7 @@
             openFirewall = cfg.openFirewall;
             login = {
               enable = true;
-              setupKeyFile = cfg.setupKeyPath;
+              setupKeyFile = config.age.secrets.${cfg.setupKeySecretName}.path;
             };
             config =
               cfg.extraConfig

--- a/modules/tailscale-with-agenix/default.nix
+++ b/modules/tailscale-with-agenix/default.nix
@@ -1,0 +1,48 @@
+{ inputs, ... }:
+{
+  flake.modules.nixos."tailscale-with-agenix" =
+    {
+      config,
+      lib,
+      ...
+    }:
+    let
+      cfg = config.services."tailscale-with-agenix";
+    in
+    {
+      imports = [
+        inputs.agenix.nixosModules.default
+      ];
+
+      options.services."tailscale-with-agenix" = with lib; {
+        enable = mkEnableOption (mdDoc "Tailscale configured with an agenix-managed auth key");
+
+        authKeySecretFile = mkOption {
+          type = types.path;
+          description = mdDoc "Encrypted age file containing the Tailscale auth key.";
+        };
+
+        authKeySecretName = mkOption {
+          type = types.str;
+          default = "tailscale/auth-key";
+          description = mdDoc "Name of the agenix secret that materializes the Tailscale auth key.";
+        };
+
+        extraSetFlags = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          description = mdDoc "Extra flags passed to services.tailscale.extraSetFlags.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        age.secrets.${cfg.authKeySecretName}.file = cfg.authKeySecretFile;
+
+        services.tailscale = {
+          enable = true;
+          authKeyFile = config.age.secrets.${cfg.authKeySecretName}.path;
+          extraSetFlags = cfg.extraSetFlags;
+        };
+      };
+    };
+}


### PR DESCRIPTION
## Summary

- rename the NetBird wrapper module to `netbird-with-agenix` and move its options to `services.netbird-with-agenix`
- restore the Tailscale wrapper as `tailscale-with-agenix` for Tailscale-based infrastructure repos
- configure agenix secrets directly in both modules, removing organization-branded module names and option namespaces

## Verification

- nix develop .#pre-commit --accept-flake-config -c prek run --files modules/default.nix modules/netbird-with-agenix/default.nix modules/tailscale-with-agenix/default.nix
- nix eval --json .#modules.nixos --apply builtins.attrNames
- nix eval --impure enabled tailscale-with-agenix module smoke expression
- nix eval --impure enabled netbird-with-agenix module smoke expression
- git diff --check