### PR TITLE
[codex] Bound mcl substitute probes

### DIFF
--- a/packages/mcl/src/mcl/commands/cache.d
+++ b/packages/mcl/src/mcl/commands/cache.d
@@ -8,7 +8,7 @@ import argparse : Command, Default, Description, EnvFallback, NamedArgument,
     Placeholder, PositionalArgument, SubCommand, matchCmd;
 
 import mcl.utils.cache_backends : CacheBackend, CachePushRequest,
-    parseCacheBackend, pushClosure;
+    defaultCacheProbeTimeoutSeconds, parseCacheBackend, pushClosure;
 import mcl.utils.deployment_events : deploymentEventLogPathFromEnv;
 import mcl.utils.process : ProcessRunner, runProcessCapture, runProcessInlineCapture;
 
@@ -86,6 +86,12 @@ struct PushClosureArgs
         .Description("Fail when uploaded closure paths cannot be substituted from the cache"))
     bool requireSubstitute = false;
 
+    @(NamedArgument(["probe-timeout-seconds"])
+        .Placeholder("SECONDS")
+        .Description("Maximum seconds to wait for each substitute probe")
+        .EnvFallback("MCL_CACHE_PROBE_TIMEOUT_SECONDS"))
+    ulong probeTimeoutSeconds = defaultCacheProbeTimeoutSeconds;
+
     @(PositionalArgument(0)
         .Placeholder("STORE_PATH")
         .Description("Root store path to push; repeat for multiple roots"))
@@ -128,6 +134,8 @@ int cachePushClosureImpl(PushClosureArgs args, ProcessRunner runProcess, Process
     enforce(args.storePaths.length > 0, "At least one store path is required.");
     enforce(backend == CacheBackend.none || cacheName != "",
         "A cache name is required for cachix and attic backends.");
+    enforce(args.probeTimeoutSeconds > 0,
+        "--probe-timeout-seconds must be greater than zero.");
 
     auto eventLogPath = args.eventLog != ""
         ? args.eventLog
@@ -146,5 +154,6 @@ int cachePushClosureImpl(PushClosureArgs args, ProcessRunner runProcess, Process
         eventLogPath: eventLogPath,
         correlationId: args.correlationId,
         requireSubstitute: args.requireSubstitute,
+        probeTimeoutSeconds: args.probeTimeoutSeconds,
     ), runProcess, queryProcess);
 }

--- a/packages/mcl/src/mcl/utils/cache_backends.d
+++ b/packages/mcl/src/mcl/utils/cache_backends.d
@@ -1,7 +1,8 @@
 module mcl.utils.cache_backends;
 
-import std.algorithm : any, canFind, map;
+import std.algorithm : canFind, map;
 import std.array : array, join;
+import std.conv : to;
 import std.file : deleteme, exists, mkdirRecurse, rmdirRecurse;
 import std.json : JSONValue;
 import std.string : splitLines, strip, toLower;
@@ -10,6 +11,8 @@ import std.typecons : Nullable;
 import mcl.utils.deployment_events : ClosureSummary, DeploymentEventContext,
     appendDeploymentEvent, deploymentEventJson, queryClosureSummary, stderrSummary;
 import mcl.utils.process : ProcessResult, ProcessRunner;
+
+enum ulong defaultCacheProbeTimeoutSeconds = 30;
 
 enum CacheBackend
 {
@@ -32,6 +35,7 @@ struct CachePushRequest
     string eventLogPath;
     string correlationId;
     bool requireSubstitute = true;
+    ulong probeTimeoutSeconds = defaultCacheProbeTimeoutSeconds;
 }
 
 struct CachePushPlan
