### PR TITLE
build(flake.nix/inputs): Update nixpkgs to 26.05

### DIFF
--- a/checks/secret-integration/default.nix
+++ b/checks/secret-integration/default.nix
@@ -32,6 +32,7 @@ let
           mcl.secrets.extraKeys = [ (builtins.readFile ./test-keys/.ssh/extra_id_ed25519.pub) ];
           boot.loader.grub.enable = false;
           fileSystems."/".device = "none";
+          fileSystems."/".fsType = "tmpfs";
           system.stateVersion = "25.11";
         }
       ];

--- a/flake.lock
+++ b/flake.lock
@@ -415,7 +415,7 @@
         ],
         "foundry-nix": "foundry-nix",
         "nixpkgs": [
-          "nixos-2505"
+          "nixos-2511"
         ],
         "nixpkgs-unstable": [
           "nixpkgs-unstable"
@@ -1022,16 +1022,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1777851538,
-        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
+        "lastModified": 1780361225,
+        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
+        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -1225,16 +1225,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1772129556,
-        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
         "owner": "nix-darwin",
-        "ref": "nix-darwin-25.11",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -1475,22 +1475,6 @@
         "type": "github"
       }
     },
-    "nixos-2505": {
-      "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixos-2511": {
       "locked": {
         "lastModified": 1778003029,
@@ -1503,6 +1487,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixos-2605": {
+      "locked": {
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1857,12 +1857,12 @@
         "nix-topology": "nix-topology",
         "nix2container": "nix2container",
         "nixd": "nixd_2",
-        "nixos-2505": "nixos-2505",
         "nixos-2511": "nixos-2511",
+        "nixos-2605": "nixos-2605",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-images": "nixos-images",
         "nixpkgs": [
-          "nixos-2511"
+          "nixos-2605"
         ],
         "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems_5",

--- a/flake.nix
+++ b/flake.nix
@@ -13,14 +13,14 @@
   };
 
   inputs = {
-    nixos-2505.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixos-2511.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixos-2605.url = "github:NixOS/nixpkgs/nixos-26.05";
 
-    nixpkgs.follows = "nixos-2511";
+    nixpkgs.follows = "nixos-2605";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -30,7 +30,7 @@
     };
 
     nix-darwin = {
-      url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
+      url = "github:nix-darwin/nix-darwin/nix-darwin-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -80,7 +80,7 @@
     ethereum-nix = {
       url = "github:metacraft-labs/ethereum.nix/dev";
       inputs = {
-        nixpkgs.follows = "nixos-2505";
+        nixpkgs.follows = "nixos-2511";
         nixpkgs-unstable.follows = "nixpkgs-unstable";
         flake-parts.follows = "flake-parts";
         flake-utils.follows = "flake-utils";

--- a/lib/current-flake.nix
+++ b/lib/current-flake.nix
@@ -1,6 +1,6 @@
 let
   currentFlake = builtins.fromJSON (builtins.readFile ../flake.lock);
-  inherit (currentFlake.nodes.nixos-2511.locked)
+  inherit (currentFlake.nodes.nixos-2605.locked)
     owner
     repo
     rev

--- a/packages/cachix-deploy-metrics/default.nix
+++ b/packages/cachix-deploy-metrics/default.nix
@@ -4,11 +4,13 @@
   pkg-config,
   openssl,
   zlib,
+  dCompiler,
   ...
 }:
 buildDubPackage rec {
   pname = "cachix-deploy-metrics";
   version = "unstable";
+  inherit dCompiler;
   src = lib.fileset.toSource {
     root = ./.;
     fileset = lib.fileset.fileFilter (

--- a/packages/cachix-deploy-metrics/dub.selections.json
+++ b/packages/cachix-deploy-metrics/dub.selections.json
@@ -4,7 +4,7 @@
 		"argparse": "2.0.2",
 		"diet-ng": "1.8.4",
 		"during": "0.3.0",
-		"eventcore": "0.9.38",
+		"eventcore": "0.9.39",
 		"mir-linux-kernel": "1.2.1",
 		"openssl": "3.4.0",
 		"openssl-static": "1.0.5+3.0.8",
@@ -13,11 +13,11 @@
 		"stdx-allocator": "2.77.5",
 		"taggedalgebraic": "1.0.1",
 		"vibe-container": "1.7.1",
-		"vibe-core": "2.13.3",
-		"vibe-d": "0.10.2",
-		"vibe-http": "1.3.2",
-		"vibe-inet": "1.2.0",
-		"vibe-serialization": "1.1.3",
-		"vibe-stream": "1.3.0"
+		"vibe-core": "2.14.0",
+		"vibe-d": "0.10.3",
+		"vibe-http": "1.5.1",
+		"vibe-inet": "1.3.1",
+		"vibe-serialization": "1.2.0",
+		"vibe-stream": "1.4.1"
 	}
 }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -67,7 +67,9 @@
             exec python3 ${../scripts/attic-migrate-flake} "$@"
           '';
         };
-        cachix-deploy-metrics = pkgs.callPackage ./cachix-deploy-metrics { };
+        cachix-deploy-metrics = pkgs.callPackage ./cachix-deploy-metrics {
+          dCompiler = inputs'.dlang-nix.packages.ldc;
+        };
         consumer-flake-cachix-inventory-tool = pkgs.writeShellApplication {
           name = "consumer-flake-cachix-inventory";
           runtimeInputs = [ pkgs.python3 ];
@@ -84,7 +86,9 @@
         };
         lido-withdrawals-automation = pkgs.callPackage ./lido-withdrawals-automation { };
         pyroscope = pkgs.callPackage ./pyroscope { };
-        random-alerts = pkgs.callPackage ./random-alerts { };
+        random-alerts = pkgs.callPackage ./random-alerts {
+          dCompiler = inputs'.dlang-nix.packages."ldc-binary-1_38_0";
+        };
         mcl = pkgs.callPackage ./mcl {
           dCompiler = inputs'.dlang-nix.packages."ldc-binary-1_38_0";
           inherit (legacyPackages.inputs.nixpkgs) cachix nix nix-eval-jobs;

--- a/packages/mcl/default.nix
+++ b/packages/mcl/default.nix
@@ -21,7 +21,7 @@ let
       util-linux
       bash
       coreutils
-      xorg.xrandr
+      xrandr
       alejandra
       openssh
       cachix

--- a/packages/mcl/src/mcl/utils/test/nix/shard-matrix-ok/flake.lock
+++ b/packages/mcl/src/mcl/utils/test/nix/shard-matrix-ok/flake.lock
@@ -237,7 +237,7 @@
         "foundry-nix": "foundry-nix",
         "nixpkgs": [
           "nixos-modules",
-          "nixos-2505"
+          "nixos-2511"
         ],
         "nixpkgs-unstable": [
           "nixos-modules",
@@ -556,16 +556,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1767910483,
-        "narHash": "sha256-MOU5YdVu4DVwuT5ztXgQpPuRRBjSjUGIdUzOQr9iQOY=",
+        "lastModified": 1780361225,
+        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "82fb7dedaad83e5e279127a38ef410bcfac6d77c",
+        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -793,16 +793,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1767634391,
-        "narHash": "sha256-owcSz2ICqTSvhBbhPP+1eWzi88e54rRZtfCNE5E/wwg=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "08585aacc3d6d6c280a02da195fdbd4b9cf083c2",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
         "owner": "nix-darwin",
-        "ref": "nix-darwin-25.11",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -1028,22 +1028,6 @@
         "type": "github"
       }
     },
-    "nixos-2505": {
-      "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixos-2511": {
       "locked": {
         "lastModified": 1767799921,
@@ -1056,6 +1040,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixos-2605": {
+      "locked": {
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1156,13 +1156,13 @@
         "nix-topology": "nix-topology",
         "nix2container": "nix2container",
         "nixd": "nixd_2",
-        "nixos-2505": "nixos-2505",
         "nixos-2511": "nixos-2511",
+        "nixos-2605": "nixos-2605",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-images": "nixos-images",
         "nixpkgs": [
           "nixos-modules",
-          "nixos-2511"
+          "nixos-2605"
         ],
         "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems_4",

--- a/packages/random-alerts/default.nix
+++ b/packages/random-alerts/default.nix
@@ -1,7 +1,8 @@
-{ buildDubPackage, ... }:
+{ buildDubPackage, dCompiler, ... }:
 buildDubPackage rec {
   pname = "random-alerts";
   version = "1.0.0";
+  inherit dCompiler;
   src = ./.;
   dubLock = {
     dependencies = { };

--- a/shells/default.nix
+++ b/shells/default.nix
@@ -44,9 +44,9 @@
               pkg-config
               repl
               rage
-              dub
               dub-to-nix
-              ldc
+              inputs'.dlang-nix.packages.dub
+              inputs'.dlang-nix.packages.ldc
               inputs'.nixpkgs-unstable.legacyPackages.act
               podman-as-docker
 
@@ -57,7 +57,7 @@
               tflint
             ]
             ++ pkgs.lib.optionals (pkgs.stdenv.system == "x86_64-linux") [
-              dmd
+              inputs'.dlang-nix.packages.dmd
             ]
             ++ config.pre-commit.settings.enabledPackages
             ++ [ config.pre-commit.settings.package ];


### PR DESCRIPTION
```
• Updated input 'ethereum-nix/nixpkgs':
    follows 'nixos-2505'
  → follows 'nixos-2511'
• Updated input 'home-manager':
    'github:nix-community/home-manager/cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5?narHash=sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8%3D' (2026-05-03)
  → 'github:nix-community/home-manager/e28654b71096e08c019d4861ca26acb646f583d8?narHash=sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA%3D' (2026-06-02)
• Updated input 'nix-darwin':
    'github:nix-darwin/nix-darwin/ebec37af18215214173c98cf6356d0aca24a2585?narHash=sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg%3D' (2026-02-26)
  → 'github:nix-darwin/nix-darwin/56c666e108467d87d13508936aade6d567f2a501?narHash=sha256-zXcwYQGCT6pzinK%2B1dBB2ekTVtfxGZAapb3Evdcu4fY%3D' (2026-05-17)
• Removed input 'nixos-2505'
• Added input 'nixos-2605':
    'github:NixOS/nixpkgs/6b316287bae2ee04c9b93c8c858d930fd07d7338?narHash=sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4%2BYJCYVmQ7FY%3D' (2026-06-03)
• Updated input 'nixpkgs':
    follows 'nixos-2511'
  → follows 'nixos-2605'
```
