### PR TITLE
fix(ci): allow cache status without cachix

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -9,10 +9,12 @@ inputs:
     default: false
   cachix-cache:
     description: The name of the cachix cache to use
-    required: true
+    required: false
+    default: ''
   cachix-auth-token:
     description: Cachix auth token
-    required: true
+    required: false
+    default: ''
   trusted-public-keys:
     description: Trusted public keys
     required: false
@@ -118,12 +120,16 @@ runs:
           netrc-file = $HOME/.config/nix/netrc
         EOF
 
-        cat << EOF > "$HOME/.config/nix/netrc"
-          machine ${{inputs.cachix-cache}}.cachix.org password ${{inputs.cachix-auth-token}}
+        touch "$HOME/.config/nix/netrc"
+        chmod 0600 "$HOME/.config/nix/netrc"
+        if [[ -n "${{ inputs.cachix-cache }}" && -n "${{ inputs.cachix-auth-token }}" ]]; then
+          cat << EOF >> "$HOME/.config/nix/netrc"
+          machine ${{ inputs.cachix-cache }}.cachix.org password ${{ inputs.cachix-auth-token }}
         EOF
+        fi
 
     - uses: cachix/cachix-action@v15
-      if: ${{ fromJSON(inputs.push-to-cache || 'false') }}
+      if: ${{ fromJSON(inputs.push-to-cache || 'false') && inputs.cachix-cache != '' && inputs.cachix-auth-token != '' }}
       with:
         name: ${{ inputs.cachix-cache }}
         authToken: ${{ inputs.cachix-auth-token }}

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -40,7 +40,7 @@ on:
     secrets:
       CACHIX_AUTH_TOKEN:
         description: 'Cachix auth token'
-        required: true
+        required: false
       CACHIX_ACTIVATE_TOKEN:
         description: 'Cachix activate token'
         required: false
@@ -119,6 +119,7 @@ jobs:
         env:
           CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} shard-matrix
 
@@ -152,6 +153,7 @@ jobs:
         env:
           CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
         run: |
           ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} -- ci-matrix \
@@ -192,6 +194,7 @@ jobs:
           IS_INITIAL: 'true'
           CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           PRECALC_MATRIX: ${{ steps.merge.outputs.full_matrix }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} print-table
 

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -16,7 +16,7 @@ on:
         required: false
       CACHIX_AUTH_TOKEN:
         description: 'Cachix auth token'
-        required: true
+        required: false
       NIX_GITLAB_TOKEN:
         description: GitLab token to add as access-token in nix.conf
         required: false

--- a/.github/workflows/reusable-nix-diff.yml
+++ b/.github/workflows/reusable-nix-diff.yml
@@ -16,7 +16,7 @@ on:
     secrets:
       CACHIX_AUTH_TOKEN:
         description: 'Cachix auth token'
-        required: true
+        required: false
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false

--- a/.github/workflows/reusable-update-flake-lock.yml
+++ b/.github/workflows/reusable-update-flake-lock.yml
@@ -29,7 +29,7 @@ on:
         required: false
       CACHIX_AUTH_TOKEN:
         description: 'Cachix auth token'
-        required: true
+        required: false
       CREATE_PR_APP_ID:
         description: ID of the GitHub App used for opening pull requests.
         required: true

--- a/.github/workflows/reusable-update-flake-packages.yml
+++ b/.github/workflows/reusable-update-flake-packages.yml
@@ -19,7 +19,7 @@ on:
         required: false
       CACHIX_AUTH_TOKEN:
         description: 'Cachix auth token'
-        required: true
+        required: false
       CREATE_PR_APP_ID:
         description: ID of the GitHub App used for opening pull requests.
         required: true

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -61,7 +61,6 @@
 
       packages = {
         cachix-deploy-metrics = pkgs.callPackage ./cachix-deploy-metrics { };
-        deployment-event-metrics = pkgs.callPackage ./deployment-event-metrics { };
         lido-withdrawals-automation = pkgs.callPackage ./lido-withdrawals-automation { };
         pyroscope = pkgs.callPackage ./pyroscope { };
         random-alerts = pkgs.callPackage ./random-alerts { };
@@ -74,6 +73,7 @@
         aztec = pkgs.callPackage ./aztec { };
       }
       // optionalAttrs isLinux {
