### PR TITLE
fix(deploy-spec): skip redundant cache push on aggregator runner

### DIFF
--- a/packages/mcl/src/mcl/commands/deploy_spec.d
+++ b/packages/mcl/src/mcl/commands/deploy_spec.d
@@ -41,22 +41,6 @@ struct DeploySpecDependencies
     ProcessRunner queryProcess;
 }
 
-private string[] pushDeploymentClosureCommand(DeploySpec spec, string cachixCache)
-{
-    return [
-        "bash", "-euo", "pipefail", "-c",
-        q{
-cache="$1"
-shift
-
-nix-store -r "$@"
-nix-store -qR "$@" | cachix push "$cache"
-        },
-        "mcl-push-deployment-closure",
-        cachixCache,
-    ] ~ spec.agents.values;
-}
-
 export int deploy_spec(DeploySpecArgs args)
 {
     return deploySpecImpl(args, DeploySpecDependencies(
@@ -215,9 +199,31 @@ int deploySpecImpl(DeploySpecArgs args, DeploySpecDependencies deps, string depl
         args.cachixCache
     );
 
-    auto pushCommand = pushDeploymentClosureCommand(spec, args.cachixCache);
-    auto pushResult = deps.runProcess(pushCommand);
-
+    // NOTE: deploy_spec used to run a second `nix-store -r ... | cachix push`
+    // here, but that turned out to be redundant *and* prone to failure on the
+    // Final Results runner.
+    //
+    //   * Redundant: the matrix-build step in the reusable workflow already
+    //     ran `mcl cache push-closure` for every machine on the per-machine
+    //     runner where the closure was actually built. By the time deploy_spec
+    //     runs on the aggregator (Final Results) runner, the closure narinfos
+    //     are on the configured Cachix cache and the activation only needs
+    //     `cachix deploy activate` to point the agent at the deploy spec.
+    //
+    //   * Prone to failure: the aggregator runner does not have the closure
+    //     in its local /nix/store (matrix builds happen on other runners).
+    //     The old `nix-store -r ...` step needed to substitute every system
+    //     closure first — and when nix-eval-jobs reports `isCached` based on
+    //     narinfo presence alone (without verifying the NAR is also there),
+    //     a half-pushed cache entry would let shard-matrix skip the per-
+    //     machine build step, leaving deploy_spec unable to substitute,
+    //     unable to build, and unable to push. The whole deploy then fails
+    //     at the redundant push step (`don't know how to build these paths`).
+    //
+    // The activate step below is sufficient: cachix-agent on the target host
+    // substitutes from the configured caches, and the agent fails clearly if
+    // a NAR is missing. Emit a single skipped `cache-push` event per agent
+    // so the deployment event log still records the phase.
     if (eventLoggingEnabled)
         foreach (target, systemPath; spec.agents)
             appendDeploymentEvent(eventLogPath, deploymentEventJson(
@@ -226,19 +232,21 @@ int deploySpecImpl(DeploySpecArgs args, DeploySpecDependencies deps, string depl
                 target,
                 systemPath,
                 "mcl-push-deployment-closure",
-                pushCommand,
-                pushResult.succeeded ? "succeeded" : "failed",
-                pushResult.exitCode,
+                ["skipped-by-deploy-spec"],
+                "skipped",
+                0,
                 queryClosureSummary(systemPath, queryRunner),
-                pushResult.succeeded ? "" : "Closure push failed before activation",
-                "closure_push_failed",
-                pushResult.succeeded ? "" : pushResult.stderr.stderrSummary,
+                "",
+                "command_failed",
+                "",
                 [
                     "deploySpecFile": JSONValue(deploySpecFile),
+                    "reason": JSONValue(
+                        "Per-machine matrix push handles the closure upload; "
+                        ~ "deploy_spec runs on the aggregator and only triggers activation."
+                    ),
                 ],
             ));
-
-    enforce(pushResult.succeeded, "Closure push failed.");
 
     auto activateCommand = [
         "cachix", "deploy", "activate", deploySpecFile, "--async"
@@ -318,8 +326,12 @@ unittest
     auto events = eventLog.readText.splitLines.filter!(line => line != "").map!(line => line.parseJSON).array;
     assert(events.length == 3);
     assert(events[0]["phase"].str == "evaluate");
+    // deploy_spec no longer invokes its own cache push; it records a
+    // "skipped" cache-push event to keep the event sequence shape stable
+    // for consumers. The per-machine matrix push step in the workflow is
+    // the actual cache push.
     assert(events[1]["phase"].str == "cache-push");
-    assert(events[1]["command"]["status"].str == "succeeded");
+    assert(events[1]["command"]["status"].str == "skipped");
     assert(events[2]["phase"].str == "activate-requested");
     assert(events[2]["command"]["status"].str == "succeeded");
     assert(events[2]["storePaths"]["closure"]["count"].integer == 2);


### PR DESCRIPTION
## Summary

The cache push step in \`deploy_spec\` was a leftover from when M0/M1 ran on the same runner that built the closures. After M2 split the push into a per-machine matrix step (\`Push deployment closure caches\`), the deploy_spec push became redundant AND broken.

Observed in [infra main run 26645543960](https://github.com/metacraft-labs/infra/actions/runs/26645543960/job/78530257631):

\`\`\`
[info] Pushing deployment closure for 13 agents to Cachix cache 'metacraft-private-infrastructure'.
don't know how to build these paths:
  /nix/store/bi5sq75vd9sfj4fy12faa4yd5cg8w2y7-nixos-system-shared-workstation-001-...
  /nix/store/fq9hdagwcgrlzmbizbn6fw7whkj5516q-nixos-system-gpu-server-001-...
  [...]
object.Exception@src/mcl/commands/deploy_spec.d(241): Closure push failed.
\`\`\`

## Root cause

deploy_spec runs on the aggregator (\`Final Results\`) runner. It doesn't have the closures in its local \`/nix/store\` — they were built on per-matrix runners. The inner \`nix-store -r ... | cachix push\` requires the paths to be in /nix/store to push.

When \`nix-eval-jobs\` \`isCached\` returns true based on narinfo presence on Cachix, shard-matrix skips the per-machine build entirely — so the aggregator can't substitute either. Half-pushed entries (narinfo without NAR) cause \`nix-store -r\` to fail with \"don't know how to build these paths\" and the whole deploy aborts before activation.

## Fix

Drop the push step from \`deploy_spec\`. Activation alone is sufficient: cachix-agent on each target host substitutes from the configured cache and fails loudly if a NAR is genuinely missing.

Emit a \`cache-push\` event with \`status=\"skipped\"\` so the event-log shape stays stable for downstream consumers (\`deploy-status summarize\`).

## Verification

Both \`deploy_spec\` unit tests updated and pass locally (success-shape with skipped cache-push event, failure-shape on activate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)