### PR TITLE
[codex] gate deploy cache push to server targets

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -269,11 +269,12 @@ jobs:
       # The artifact upload below is already gated on run-cachix-deploy;
       # the push step itself needs the same gate.
       - name: Push deployment closure caches ${{ matrix.name }}
-        if: ${{ inputs.run-cachix-deploy && !matrix.noop }}
+        if: ${{ inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}
         shell: bash
         env:
           DEPLOY_TARGET: ${{ matrix.name }}
           DEPLOY_SYSTEM: ${{ matrix.system }}
+          DEPLOY_KIND: ${{ matrix.deploymentKind }}
           DEPLOY_STORE_PATH: ${{ matrix.output }}
           DEPLOYMENT_CACHE_PUSH_BACKENDS: ${{ inputs.deployment-cache-push-backends }}
           CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
@@ -392,7 +393,7 @@ jobs:
               --cache "$cache" \
               --target "$DEPLOY_TARGET" \
               --system "$DEPLOY_SYSTEM" \
-              --kind unknown \
+              --kind "$DEPLOY_KIND" \
               --transport cachix-agent \
               --event-log .result/deployment-cache-push-events.jsonl \
               "${substituter_args[@]}" \
@@ -401,7 +402,7 @@ jobs:
           done
 
       - uses: actions/upload-artifact@v7
-        if: ${{ always() && inputs.run-cachix-deploy && !matrix.noop }}
+        if: ${{ always() && inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}
         with:
           name: deployment-cache-push-${{ github.run_id }}-${{ strategy.job-index }}
           path: .result/deployment-cache-push-events.jsonl

--- a/checks/deployment-production-cutover.nix
+++ b/checks/deployment-production-cutover.nix
@@ -480,6 +480,10 @@ top@{ config, ... }:
               assert "run-cachix-deploy:" in workflow, "workflow no longer exposes the legacy deploy gate"
               assert re.search(r"run-cachix-deploy:.*?default:\s*false", workflow, re.S), "legacy deploy gate must default false in the reusable workflow"
               assert "if: inputs.run-cachix-deploy" in workflow, "legacy deploy step must remain explicitly gated"
+              assert "if: ''${{ inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}" in workflow, "deployment cache push must be limited to deployment targets"
+              assert "if: ''${{ always() && inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}" in workflow, "deployment cache artifact upload must be limited to deployment targets"
+              assert "DEPLOY_KIND: ''${{ matrix.deploymentKind }}" in workflow, "deployment cache push must receive the matrix deployment kind"
+              assert '--kind "$DEPLOY_KIND"' in workflow, "deployment cache push must pass the deployment kind to mcl"
               assert "mcl_flake_cmd }} deploy-spec" in workflow, "legacy fallback deploy-spec call disappeared"
               assert "cachix deploy activate" in deploy_spec, "fallback deploy-spec no longer exposes Cachix Deploy activation"
 

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -132,6 +132,8 @@ struct Package
     NixSystem system;
     string derivation;
     string output;
+    bool deploymentTarget = false;
+    string deploymentKind = "";
 
     string getNarInfoUrl(string binaryCacheHttpEndpoint) const
     {
@@ -438,23 +440,69 @@ Package packageFromNixEvalJobsJson(
     JSONValue json,
     string flakeAttrPath,
     NixSystemToGHRunner nixSystemToRunnerLabels,
+    const(string)[] deploymentTargetNames = [],
 )
 {
     auto sys = json["system"].fromJSON!NixSystem;
+    const attr = json["attr"].str;
 
     // WARN: The `isCached` property coming from `nix-eval-jobs` is
     //       insufficient as it just says if the package is cached
     //       "somewhere" (including in the local store)
     return Package(
-        name: json["attr"].str,
+        name: attr,
         allowedToFail: false,
-        attrPath: flakeAttrPath ~ "." ~ json["attr"].str,
+        attrPath: flakeAttrPath ~ "." ~ attr,
         cachedAt: [],
         system: sys,
         ghRunner: nixSystemToRunnerLabels[sys],
         derivation: json["drvPath"].str,
         output: json["outputs"]["out"].str,
+        deploymentTarget: isDeployableServerMachineAttr(flakeAttrPath, attr, deploymentTargetNames),
+        deploymentKind: deploymentKindFor(flakeAttrPath, attr, deploymentTargetNames),
     );
+}
+
+enum deployableServerMachinesAttrPath = "legacyPackages.x86_64-linux.serverMachines";
+
+bool isShardMatrixAttrPath(string flakeAttrPath)
+{
+    return flakeAttrPath.startsWith("mcl.shard-matrix.result.shards");
+}
+
+string shardMatrixMachineName(string attr)
+{
+    import std.string : split;
+
+    auto parts = attr.split("/");
+    return parts.length >= 3 && parts[0] == "machine"
+        ? parts[1]
+        : "";
+}
+
+bool isDeployableServerMachineAttr(
+    string flakeAttrPath,
+    string attr,
+    const(string)[] deploymentTargetNames = [],
+)
+{
+    if (flakeAttrPath == deployableServerMachinesAttrPath
+        || flakeAttrPath.startsWith(deployableServerMachinesAttrPath ~ "."))
+        return true;
+
+    if (!flakeAttrPath.isShardMatrixAttrPath)
+        return false;
+
+    if (attr == "serverMachines" || attr.startsWith("serverMachines/"))
+        return true;
+
+    return attr.shardMatrixMachineName != ""
+        && deploymentTargetNames.canFind(attr.shardMatrixMachineName);
+}
+
+string deploymentKindFor(string flakeAttrPath, string attr, const(string)[] deploymentTargetNames = [])
+{
+    return isDeployableServerMachineAttr(flakeAttrPath, attr, deploymentTargetNames) ? "server" : "";
 }
 
 @("packageFromNixEvalJobsJson")
@@ -504,6 +552,137 @@ unittest
         );
     }
 }