@@ -46,6 +50,7 @@ struct CachePushPlan
 struct CacheProbeResult
 {
     string path;
+    string substituter;
     string outcome;
     int exitCode;
     string message;
@@ -158,10 +163,12 @@ CacheProbeResult probeCacheSubstitute(
     string substituter,
     string[] trustedPublicKeys,
     ProcessRunner runner,
+    ulong timeoutSeconds = defaultCacheProbeTimeoutSeconds,
 )
 {
     if (runner is null)
-        return CacheProbeResult(path, "narinfo-missing", 1, "no process runner configured");
+        return CacheProbeResult(path, substituter, "narinfo-missing", 1,
+            "no process runner configured");
 
     auto pathInfoCommand = [
         "nix", "path-info", "--store", substituter, path,
@@ -169,10 +176,17 @@ CacheProbeResult probeCacheSubstitute(
     if (trustedPublicKeys.length)
         pathInfoCommand ~= ["--option", "trusted-public-keys", trustedPublicKeys.join(" ")];
 
-    auto pathInfo = runner(pathInfoCommand);
+    auto pathInfo = runner(cacheProbeTimeoutCommand(pathInfoCommand, timeoutSeconds));
     if (!pathInfo.succeeded)
-        return CacheProbeResult(path, classifyProbeFailure(pathInfo.stderr), pathInfo.exitCode,
-            pathInfo.stderr.stderrSummary);
+    {
+        auto outcome = isTimeoutExitCode(pathInfo.exitCode)
+            ? "probe-timeout"
+            : classifyProbeFailure(pathInfo.stderr);
+        auto message = pathInfo.stderr.stderrSummary;
+        if (outcome == "probe-timeout" && message == "")
+            message = "substitute probe exceeded " ~ timeoutSeconds.to!string ~ "s timeout";
+        return CacheProbeResult(path, substituter, outcome, pathInfo.exitCode, message);
+    }
 
     // `nix path-info` performs a `HEAD /<hash>.narinfo` against the
     // substituter — this is sufficient evidence that the path is
@@ -187,7 +201,17 @@ CacheProbeResult probeCacheSubstitute(
     // re-verified at install time on the target host. The probe's job
     // is just to answer "is this path available from a trusted cache?"
     // and the narinfo HEAD does that without any download.
-    return CacheProbeResult(path, "successful-substitute", 0, "");
+    return CacheProbeResult(path, substituter, "successful-substitute", 0, "");
+}
+
+string[] cacheProbeTimeoutCommand(string[] command, ulong timeoutSeconds)
+{
+    return ["timeout", "--kill-after=5s", timeoutSeconds.to!string ~ "s"] ~ command;
+}
+
+bool isTimeoutExitCode(int exitCode)
+{
+    return exitCode == 124 || exitCode == 137 || exitCode == 143;
 }
 
 string classifyProbeFailure(string stderr)
@@ -214,28 +238,30 @@ JSONValue cachePushMetadata(
 )
 {
     JSONValue[] probeJson;
-    ulong successful;
     foreach (probe; probes)
     {
-        if (probe.successful)
-            successful++;
         probeJson ~= JSONValue([
             "path": JSONValue(probe.path),
+            "substituter": JSONValue(probe.substituter),
             "outcome": JSONValue(probe.outcome),
             "exitCode": JSONValue(cast(long) probe.exitCode),
             "message": JSONValue(probe.message),
         ]);
     }
 
+    auto coverage = probeCoverage(probes);
+
     JSONValue[string] metadata = [
         "backend": JSONValue(cacheBackendName(request.backend)),
         "controller": JSONValue(plan.controller),
         "coverage": JSONValue([
             "rootPathCount": JSONValue(cast(long) request.storePaths.length),
-            "probedPathCount": JSONValue(cast(long) probes.length),
-            "successfulSubstituteCount": JSONValue(cast(long) successful),
-            "complete": JSONValue(probes.length > 0 && successful == probes.length),
+            "probedPathCount": JSONValue(cast(long) coverage.probedPathCount),
+            "probeAttemptCount": JSONValue(cast(long) probes.length),
+            "successfulSubstituteCount": JSONValue(cast(long) coverage.successfulPathCount),
+            "complete": JSONValue(probes.length > 0 && coverage.complete),
         ]),
+        "probeTimeoutSeconds": JSONValue(cast(long) request.probeTimeoutSeconds),
         "probes": JSONValue(probeJson),
     ];
 
@@ -282,8 +308,8 @@ int pushClosure(CachePushRequest request, ProcessRunner runProcess, ProcessRunne
         // resolves it. Target hosts are configured with multiple substituters
         // (deployment cache + auxiliary caches), so "the closure is resolvable
         // for deploys" — not "every path lives on the primary cache" — is what
-        // matters. Record only the most informative failure per path when no
-        // substituter resolves it.
+        // matters. Record each attempted substituter until the first success so
+        // failure events can explain timeouts and later misses.
         foreach (root; request.storePaths)
             foreach (path; queryClosurePaths(root, queryRunner))
             {
@@ -291,15 +317,16 @@ int pushClosure(CachePushRequest request, ProcessRunner runProcess, ProcessRunne
                 foreach (substituter; plan.substituters)
                 {
                     last = probeCacheSubstitute(path, substituter,
-                        request.trustedPublicKeys, queryRunner);
+                        request.trustedPublicKeys, queryRunner,
+                        request.probeTimeoutSeconds);
+                    probes ~= last;
                     if (last.successful)
                         break;
                 }
-                probes ~= last;
             }
     }
 
-    const probeFailed = probes.any!(probe => !probe.successful);
+    const probeFailed = probes.length > 0 && !probeCoverage(probes).complete;
     const substituteCheckFailed = missingRequiredSubstituter || probeFailed;
     const status = substituteCheckFailed
         ? "failed"
@@ -340,11 +367,65 @@ int pushClosure(CachePushRequest request, ProcessRunner runProcess, ProcessRunne
 
 string probeFailureSummary(CacheProbeResult[] probes)
 {
+    string failedPath;
+    auto successfulPaths = successfulProbePaths(probes);
     foreach (probe; probes)
-        if (!probe.successful)
-            return probe.path ~ ": " ~ probe.outcome ~
-                (probe.message == "" ? "" : ": " ~ probe.message);
-    return "";
+        if (!probe.successful && (probe.path !in successfulPaths))
+        {
+            failedPath = probe.path;
+            break;
+        }
+    if (failedPath == "")
+        return "";
+
+    string[] attempts;
+    foreach (probe; probes)
+        if (probe.path == failedPath && !probe.successful)
+            attempts ~= probeAttemptSummary(probe);
+
+    return failedPath ~ ": no substituter succeeded (" ~ attempts.join("; ") ~ ")";
+}
+
+private struct ProbeCoverage
+{
+    ulong probedPathCount;
+    ulong successfulPathCount;
+    bool complete;
+}
+
+private ProbeCoverage probeCoverage(CacheProbeResult[] probes)
+{
+    bool[string] probedPaths;
+    auto successfulPaths = successfulProbePaths(probes);
+
+    foreach (probe; probes)
+        probedPaths[probe.path] = true;
+
+    bool complete = probes.length > 0;
+    foreach (path, _; probedPaths)
+        if (path !in successfulPaths)
+            complete = false;
+
+    return ProbeCoverage(
+        probedPathCount: cast(ulong) probedPaths.length,
+        successfulPathCount: cast(ulong) successfulPaths.length,
+        complete: complete,
+    );
+}
+
+private bool[string] successfulProbePaths(CacheProbeResult[] probes)
+{
+    bool[string] paths;
+    foreach (probe; probes)
+        if (probe.successful)
+            paths[probe.path] = true;
+    return paths;
+}
+
+private string probeAttemptSummary(CacheProbeResult probe)
+{
+    return probe.substituter ~ ": " ~ probe.outcome ~
+        (probe.message == "" ? "" : ": " ~ probe.message);
 }
 
 @("test_cache_push_closure_invokes_backend")
@@ -353,7 +434,7 @@ unittest
     import std.file : deleteme, readText, remove;
     import std.json : parseJSON;
     import std.string : splitLines;
-    import std.algorithm : filter;
+    import std.algorithm : any, filter;
 
     auto eventLog = deleteme ~ ".cache-push.events.jsonl";
     scope(exit)
@@ -411,6 +492,160 @@ unittest
     assert(events[1]["backend"]["controller"].str == "attic");
     assert(events[1]["metadata"]["coverage"]["complete"].boolean);
     assert(events[1]["metadata"]["probes"][0]["outcome"].str == "successful-substitute");
+}
+
+@("test_cache_probe_wraps_path_info_with_timeout")
+unittest
+{
+    string[][] commands;
+    ProcessResult fakeRunner(string[] command)
+    {
+        commands ~= command;
+        return ProcessResult(0, "", "");
+    }
+
+    auto root = "/nix/store/0123456789abcdfghijklmnpqrsvwxyz-root";
+    auto result = probeCacheSubstitute(root, "https://cache.example",
+        ["cache.example-1:abc"], &fakeRunner, 7);
+
+    assert(result.successful);
+    assert(commands.length == 1);
+    assert(commands[0] == [
+        "timeout", "--kill-after=5s", "7s",
+        "nix", "path-info", "--store", "https://cache.example", root,
+        "--option", "trusted-public-keys", "cache.example-1:abc",
+    ]);
+}
+
+@("test_cache_probe_timeout_command_executes_inner_command")
+unittest
+{
+    import mcl.utils.process : runProcessCapture;
+
+    auto result = runProcessCapture(
+        cacheProbeTimeoutCommand(["sh", "-c", "printf probe-ok"], 1));
+
+    assert(result.exitCode == 0);
+    assert(result.stdout == "probe-ok");
+}
+
+@("test_cache_probe_timeout_continues_to_later_substituter")
+unittest
+{
+    import std.file : deleteme, readText, remove;
+    import std.json : parseJSON;
+    import std.string : splitLines;
+    import std.algorithm : any, filter;
+
+    auto eventLog = deleteme ~ ".cache-push-timeout-success.events.jsonl";
+    scope(exit)
+        if (eventLog.exists) eventLog.remove;
+
+    auto root = "/nix/store/0123456789abcdfghijklmnpqrsvwxyz-root";
+    string[][] commands;
+    ProcessResult fakeRunner(string[] command)
+    {
+        commands ~= command;
+        if (command.length >= 2 && command[0] == "nix" && command[1] == "path-info"
+            && command.canFind("--json"))
+            return ProcessResult(0, `{"/nix/store/0123456789abcdfghijklmnpqrsvwxyz-root":{"narSize":7}}`, "");
+        if (command.length >= 2 && command[0] == "nix" && command[1] == "path-info"
+            && command.canFind("--recursive"))
+            return ProcessResult(0, root ~ "\n", "");
+        if (command.canFind("--store") && command.canFind("https://slow.example"))
+            return ProcessResult(124, "", "");
+        if (command.canFind("--store") && command.canFind("https://good.example"))
+            return ProcessResult(0, root ~ "\n", "");
+        return ProcessResult(0, "", "");
+    }
+
+    assert(pushClosure(CachePushRequest(
+        backend: CacheBackend.cachix,
+        cache: "example-cache",
+        storePaths: [root],
+        substituters: ["https://slow.example", "https://good.example"],
+        eventLogPath: eventLog,
+        probeTimeoutSeconds: 3,
+    ), &fakeRunner, &fakeRunner) == 0);
+
+    assert(commands.any!(cmd => cmd.canFind("3s") && cmd.canFind("https://slow.example")));
+    assert(commands.any!(cmd => cmd.canFind("3s") && cmd.canFind("https://good.example")));
+
+    auto events = eventLog.readText.splitLines
+        .filter!(line => line.strip != "")
+        .map!(line => line.parseJSON)
+        .array;
+    assert(events.length == 1);
+    assert(events[0]["command"]["status"].str == "succeeded");
+    assert(events[0]["metadata"]["coverage"]["complete"].boolean);
+    assert(events[0]["metadata"]["coverage"]["probeAttemptCount"].integer == 2);
+    assert(events[0]["metadata"]["probes"][0]["outcome"].str == "probe-timeout");
+    assert(events[0]["metadata"]["probes"][1]["outcome"].str == "successful-substitute");
+}
+
+@("test_cache_probe_timeout_failure_metadata")
+unittest
+{
+    import std.file : deleteme, readText, remove;
+    import std.json : parseJSON;
+    import std.string : splitLines;
+    import std.algorithm : filter;
+
+    auto eventLog = deleteme ~ ".cache-push-timeout-failure.events.jsonl";
+    scope(exit)
+        if (eventLog.exists) eventLog.remove;
+
+    auto root = "/nix/store/0123456789abcdfghijklmnpqrsvwxyz-root";
+    ProcessResult fakeRunner(string[] command)
+    {
+        if (command.length >= 2 && command[0] == "nix" && command[1] == "path-info"
+            && command.canFind("--json"))
+            return ProcessResult(0, `{"/nix/store/0123456789abcdfghijklmnpqrsvwxyz-root":{"narSize":7}}`, "");
+        if (command.length >= 2 && command[0] == "nix" && command[1] == "path-info"
+            && command.canFind("--recursive"))
+            return ProcessResult(0, root ~ "\n", "");
+        if (command.canFind("--store") && command.canFind("https://slow.example"))
+            return ProcessResult(124, "", "");
+        if (command.canFind("--store") && command.canFind("https://missing.example"))
+            return ProcessResult(1, "", "404 Not Found");
+        return ProcessResult(0, "", "");
+    }
+
+    bool threw;
+    try
+    {
+        pushClosure(CachePushRequest(
+            backend: CacheBackend.cachix,
+            cache: "example-cache",
+            storePaths: [root],
+            substituters: ["https://slow.example", "https://missing.example"],
+            eventLogPath: eventLog,
+            probeTimeoutSeconds: 3,
+        ), &fakeRunner, &fakeRunner);
+    }
+    catch (Exception e)
+    {
+        threw = true;
+        assert(e.msg == "Cache substitute integrity probe failed");
+    }
+    assert(threw);
+
+    auto events = eventLog.readText.splitLines
+        .filter!(line => line.strip != "")
+        .map!(line => line.parseJSON)
+        .array;
+    assert(events.length == 1);
+    assert(events[0]["command"]["status"].str == "failed");
+    assert(events[0]["error"]["code"].str == "cache_probe_failed");
+    assert(events[0]["error"]["details"]["stderrSummary"].str.canFind("probe-timeout"));
+    assert(events[0]["error"]["details"]["stderrSummary"].str.canFind("https://slow.example"));
+    assert(events[0]["error"]["details"]["stderrSummary"].str.canFind("narinfo-missing"));
+    assert(events[0]["metadata"]["probeTimeoutSeconds"].integer == 3);
+    assert(events[0]["metadata"]["coverage"]["complete"].boolean == false);
+    assert(events[0]["metadata"]["coverage"]["probeAttemptCount"].integer == 2);
+    assert(events[0]["metadata"]["probes"][0]["outcome"].str == "probe-timeout");
+    assert(events[0]["metadata"]["probes"][0]["message"].str.canFind("3s timeout"));
+    assert(events[0]["metadata"]["probes"][1]["outcome"].str == "narinfo-missing");
 }
 
 @("test_cache_probe_classifies_failures")


### PR DESCRIPTION
## Summary

- Add a bounded timeout for `mcl cache push-closure --require-substitute` substitute probes.
- Continue probing later substituters after timeout/failure instead of allowing one slow or dead auxiliary cache to stall the deployment job indefinitely.
- Expose the timeout as `--probe-timeout-seconds` and `MCL_CACHE_PROBE_TIMEOUT_SECONDS`, defaulting to 30 seconds.
- Include probe timeout/attempt metadata in cache deployment events for observability.

## Root Cause

The infra deployment run hung inside `mcl cache push-closure --backend cachix --require-substitute` while a child `nix path-info --store <substituter>` probe waited indefinitely on an auxiliary substituter. This prevented the workflow from reaching the later deployment stages and masked the separate Attic DNS issue.

## Validation

- Implementation agent ran: `nix develop --command sh -lc 'dub --root ./packages/mcl/ test -- -i "cache_probe|cache_push_closure" -e coda'` -> 73 passed, 0 failed.
- Review agent rejected an invalid `timeout ... -- nix` command shape, fixed it, added an executable smoke test, ran the package-style mcl test set, and committed the verified fix.
- Local follow-up run: `nix develop --command sh -lc 'dub --root ./packages/mcl/ test -- -e "(nix\\.(build|run|eval))|fetchJson|(coda\\.)|isCached|generateShardMatrix"'` -> 67 passed, 0 failed.
- `git diff --check` passed during review.