### PR TITLE
fix(terraform-ci): avoid shell hook output in tofu runs

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -357,10 +357,9 @@ jobs:
             backend_args+=("-backend-config=$(realpath --relative-to="$PWD" "$backend_path")")
           done < <(printf '%s\n' "$backend_config_files" | tr ',' '\n')
 
+          tofu_bin="$(nix develop --accept-flake-config --command bash -euo pipefail -c 'command -v tofu' | tail -n 1)"
           run_tofu() {
-            nix develop --accept-flake-config --command bash -euo pipefail -c \
-              'unset AWS_PROFILE AWS_DEFAULT_PROFILE; exec tofu "$@"' \
-              -- "$@"
+            env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" "$@"
           }
 
           run_tofu init -input=false "${backend_args[@]}"
@@ -398,7 +397,7 @@ jobs:
           fi
 
           if [ -f "$plan_bin" ]; then
-            nix develop --accept-flake-config --command tofu show -json "$plan_bin" > "$plan_json"
+            run_tofu show -json "$plan_bin" > "$plan_json"
             echo "plan_path=$(realpath --relative-to="$GITHUB_WORKSPACE" "$plan_bin")" >> "$GITHUB_OUTPUT"
             echo "json_plan_path=$(realpath --relative-to="$GITHUB_WORKSPACE" "$plan_json")" >> "$GITHUB_OUTPUT"
           fi
@@ -615,10 +614,9 @@ jobs:
             backend_args+=("-backend-config=$(realpath --relative-to="$PWD" "$backend_path")")
           done < <(printf '%s\n' "$backend_config_files" | tr ',' '\n')
 
+          tofu_bin="$(nix develop --accept-flake-config --command bash -euo pipefail -c 'command -v tofu' | tail -n 1)"
           run_tofu() {
-            nix develop --accept-flake-config --command bash -euo pipefail -c \
-              'unset AWS_PROFILE AWS_DEFAULT_PROFILE; exec tofu "$@"' \
-              -- "$@"
+            env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" "$@"
           }
 
           run_tofu init -input=false "${backend_args[@]}"
@@ -724,18 +722,16 @@ jobs:
       - name: Init
         run: |
           cd ${{ inputs.working_directory }}
-          nix develop --accept-flake-config --command bash -euo pipefail -c \
-            'unset AWS_PROFILE AWS_DEFAULT_PROFILE; exec tofu "$@"' \
-            -- init \
+          tofu_bin="$(nix develop --accept-flake-config --command bash -euo pipefail -c 'command -v tofu' | tail -n 1)"
+          env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" init \
             ${{ inputs.backend_config_file != '' && format('-backend-config=../{0}', inputs.backend_config_file) || '' }}
 
       - name: Detect drift
         id: drift
         run: |
           cd ${{ inputs.working_directory }}
-          nix develop --accept-flake-config --command bash -euo pipefail -c \
-            'unset AWS_PROFILE AWS_DEFAULT_PROFILE; exec tofu "$@"' \
-            -- plan -detailed-exitcode 2>&1 | tee /tmp/drift-plan.txt || {
+          tofu_bin="$(nix develop --accept-flake-config --command bash -euo pipefail -c 'command -v tofu' | tail -n 1)"
+          env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" plan -detailed-exitcode 2>&1 | tee /tmp/drift-plan.txt || {
             exit_code=$?
             if [ "$exit_code" -eq 2 ]; then
               echo "drift_detected=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- resolve the `tofu` binary path from the consuming repo dev shell once
- execute that binary directly for plan/apply/drift operations with `AWS_PROFILE` selectors removed
- run `tofu show -json` without `nix develop` shell-hook output contaminating JSON

## Why
After #457 supplied Python for the plan gates, Agent Harbor's credentialed AWS PR plan initialized the backend and produced a no-op plan. The post-plan count step then failed with a JSON decode error because the reusable workflow generated plan JSON via:

```sh
nix develop --command tofu show -json ... > plan.json
```

The consuming repo shell hook prints banners and `AWS_PROFILE=...` to stdout before the command, making `plan.json` invalid. Resolving the binary once and executing it directly keeps the repo-provided OpenTofu while avoiding shell-hook output in machine-readable command streams.

## Validation
- `actionlint .github/workflows/reusable-terraform-ci.yml`
- `git diff --check`
- `nix develop --accept-flake-config .#pre-commit -c prek run --files .github/workflows/reusable-terraform-ci.yml --show-diff-on-failure --color always`