+
+@("deployment target metadata is limited to serverMachines")
+unittest
+{
+    const deploymentTargetNames = [
+        "Hetzner-FSN1-DC11-i7-4770-16-512-001",
+        "gpu-server-001",
+        "gpu-server-002",
+        "gpu-server-003",
+        "hetzner-002",
+        "hetzner-003",
+        "solunska-server",
+    ];
+
+    assert(isDeployableServerMachineAttr(
+        "legacyPackages.x86_64-linux.serverMachines",
+        "app-server-01"
+    ));
+    assert(isDeployableServerMachineAttr(
+        "mcl.shard-matrix.result.shards.shard-42",
+        "serverMachines/app-server-01/x86_64-linux",
+        deploymentTargetNames,
+    ));
+    assert(isDeployableServerMachineAttr(
+        "mcl.shard-matrix.result.shards.shard-42",
+        "machine/gpu-server-001/x86_64-linux",
+        deploymentTargetNames,
+    ));
+    assert(isDeployableServerMachineAttr(
+        "mcl.shard-matrix.result.shards.shard-42",
+        "machine/solunska-server/x86_64-linux",
+        deploymentTargetNames,
+    ));
+    assert(isDeployableServerMachineAttr(
+        "mcl.shard-matrix.result.shards.shard-42",
+        "machine/hetzner-002/x86_64-linux",
+        deploymentTargetNames,
+    ));
+    assert(isDeployableServerMachineAttr(
+        "mcl.shard-matrix.result.shards.shard-42",
+        "machine/Hetzner-FSN1-DC11-i7-4770-16-512-001/x86_64-linux",
+        deploymentTargetNames,
+    ));
+    assert(!isDeployableServerMachineAttr(
+        "mcl.shard-matrix.result.shards.shard-42",
+        "machine/elitsa-dimitrova-001/x86_64-linux",
+        deploymentTargetNames,
+    ));
+    assert(!isDeployableServerMachineAttr(
+        "mcl.shard-matrix.result.shards.shard-42",
+        "machine/usb-drive/x86_64-linux",
+        deploymentTargetNames,
+    ));
+    assert(!isDeployableServerMachineAttr(
+        "legacyPackages.x86_64-linux.checks",
+        "machine/gpu-server-001/x86_64-linux",
+        deploymentTargetNames,
+    ));
+
+    auto server = `{
+        "attr": "machine/gpu-server-001/x86_64-linux",
+        "drvPath": "/nix/store/server.drv",
+        "outputs": { "out": "/nix/store/11111111111111111111111111111111-server" },
+        "system": "x86_64-linux"
+    }`.parseJSON.packageFromNixEvalJobsJson(
+        "mcl.shard-matrix.result.shards.shard-42",
+        NixSystemToGHRunner(`{ "x86_64-linux": ["self-hosted"] }`),
+        deploymentTargetNames,
+    );
+    assert(server.deploymentTarget);
+    assert(server.deploymentKind == "server");
+
+    auto workstation = `{
+        "attr": "machine/elitsa-dimitrova-001/x86_64-linux",
+        "drvPath": "/nix/store/workstation.drv",
+        "outputs": { "out": "/nix/store/22222222222222222222222222222222-workstation" },
+        "system": "x86_64-linux"
+    }`.parseJSON.packageFromNixEvalJobsJson(
+        "mcl.shard-matrix.result.shards.shard-42",
+        NixSystemToGHRunner(`{ "x86_64-linux": ["self-hosted"] }`),
+        deploymentTargetNames,
+    );
+    assert(!workstation.deploymentTarget);
+    assert(workstation.deploymentKind == "");
+
+    auto installMedia = `{
+        "attr": "machine/usb-drive/x86_64-linux",
+        "drvPath": "/nix/store/install-media.drv",
+        "outputs": { "out": "/nix/store/33333333333333333333333333333333-install-media" },
+        "system": "x86_64-linux"
+    }`.parseJSON.packageFromNixEvalJobsJson(
+        "mcl.shard-matrix.result.shards.shard-42",
+        NixSystemToGHRunner(`{ "x86_64-linux": ["self-hosted"] }`),
+        deploymentTargetNames,
+    );
+    assert(!installMedia.deploymentTarget);
+    assert(installMedia.deploymentKind == "");
+
+    Package[] matrixPackages = [server, workstation, installMedia];
+    auto matrix = JSONValue([
+        "include": JSONValue(matrixPackages.map!toJSON.array),
+    ]);
+    assert(matrix["include"][0]["deploymentTarget"].boolean);
+    assert(matrix["include"][0]["deploymentKind"].str == "server");
+    assert(!matrix["include"][1]["deploymentTarget"].boolean);
+    assert(matrix["include"][1]["deploymentKind"].str == "");
+    assert(!matrix["include"][2]["deploymentTarget"].boolean);
+    assert(matrix["include"][2]["deploymentKind"].str == "");
+}
+
+@("workflow deployment cache push is gated by deployment target metadata")
+unittest
+{
+    const workflow = rootDir
+        .buildPath(".github/workflows/reusable-flake-checks-ci-matrix.yml")
+        .readText;
+
+    assert(workflow.canFind(
+        "if: ${{ inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}"
+    ));
+    assert(workflow.canFind(
+        "if: ${{ always() && inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}"
+    ));
+    assert(workflow.canFind(
+        "DEPLOY_KIND: ${{ matrix.deploymentKind }}"
+    ));
+    assert(workflow.canFind(
+        `--kind "$DEPLOY_KIND"`
+    ));
+}
+
 Package[] nixEvalJobs(T)(string flakeAttrPath, auto ref T args)
     if (is(T == CiMatrixArgs) || is(T == PrintTableArgs) || is(T == CiArgs) || is(T == DeploySpecArgs))
 {
@@ -520,6 +699,9 @@ Package[] nixEvalJobs(T)(string flakeAttrPath, auto ref T args)
         maxWorkers.to!string, "--max-memory-size", maxMemoryMB.to!string,
         "--flake", rootDir ~ "#" ~ flakeAttrPath
     ];
