### PR TITLE
fix(setup-nix): fail when the devShell can't be built

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -141,16 +141,64 @@ runs:
         primary-key: ${{ inputs.nix-cache-key }}
         restore-prefixes-first-match: ${{ inputs.nix-cache-restore-prefixes }}
 
-    - name: Build & activate the Nix Dev Shell
+    # Resolve which flake devShell to build/activate, validating the inputs.
+    # In `devshell` mode the ref is given directly; in `use-direnv` mode we read
+    # it from the repo's .envrc when it loads a flake (`use flake [ref]`,
+    # defaulting to the '.' default devShell). The output `flake-ref` stays
+    # empty for non-flake .envrc files, which we cannot pre-build generically.
+    - name: Determine the devShell to build
+      id: determine-devshell
       if: ${{ fromJSON(inputs.use-direnv || 'false') || inputs.devshell != '' }}
       shell: bash
       run: |
-        direnv() { nix run --inputs-from . nixpkgs#direnv -- "$@"; }
-
         if [ "${{ inputs.devshell }}" != "" ] && [ "${{ inputs.use-direnv }}" == "true" ]; then
           echo "Error: 'devshell' and 'use-direnv' are mutually exclusive."
           exit 1
         fi
+
+        flake_ref=""
+        if [ "${{ inputs.devshell }}" != "" ]; then
+          flake_ref=".#${{ inputs.devshell }}"
+        elif [ "${{ inputs.use-direnv }}" == "true" ]; then
+          if [ ! -f .envrc ]; then
+            echo "Error: 'use-direnv' is enabled but .envrc does not exist."
+            exit 1
+          fi
+          if grep -qE '^[[:space:]]*use[[:space:]]+flake' .envrc; then
+            flake_ref="$(sed -n 's/^[[:space:]]*use[[:space:]][[:space:]]*flake[[:space:]]*//p' .envrc | head -n1)"
+            flake_ref="${flake_ref:-.}"
+          fi
+        fi
+
+        echo "flake-ref=$flake_ref" >> "$GITHUB_OUTPUT"
+        echo "Resolved devShell flake ref: '${flake_ref:-<none>}'"
+
+    # Build the devShell explicitly so a build/eval failure aborts the job here
+    # with a clear error. This is necessary because direnv's `use flake`
+    # swallows such failures: it runs `eval "$(nix print-dev-env ...)"`, so when
+    # the devShell fails to build the substitution is empty, `eval ""` succeeds,
+    # and the later `direnv export` still exits 0 while leaving $GITHUB_ENV
+    # without the devShell's PATH. The action would then report success and the
+    # real failure would only surface in a later step as an obscure
+    # "<tool>: command not found" (exit 127). `nix print-dev-env` propagates the
+    # build/eval exit code, so we use it to fail fast.
+    - name: Build the Nix DevShell
+      if: ${{ steps.determine-devshell.outputs.flake-ref != '' }}
+      shell: bash
+      run: |
+        echo "::group::Building Nix DevShell"
+        nix --extra-experimental-features "nix-command flakes" \
+          print-dev-env "${{ steps.determine-devshell.outputs.flake-ref }}" >/dev/null
+        echo "::endgroup::"
+
+    # Generate the .envrc (in `devshell` mode) or use the repo's existing one
+    # (in `use-direnv` mode), then export the devShell environment to
+    # $GITHUB_ENV via direnv so subsequent steps run inside it.
+    - name: Activate the Nix DevShell
+      if: ${{ fromJSON(inputs.use-direnv || 'false') || inputs.devshell != '' }}
+      shell: bash
+      run: |
+        direnv() { nix run --inputs-from . nixpkgs#direnv -- "$@"; }
 
         if [ "${{ inputs.devshell }}" != "" ]; then
           # Function to restore .envrc
@@ -165,14 +213,9 @@ runs:
           trap restore_envrc EXIT
 
           echo "use flake .#${{ inputs.devshell }}" > .envrc
-        elif [ "${{ inputs.use-direnv }}" == "true" ]; then
-          if [ ! -f .envrc ]; then
-            echo "Error: 'use-direnv' is enabled but .envrc does not exist."
-            exit 1
-          fi
         fi
 
         direnv allow .
-        echo "::group::Building Nix DevShell"
+        echo "::group::Exporting Nix DevShell to GITHUB_ENV"
         direnv export gha >> "$GITHUB_ENV"
         echo "::endgroup::"

--- a/.github/setup-nix/tests/devshell-fixture/flake.nix
+++ b/.github/setup-nix/tests/devshell-fixture/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "Test fixture for the setup-nix action: a devShell that fails to build and one that succeeds.";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          # A devShell whose build always fails. Used to assert that the
+          # setup-nix action fails fast instead of silently reporting success
+          # (see the action's "Build the Nix DevShell" step).
+          failing = pkgs.mkShell {
+            packages = [
+              (pkgs.runCommand "always-fails" { } ''
+                echo "deliberately failing build for the setup-nix regression test" >&2
+                exit 1
+              '')
+            ];
+          };
+
+          # A devShell that builds and puts `hello` on PATH. Used to assert the
+          # success path still exports the environment to $GITHUB_ENV.
+          default = pkgs.mkShell {
+            packages = [ pkgs.hello ];
+          };
+        }
+      );
+    };
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,62 @@ jobs:
       - name: Build and test the `mcl` command
         run: dub test --root packages/mcl -- -e 'fetchJson|(coda\.)|nix.run|nix.build'
 
