### PR TITLE
fix(reusable-flake-checks-ci-matrix): gate cache-push on run-cachix-deploy

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -243,7 +243,17 @@ jobs:
           nix build -L --no-link --keep-going --show-trace \
             '.#${{ matrix.attrPath }}'
 
+      # Cache push runs only when we're actually deploying (i.e. on main).
+      # On PR check runs the build itself already validates that the closure
+      # is buildable; redoing the push + per-path substitute probe on every
+      # matrix job would multiply runtime by 10x — a single NixOS system
+      # closure has thousands of paths and the probe's nix-copy fallback
+      # has timed out 6h+ jobs in the past (infra#965 first attempt).
+      #
+      # The artifact upload below is already gated on run-cachix-deploy;
+      # the push step itself needs the same gate.
       - name: Push deployment closure caches ${{ matrix.name }}
+        if: inputs.run-cachix-deploy
         shell: bash
         env:
           DEPLOY_TARGET: ${{ matrix.name }}


### PR DESCRIPTION
## Summary

The new \"Push deployment closure caches\" step from the M2 cache-backend work (PR #441) ran on every build matrix job unconditionally — including PR check runs that never actually deploy. For NixOS system closures (thousands of paths × multiple substituters) the per-path probe is expensive enough that **infra#965's first attempt hit GitHub's 6h job timeout** before the probe finished on \`gpu-server-001\`.

The artifact upload immediately below the push step already had \`if: inputs.run-cachix-deploy\`. The push step needs the same gate. On main runs the push happens; on PR runs we only verify the build itself (which the preceding \`nix build\` step already does).

## Verification

- One-line workflow change.
- After this lands, infra#965 (which uses this workflow via \`@main\`) will skip the push step on PR runs and only invoke it on \`main\` pushes / \`merge_group\`.

## Follow-up (not in this PR)

The probe itself is also doing more work than strictly necessary (\`nix copy\` after \`nix path-info\` for every path on every substituter). On deploy runs that's still expensive. Worth a follow-up to either:

- Drop the \`nix copy\` fallback (narinfo presence is sufficient for substitutability), or
- Probe only root paths instead of the full closure, or
- Cap probing time per push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)