### PR TITLE
fix(terraform-ci): ignore local AWS profiles in tofu jobs

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -357,7 +357,13 @@ jobs:
             backend_args+=("-backend-config=$(realpath --relative-to="$PWD" "$backend_path")")
           done < <(printf '%s\n' "$backend_config_files" | tr ',' '\n')
 
-          nix develop --accept-flake-config --command tofu init -input=false "${backend_args[@]}"
+          run_tofu() {
+            nix develop --accept-flake-config --command bash -euo pipefail -c \
+              'unset AWS_PROFILE AWS_DEFAULT_PROFILE; exec tofu "$@"' \
+              -- "$@"
+          }
+
+          run_tofu init -input=false "${backend_args[@]}"
 
           plan_bin="$plan_dir/plan.tfplan"
           plan_text="$plan_dir/plan.txt"
@@ -365,7 +371,7 @@ jobs:
           plan_json="$plan_dir/plan.json"
 
           set +e
-          nix develop --accept-flake-config --command tofu plan \
+          run_tofu plan \
             -input=false \
             -no-color \
             -lock=false \
@@ -607,7 +613,13 @@ jobs:
             backend_args+=("-backend-config=$(realpath --relative-to="$PWD" "$backend_path")")
           done < <(printf '%s\n' "$backend_config_files" | tr ',' '\n')
 
-          nix develop --accept-flake-config --command tofu init -input=false "${backend_args[@]}"
+          run_tofu() {
+            nix develop --accept-flake-config --command bash -euo pipefail -c \
+              'unset AWS_PROFILE AWS_DEFAULT_PROFILE; exec tofu "$@"' \
+              -- "$@"
+          }
+
+          run_tofu init -input=false "${backend_args[@]}"
 
           plan_bin="$apply_dir/plan.tfplan"
           plan_text="$apply_dir/plan.txt"
@@ -616,7 +628,7 @@ jobs:
           apply_stderr="$apply_dir/apply.stderr"
 
           set +e
-          nix develop --accept-flake-config --command tofu plan \
+          run_tofu plan \
             -input=false \
             -no-color \
             -lock-timeout=300s \
@@ -638,7 +650,7 @@ jobs:
           fi
 
           set +e
-          nix develop --accept-flake-config --command tofu apply \
+          run_tofu apply \
             -input=false \
             -no-color \
             -auto-approve \
@@ -710,14 +722,18 @@ jobs:
       - name: Init
         run: |
           cd ${{ inputs.working_directory }}
-          nix develop --accept-flake-config --command tofu init \
+          nix develop --accept-flake-config --command bash -euo pipefail -c \
+            'unset AWS_PROFILE AWS_DEFAULT_PROFILE; exec tofu "$@"' \
+            -- init \
             ${{ inputs.backend_config_file != '' && format('-backend-config=../{0}', inputs.backend_config_file) || '' }}
 
       - name: Detect drift
         id: drift
         run: |
           cd ${{ inputs.working_directory }}
-          nix develop --accept-flake-config --command tofu plan -detailed-exitcode 2>&1 | tee /tmp/drift-plan.txt || {
+          nix develop --accept-flake-config --command bash -euo pipefail -c \
+            'unset AWS_PROFILE AWS_DEFAULT_PROFILE; exec tofu "$@"' \
+            -- plan -detailed-exitcode 2>&1 | tee /tmp/drift-plan.txt || {
             exit_code=$?
             if [ "$exit_code" -eq 2 ]; then
               echo "drift_detected=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- run native `tofu` commands through a small wrapper that unsets `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` inside the Nix dev shell
- apply the wrapper to credentialed PR plan, main apply, and drift jobs

## Why
After #455 moved plan/apply off the dflook Docker action and into the consuming repo's Nix dev shell, Agent Harbor's PR plan reached `tofu init` but failed with:

```text
Error: failed to get shared config profile, agent-harbor-admin
```

The consuming repo dev shell sets a workstation-oriented default `AWS_PROFILE`. In GitHub Actions, AWS credentials are already supplied by OIDC environment variables, so profile selectors from a shell hook must not be allowed to override them.

## Validation
- `actionlint .github/workflows/reusable-terraform-ci.yml`
- `git diff --check`
- `nix develop --accept-flake-config .#pre-commit -c prek run --files .github/workflows/reusable-terraform-ci.yml --show-diff-on-failure --color always`