+        deployment-event-metrics = pkgs.callPackage ./deployment-event-metrics { };
         folder-size-metrics = pkgs.callPackage ./folder-size-metrics { };
         ci-image = pkgs.callPackage ./ci-image {
           inherit (inputs'.nix2container.packages) nix2container;

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -189,7 +189,7 @@ mixin template CiMatrixBaseArgs()
     import std.json : parseJSON;
     import std.stdio : writeln, stderr, stdout;
 
-    import argparse : Command, Description, NamedArgument, Required, Parse, Placeholder, EnvFallback;
+    import argparse : Command, Description, NamedArgument, Placeholder, EnvFallback;
 
     import mcl.utils.json : fromJSON;
     import mcl.utils.cachix : cachixNixStoreUrl;
@@ -220,7 +220,6 @@ mixin template CiMatrixBaseArgs()
     @(NamedArgument(["cachix-cache"])
         .Placeholder("cache-name")
         .EnvFallback("CACHIX_CACHE")
-        .Required()
     )
     string cachixCache;
 
@@ -238,19 +237,37 @@ mixin template CiMatrixBaseArgs()
 
     string[] binaryCacheUrls() const
     {
-        import std.algorithm.iteration : map;
+        import std.algorithm.iteration : filter, joiner, map;
         import std.range : array, chain;
-        return (this.cachixCache ~ this.extraCachixCaches)
+        import std.string : split;
+
+        const string[] cachixCaches = (
+            this.cachixCache.length
+                ? [this.cachixCache]
+                : []
+        )
+            .chain(this.extraCachixCaches)
+            .filter!(cache => cache.length)
+            .array;
+
+        return cachixCaches
             .map!cachixNixStoreUrl
-            .chain(this.extraCacheUrls)
+            .chain(this.extraCacheUrls.map!(urls => urls.split).joiner)
+            .filter!(url => url.length)
             .array
             .to!(string[]);
+    }
+
+    string[string] cacheStatusAuthHeaders() const
+    {
+        return this.cachixAuthToken.length
+            ? ["Authorization": "Bearer " ~ this.cachixAuthToken]
+            : null;
     }
 
     @(NamedArgument(["cachix-auth-token"])
         .Placeholder("token")
         .EnvFallback("CACHIX_AUTH_TOKEN")
-        .Required()
     )
     string cachixAuthToken;
 
@@ -280,6 +297,41 @@ mixin template CiMatrixBaseArgs()
 struct CiMatrixArgs
 {
     mixin CiMatrixBaseArgs!();
+}
+
+@("ci matrix cache URLs do not require Cachix")
+unittest
+{
+    auto args = CiMatrixArgs(
+        cachixCache: "",
+        extraCachixCaches: ["", "team-cache"],
+        extraCacheUrls: ["https://attic.example/cache https://mirror.example/cache", ""],
+        cachixAuthToken: "",
+    );
+
+    assert(args.binaryCacheUrls == [
+        "https://team-cache.cachix.org",
+        "https://attic.example/cache",
+        "https://mirror.example/cache",
+    ]);
+    assert(args.cacheStatusAuthHeaders is null);
+}
+
+@("ci matrix cache status authorization is optional")
+unittest
+{
+    auto args = CiMatrixArgs(
+        cachixCache: "primary-cache",
+        extraCachixCaches: [],
+        extraCacheUrls: ["https://cache.nixos.org"],
+        cachixAuthToken: "secret",
+    );
+
+    assert(args.binaryCacheUrls == [
+        "https://primary-cache.cachix.org",
+        "https://cache.nixos.org",
+    ]);
+    assert(args.cacheStatusAuthHeaders["Authorization"] == "Bearer secret");
 }
 
 @(Command("print-table", "print_table")
@@ -336,17 +388,13 @@ Package[] checkCacheStatus(T)(Package[] packages, auto ref T args)
         @MaxWidth(80) string output;
     }
 
-    immutable string[string] cachixAuthHeaders = [
-        "Authorization": "Bearer " ~ args.cachixAuthToken
-    ];
-
     const useOscLinks = supportsOscLinks();
     foreach (ref pkg; packages.parallel) {
         // Skip cache check if already has cached URLs
         if (pkg.cachedAt.empty)
         {
             pkg.cachedAt ~= args.binaryCacheUrls
-                .filter!(url => pkg.isCached(url, cachixAuthHeaders))
+                .filter!(url => pkg.isCached(url, args.cacheStatusAuthHeaders))
                 .map!(url => pkg.getNarInfoUrl(url))
                 .array;
         }
@@ -488,10 +536,6 @@ Package[] nixEvalJobs(T)(string flakeAttrPath, auto ref T args)
     {
         errorf("Command `%s` failed with error:\n---\n%s\n---", commandString, msg);
     }
-
-    immutable string[string] cachixAuthHeaders = [
-        "Authorization": "Bearer " ~ args.cachixAuthToken
-    ];
 
     const errorsReported = pipes.stdout.byLine.fold!((errorsReported, line) {
         auto json = parseJSON(line);

--- a/packages/mcl/src/mcl/commands/deploy_plan.d
+++ b/packages/mcl/src/mcl/commands/deploy_plan.d
@@ -226,6 +226,25 @@ unittest
     args.output = manifestPath;
     args.stateDir = stateDir;
 
+    const hadGitHubRunId = "GITHUB_RUN_ID" in environment;
+    const oldGitHubRunId = environment.get("GITHUB_RUN_ID", "");
+    const hadGitHubSha = "GITHUB_SHA" in environment;
+    const oldGitHubSha = environment.get("GITHUB_SHA", "");
+    scope(exit)
+    {
+        if (hadGitHubRunId)
+            environment["GITHUB_RUN_ID"] = oldGitHubRunId;
+        else
+            environment.remove("GITHUB_RUN_ID");
+
+        if (hadGitHubSha)
+            environment["GITHUB_SHA"] = oldGitHubSha;
+        else
+            environment.remove("GITHUB_SHA");
+    }
+    environment.remove("GITHUB_RUN_ID");
+    environment.remove("GITHUB_SHA");
+
     assert(deployPlanImpl(args, (string[] command) => runProcessCapture(command)) == 0);
     auto manifest = manifestPath.readText.parseJSON;
     assert(manifest["deploymentId"].str == "gh-local-unknown-app-1");


### PR DESCRIPTION
## Summary
- make Cachix cache/token optional in shared setup and reusable workflows
- let MCL matrix/status checks use explicit cache URLs from repository substituters, including GitHub's space-separated `SUBSTITUTERS` variable
- avoid sending an empty Cachix bearer token and avoid probing `https://.cachix.org`
- make the deploy-plan manifest unit test deterministic under GitHub CI environment variables
- keep the Linux-only `deployment-event-metrics` package out of Darwin package/check evaluation

## Validation
- `nix build --accept-flake-config .#mcl`
- `nix develop --accept-flake-config .#default -c dub test --root packages/mcl -- -e 'fetchJson|(coda\.)|nix.run|nix.build'`
- `nix develop --accept-flake-config .#pre-commit -c prek run --all-files --show-diff-on-failure --color always`
- `nix eval --accept-flake-config --json .#checks.aarch64-darwin --apply builtins.attrNames`
- CI-shaped local smoke: `mcl shard-matrix` with GitHub runner labels and space-separated `EXTRA_CACHE_URLS`
- Agent Harbor smoke: `mcl shard-matrix` with empty `CACHIX_CACHE`/`CACHIX_AUTH_TOKEN`
- Agent Harbor smoke: `mcl print-table` with empty `CACHIX_CACHE`/`CACHIX_AUTH_TOKEN`
- Agent Harbor smoke: `mcl ci-matrix --flake-attribute-path mcl.shard-matrix.result.shards.shard-0 --is-initial` with empty `CACHIX_CACHE`/`CACHIX_AUTH_TOKEN`
- Agent Harbor smoke: `mcl ci-matrix ...` with space-separated `EXTRA_CACHE_URLS`

This keeps Cachix behavior when cache/token are configured, while allowing Attic-only consumers to finish the migration.