+  # Regression test for the setup-nix action: a devShell that fails to build
+  # must make the action fail (not silently report success and surface later as
+  # an obscure "command not found"), while a working devShell must still be
+  # exported to $GITHUB_ENV. Uses the fixture flake under
+  # `.github/setup-nix/tests/devshell-fixture/`.
+  test-setup-nix-devshell:
+    name: Validate setup-nix devShell build-failure detection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout first to use locally defined actions
+        uses: actions/checkout@v6.0.2
+
+      - name: Stage the devShell test fixture as the workspace flake
+        run: |
+          cp .github/setup-nix/tests/devshell-fixture/flake.nix ./flake.nix
+          rm -f flake.lock
+
+      - name: Setup Nix with a failing devShell (expected to fail)
+        id: setup-failing
+        continue-on-error: true
+        uses: ./.github/setup-nix
+        with:
+          push-to-cache: false
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          devshell: failing
+
+      - name: Assert the failing devShell was detected
+        run: |
+          if [ "${{ steps.setup-failing.outcome }}" != "failure" ]; then
+            echo "::error::Setup Nix reported '${{ steps.setup-failing.outcome }}' for a devShell that fails to build; expected 'failure'."
+            exit 1
+          fi
+          echo "OK: Setup Nix correctly failed when the devShell could not be built."
+
+      - name: Setup Nix with a working devShell (expected to succeed)
+        id: setup-working
+        uses: ./.github/setup-nix
+        with:
+          push-to-cache: false
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          devshell: default
+
+      - name: Assert the working devShell was exported to PATH
+        run: |
+          if ! command -v hello >/dev/null; then
+            echo "::error::'hello' from the devShell is not on PATH; the environment was not exported to GITHUB_ENV."
+            exit 1
+          fi
+          echo "OK: devShell environment exported; hello resolved to $(command -v hello)."
+
   test-mcl-secret-integration:
     runs-on: [self-hosted, nixos, x86-64-v2, bare-metal]
     steps:


### PR DESCRIPTION
## Problem

When the `setup-nix` action builds a devShell that **fails to build**, the
"Setup Nix" step nonetheless reports **success**, and the real failure only
surfaces several steps later as an obscure `<tool>: command not found`
(exit 127).

## Root cause

The step ran `direnv export gha >> "$GITHUB_ENV"`. direnv's `use flake` is:

```bash
eval "$(nix ... print-dev-env --profile ... "$@")"
```

When the devShell fails to build, the `$(...)` substitution is empty, `eval ""`
succeeds, and **`direnv export gha` exits 0 anyway** — appending a partial env
(without the devShell's PATH) to `$GITHUB_ENV`. So the step goes green and the
breakage is deferred to a later "command not found".

Verified locally: `direnv export gha` and `direnv exec . true` both exit `0` on a
failing devShell; `strict_env` does **not** help (the failure is masked inside
`use_flake`'s command substitution), but `nix print-dev-env` itself reliably
exits non-zero.

## Fix

Split the old "Build & activate the Nix Dev Shell" step into three clearer steps
and build the devShell explicitly with `nix print-dev-env` (whose exit code is
trustworthy) before the direnv export, so a build/eval failure aborts the job
with a clear error:

1. **Determine the devShell to build** — resolve the flake ref, validate inputs.
   In `devshell` mode the ref is `.#<devshell>`; in `use-direnv` mode it is read
   from the repo's `.envrc` when it loads a flake (`use flake [ref]`).
2. **Build the Nix DevShell** — `nix print-dev-env` fails fast on build/eval errors.
3. **Activate the Nix DevShell** — write/keep `.envrc`, `direnv export` to `$GITHUB_ENV`.

## Test

Adds a `test-setup-nix-devshell` CI job plus a fixture flake
(`.github/setup-nix/tests/devshell-fixture/`) that asserts:

- a devShell that fails to build makes the action **fail** (regression guard), and
- a working devShell is still exported to **PATH** (no regression).