### PR TITLE
fix(cache-backends): drop expensive nix-copy probe step

### DIFF
--- a/packages/mcl/src/mcl/utils/cache_backends.d
+++ b/packages/mcl/src/mcl/utils/cache_backends.d
@@ -174,24 +174,20 @@ CacheProbeResult probeCacheSubstitute(
         return CacheProbeResult(path, classifyProbeFailure(pathInfo.stderr), pathInfo.exitCode,
             pathInfo.stderr.stderrSummary);
 
-    auto tempStore = deleteme ~ ".mcl-cache-probe-store";
-    scope(exit)
-        if (tempStore.exists)
-            tempStore.rmdirRecurse;
-    mkdirRecurse(tempStore);
-
-    auto copyCommand = [
-        "nix", "copy", "--from", substituter, "--to", "file://" ~ tempStore, path,
-    ];
-    if (trustedPublicKeys.length)
-        copyCommand ~= ["--option", "trusted-public-keys", trustedPublicKeys.join(" ")];
-
-    auto copy = runner(copyCommand);
-    if (copy.succeeded)
-        return CacheProbeResult(path, "successful-substitute", 0, "");
-
-    return CacheProbeResult(path, classifyProbeFailure(copy.stderr), copy.exitCode,
-        copy.stderr.stderrSummary);
+    // `nix path-info` performs a `HEAD /<hash>.narinfo` against the
+    // substituter — this is sufficient evidence that the path is
+    // resolvable from that cache. Doing a full `nix copy` to verify
+    // (the previous implementation) downloaded every probed path,
+    // re-verified its signature, and re-imported into a throwaway local
+    // store. On a NixOS system closure that's thousands of paths times
+    // dozens of MB; one infra deploy in main observed the probe stuck
+    // for 2h24m on a single path (`gnome-settings-daemon`) before being
+    // killed. The signature trust check the copy was doing is
+    // redundant: every path the deploy targets will have its signature
+    // re-verified at install time on the target host. The probe's job
+    // is just to answer "is this path available from a trusted cache?"
+    // and the narinfo HEAD does that without any download.
+    return CacheProbeResult(path, "successful-substitute", 0, "");
 }
 
 string classifyProbeFailure(string stderr)


### PR DESCRIPTION
## Summary

You were right: I observed for myself today that infra main CI/CD is stuck. After PR `infra#969` (which fixed the usb-drive kernel rebuild from 6h → 1m38s), the next bottleneck is the cache integrity probe added in `nixos-modules#441`.

The infra main run `26633107692` ran cleanly through eval-matrix and almost all matrix builds, then sat in the cache-push step for **3h54min** with the cachix daemon running and `nix copy --from cache.nixos.org ... gnome-settings-daemon-49.1 ...` as the active child of the `mcl cache push-closure` process. Closure has thousands of paths; the probe is per-path; each one downloads and re-imports into a throwaway local store.

The narinfo HEAD that `nix path-info` issues against the substituter is sufficient evidence that a path is resolvable from a trusted cache. The follow-up full download and re-import was costing 1 round-trip + sig-verify + store import + cleanup per path with no informational benefit beyond what the narinfo HEAD already proved. Every path that lands on a target host has its signature re-verified there anyway, by the local nix-daemon, when the closure is materialised.

## Effect

`mcl cache push-closure ... --require-substitute` now runs in O(closure-size) HEAD-requests instead of O(closure-size) full downloads. Expected end-to-end probe time per machine: minutes → seconds.

## Verification

- Both existing cache-backends tests (`test_cache_probe_classifies_failures`, `test_cache_push_closure_invokes_backend`) still pass locally.
- `classifyProbeFailure` is unchanged — same stderr-string-based classification when the narinfo HEAD itself fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)