### PR TITLE
fix(reusable-flake-checks-ci-matrix): pass -- to nix run deploy-status

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -423,7 +423,10 @@ jobs:
         if: always() && inputs.run-cachix-deploy
         run: |
           if [[ -f .result/deployment-events.jsonl ]]; then
-            ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} deploy-status summarize \
+            # `--` separates `nix run` flags from mcl's flags. Without it,
+            # `nix run` greedily parses `--output` as one of its own and
+            # exits with "unrecognised flag '--output'".
+            ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} -- deploy-status summarize \
               .result/deployment-events.jsonl \
               --output .result/deployment-summary.md \
               --json-output .result/deployment-summary.json


### PR DESCRIPTION
## Summary

Observed in infra main run [26644801445](https://github.com/metacraft-labs/infra/actions/runs/26644801445): every per-machine build job succeeded, but `ci / Final Results` failed with:

\`\`\`
error: unrecognised flag '--output'
Try 'nix --help' for more information.
\`\`\`

The \"Generate deployment summary\" step runs:

\`\`\`
nix run --accept-flake-config github:.../#mcl \\
  deploy-status summarize \\
  .result/deployment-events.jsonl \\
  --output .result/deployment-summary.md \\
  --json-output .result/deployment-summary.json
\`\`\`

Without \`--\`, \`nix run\` parses \`--output\` as one of its own flags and exits 1. The Final Results job then reports failure, which makes the overall CI/CD reported failure → \`cachix deploy activate\` never runs → Solunska stays pinned to the May 12 closure.

Add the separator (matching the existing \`cache push-closure\` and \`ci-matrix\` invocations elsewhere in this file that already use it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)