### PR TITLE
fix(terraform-ci): provide python for plan gates

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -404,7 +404,8 @@ jobs:
           fi
           echo "text_plan_path=$(realpath --relative-to="$GITHUB_WORKSPACE" "$plan_text")" >> "$GITHUB_OUTPUT"
 
-          python3 - "$plan_json" "$GITHUB_OUTPUT" <<'PY'
+          nix shell --accept-flake-config --inputs-from "$GITHUB_WORKSPACE" nixpkgs#python3 --command \
+            python3 - "$plan_json" "$GITHUB_OUTPUT" <<'PY'
           import json
           import os
           import sys
@@ -461,7 +462,7 @@ jobs:
             exit 0
           fi
           # Detect resources with replace actions (create + delete)
-          REPLACES=$(python3 -c "
+          REPLACES=$(nix shell --accept-flake-config --inputs-from "$GITHUB_WORKSPACE" nixpkgs#python3 --command python3 -c "
           import json, sys
           plan = json.load(open(sys.argv[1]))
           replaces = [
@@ -507,7 +508,8 @@ jobs:
           fi
 
           # Run policy check
-          python3 /tmp/tofu-plan-policy.py "$PLAN_JSON" "${POLICY_ARGS[@]}"
+          nix shell --accept-flake-config --inputs-from "$GITHUB_WORKSPACE" nixpkgs#python3 --command \
+            python3 /tmp/tofu-plan-policy.py "$PLAN_JSON" "${POLICY_ARGS[@]}"
 
       - name: Sensitive-change gate
         if: inputs.sensitive_change_label != '' && steps.plan.outputs.changes == 'true'


### PR DESCRIPTION
## Summary
- run plan-count, replace-detection, and policy Python helpers through `nix shell nixpkgs#python3`
- avoid depending on `python3` being present on the GitHub runner PATH or in the consuming repository dev shell

## Why
After #456 fixed AWS profile leakage, Agent Harbor's credentialed AWS PR plan successfully initialized the S3 backend and reported:

```text
No changes. Your infrastructure matches the configuration.
```

The job then failed in the reusable workflow's post-plan accounting step because the self-hosted runner did not have `python3` on PATH:

```text
python3: command not found
```

The reusable workflow should supply its own interpreter for its own Python helpers.

## Validation
- `actionlint .github/workflows/reusable-terraform-ci.yml`
- `git diff --check`
- `nix develop --accept-flake-config .#pre-commit -c prek run --files .github/workflows/reusable-terraform-ci.yml --show-diff-on-failure --color always`