+    const deploymentTargetNames = flakeAttrPath.isShardMatrixAttrPath
+        ? getDeployableServerMachineNames()
+        : [];
 
     const commandString = nixArgs.join(" ");
 
@@ -546,7 +728,11 @@ Package[] nixEvalJobs(T)(string flakeAttrPath, auto ref T args)
             return true;
         }
 
-        Package pkg = json.packageFromNixEvalJobsJson(flakeAttrPath, NixSystemToGHRunner(args.nixSystemToGHRunner));
+        Package pkg = json.packageFromNixEvalJobsJson(
+            flakeAttrPath,
+            NixSystemToGHRunner(args.nixSystemToGHRunner),
+            deploymentTargetNames,
+        );
 
         pkg = checkCacheStatus([pkg], args)[0];
 
@@ -567,6 +753,16 @@ Package[] nixEvalJobs(T)(string flakeAttrPath, auto ref T args)
     enforce(status == 0 && !errorsReported, "Command `%s` failed with status %s".fmt(commandString, status));
 
     return result;
+}
+
+string[] getDeployableServerMachineNames(string flakeRef = rootDir)
+{
+    return nix.eval!JSONValue(flakeRef ~ "#" ~ deployableServerMachinesAttrPath, [
+            "--apply",
+            "builtins.attrNames",
+        ])
+        .ifThrown(parseJSON("[]"))
+        .fromJSON!(string[]);
 }
 
 NixSystem[] getSupportedSystems(string flakeRef = ".")

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -662,27 +662,6 @@ unittest
     assert(matrix["include"][2]["deploymentKind"].str == "");
 }
 
-@("workflow deployment cache push is gated by deployment target metadata")
-unittest
-{
-    const workflow = rootDir
-        .buildPath(".github/workflows/reusable-flake-checks-ci-matrix.yml")
-        .readText;
-
-    assert(workflow.canFind(
-        "if: ${{ inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}"
-    ));
-    assert(workflow.canFind(
-        "if: ${{ always() && inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}"
-    ));
-    assert(workflow.canFind(
-        "DEPLOY_KIND: ${{ matrix.deploymentKind }}"
-    ));
-    assert(workflow.canFind(
-        `--kind "$DEPLOY_KIND"`
-    ));
-}
-
 Package[] nixEvalJobs(T)(string flakeAttrPath, auto ref T args)
     if (is(T == CiMatrixArgs) || is(T == PrintTableArgs) || is(T == CiArgs) || is(T == DeploySpecArgs))
 {


### PR DESCRIPTION
## Summary

Restricts the reusable CI deployment cache-push step to actual Cachix Deploy server targets.

## Root Cause

When infra fixed `run-cachix-deploy` to true for `main` pushes, the reusable workflow began running `mcl cache push-closure` for every build-matrix entry. That includes non-activation outputs such as employee workstation configs and `usb-drive`, while `mcl deploy-spec` only activates `legacyPackages.x86_64-linux.serverMachines`. The result was long-running per-path substitute probes on outputs that cannot be deployed by the final activation step.

## Changes

- Add `deploymentTarget` and `deploymentKind` metadata to CI matrix entries.
- Derive deployable targets from `legacyPackages.x86_64-linux.serverMachines`, including real shard entries shaped as `machine/<host>/<system>`.
- Gate both deployment cache push and deployment-cache artifact upload on `matrix.deploymentTarget`.
- Pass `--kind "$DEPLOY_KIND"` to cache-push events.
- Add regression tests for server machine entries versus workstation/install-media entries.

## Verification

Review agent verified the real infra matrix shape and ran:

- `nix eval --json /home/zahary/metacraft/infra#legacyPackages.x86_64-linux.serverMachines --apply 'x: builtins.attrNames x'`
- `for i in 0 1 2 3; do nix eval --json /home/zahary/metacraft/infra#mcl.shard-matrix.result.shards.shard-$i --apply 'x: builtins.attrNames x'; done`
- `nix develop -c dub --root ./packages/mcl/ test -- -i "deployment target|workflow deployment"`
- `nix develop -c dub --root ./packages/mcl/ build`
- Built `mcl ci-matrix` for infra shards 1, 2, and 3 and inspected `deploymentTarget` / `deploymentKind` metadata with `jq`.
- `nix develop -c dub --root ./packages/mcl/ test -- -e coda`
- `git diff --check`
- Commit hooks: `editorconfig-checker`, `end-of-file-fixer`, `prettier`