### PR TITLE
[codex] Make Attic cache mirror optional

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -37,6 +37,16 @@ on:
         default: 'cachix'
         required: false
         type: string
+      deployment-cache-required-backends:
+        description: 'Comma-separated attempted cache push backends that must succeed'
+        default: 'cachix'
+        required: false
+        type: string
+      deployment-cache-optional-timeout-seconds:
+        description: 'Maximum seconds for each optional cache backend command'
+        default: '300'
+        required: false
+        type: string
     secrets:
       CACHIX_AUTH_TOKEN:
         description: 'Cachix auth token'
@@ -277,7 +287,10 @@ jobs:
           DEPLOY_KIND: ${{ matrix.deploymentKind }}
           DEPLOY_STORE_PATH: ${{ matrix.output }}
           DEPLOYMENT_CACHE_PUSH_BACKENDS: ${{ inputs.deployment-cache-push-backends }}
+          DEPLOYMENT_CACHE_REQUIRED_BACKENDS: ${{ inputs.deployment-cache-required-backends }}
+          DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS: ${{ inputs.deployment-cache-optional-timeout-seconds }}
           CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           ATTIC_CACHE: ${{ vars.ATTIC_CACHE }}
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
           ATTIC_ENDPOINT: ${{ vars.ATTIC_ENDPOINT }}
@@ -286,14 +299,108 @@ jobs:
           DEPLOYMENT_TRUSTED_PUBLIC_KEYS: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           DEPLOYMENT_TRUSTED_SUBSTITUTERS: ${{ vars.SUBSTITUTERS }}
         run: |
+          set -u -o pipefail
+
           mkdir -p .result
-          if [[ -n "$ATTIC_TOKEN" && -n "$ATTIC_SUBSTITUTER" ]]; then
+
+          trim_csv_value() {
+            local value="$1"
+            shopt -s extglob
+            value="${value##+([[:space:]])}"
+            value="${value%%+([[:space:]])}"
+            shopt -u extglob
+            printf '%s' "$value"
+          }
+
+          backend_is_required() {
+            local wanted="$1"
+            local required
+            IFS=',' read -ra required_backends <<< "$DEPLOYMENT_CACHE_REQUIRED_BACKENDS"
+            for required in "${required_backends[@]}"; do
+              required="$(trim_csv_value "$required")"
+              [[ -n "$required" ]] || continue
+              if [[ "$required" == "$wanted" ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          warn_optional_backend() {
+            local backend="$1"
+            local message="$2"
+            echo "::warning title=Optional deployment cache backend::backend=$backend $message"
+          }
+
+          require_backend_vars() {
+            local backend="$1"
+            local required="$2"
+            shift 2
+            local missing=()
+            local name
+            for name in "$@"; do
+              if [[ -z "${!name:-}" ]]; then
+                missing+=("$name")
+              fi
+            done
+
+            if [[ "${#missing[@]}" -eq 0 ]]; then
+              return 0
+            fi
+
+            local message
+            message="${missing[*]} required when deployment-cache-push-backends includes $backend"
+            if [[ "$required" == true ]]; then
+              echo "$message" >&2
+              exit 1
+            fi
+
+            warn_optional_backend "$backend" "$message; continuing without this mirror backend"
+            return 1
+          }
+
+          run_backend_command() {
+            local backend="$1"
+            local required="$2"
+            local label="$3"
+            shift 3
+            local exit_code
+
+            if [[ "$required" == true ]]; then
+              "$@"
+              exit_code=$?
+              if [[ "$exit_code" -ne 0 ]]; then
+                echo "Required deployment cache backend $backend failed during $label (exit $exit_code)" >&2
+                exit "$exit_code"
+              fi
+              return 0
+            fi
+
+            timeout --kill-after=30s "${DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS}s" "$@"
+            exit_code=$?
+            if [[ "$exit_code" -eq 0 ]]; then
+              return 0
+            fi
+
+            if [[ "$exit_code" -eq 124 || "$exit_code" -eq 137 || "$exit_code" -eq 143 ]]; then
+              warn_optional_backend "$backend" "$label timed out after ${DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS}s; continuing"
+            else
+              warn_optional_backend "$backend" "$label failed with exit $exit_code; continuing"
+            fi
+            return "$exit_code"
+          }
+
+          if [[ ! "$DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "deployment-cache-optional-timeout-seconds must be a positive integer" >&2
+            exit 1
+          fi
+
+          configure_attic_netrc() {
             attic_host="${ATTIC_SUBSTITUTER#http://}"
             attic_host="${attic_host#https://}"
             attic_host="${attic_host%%/*}"
             if [[ -z "$attic_host" ]]; then
-              echo "Could not derive Attic host from ATTIC_SUBSTITUTER" >&2
-              exit 1
+              return 1
             fi
 
             nix_netrc="$HOME/.config/nix/netrc"
@@ -312,41 +419,54 @@ jobs:
             if [[ "$has_attic_netrc_entry" == false ]]; then
               printf 'machine %s password %s\n' "$attic_host" "$ATTIC_TOKEN" >> "$nix_netrc"
             fi
-          fi
+          }
 
           IFS=',' read -ra backends <<< "$DEPLOYMENT_CACHE_PUSH_BACKENDS"
           for backend in "${backends[@]}"; do
-            # Trim leading/trailing whitespace without external commands.
-            # `xargs` is not on PATH for aarch64-darwin runners (their PATH
-            # contains only Nix-store paths and findutils isn't pulled in by
-            # the github-runner darwin module), so a bash builtin is the
-            # portable choice.
-            shopt -s extglob
-            backend="${backend##+([[:space:]])}"
-            backend="${backend%%+([[:space:]])}"
-            shopt -u extglob
+            backend="$(trim_csv_value "$backend")"
             [[ -n "$backend" ]] || continue
+
+            required=false
+            if backend_is_required "$backend"; then
+              required=true
+            fi
 
             case "$backend" in
               cachix)
+                if ! require_backend_vars "$backend" "$required" CACHIX_CACHE CACHIX_AUTH_TOKEN; then
+                  continue
+                fi
                 cache="$CACHIX_CACHE"
                 substituter="https://${CACHIX_CACHE}.cachix.org"
                 ;;
               attic)
-                cache="$ATTIC_CACHE"
-                substituter="$ATTIC_SUBSTITUTER"
-                : "${ATTIC_TOKEN:?ATTIC_TOKEN is required when deployment-cache-push-backends includes attic}"
-                : "${ATTIC_CACHE:?ATTIC_CACHE is required when deployment-cache-push-backends includes attic}"
-                : "${ATTIC_SUBSTITUTER:?ATTIC_SUBSTITUTER is required when deployment-cache-push-backends includes attic}"
-                : "${ATTIC_TRUSTED_PUBLIC_KEY:?ATTIC_TRUSTED_PUBLIC_KEY is required when deployment-cache-push-backends includes attic}"
+                if ! require_backend_vars "$backend" "$required" ATTIC_TOKEN ATTIC_CACHE ATTIC_SUBSTITUTER ATTIC_TRUSTED_PUBLIC_KEY; then
+                  continue
+                fi
+
+                if ! configure_attic_netrc; then
+                  if [[ "$required" == true ]]; then
+                    echo "Could not derive Attic host from ATTIC_SUBSTITUTER" >&2
+                    exit 1
+                  fi
+                  warn_optional_backend "$backend" "could not derive Attic host from ATTIC_SUBSTITUTER; continuing"
+                  continue
+                fi
 
                 attic_endpoint="$ATTIC_ENDPOINT"
                 if [[ -z "$attic_endpoint" ]]; then
                   attic_endpoint="${ATTIC_SUBSTITUTER%/$ATTIC_CACHE}"
                 fi
                 attic_endpoint="${attic_endpoint%/}/"
-                nix shell nixpkgs#attic-client -c \
-                  attic login --set-default deployment "$attic_endpoint" "$ATTIC_TOKEN"
+                if ! run_backend_command "$backend" "$required" "attic login" \
+                  nix shell nixpkgs#attic-client -c \
+                    attic login --set-default deployment "$attic_endpoint" "$ATTIC_TOKEN"
+                then
+                  continue
+                fi
+
+                cache="$ATTIC_CACHE"
+                substituter="$ATTIC_SUBSTITUTER"
                 ;;
               none)
                 cache="none"
@@ -388,7 +508,8 @@ jobs:
             trusted_args+=(--trusted-public-key
               "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=")
 
-            ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} -- cache push-closure \
+            if ! run_backend_command "$backend" "$required" "cache push and substitute probe" \
+              ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} -- cache push-closure \
               --backend "$backend" \
               --cache "$cache" \
               --target "$DEPLOY_TARGET" \
@@ -399,6 +520,9 @@ jobs:
               "${substituter_args[@]}" \
               "${trusted_args[@]}" \
               "$DEPLOY_STORE_PATH"
+            then
+              continue
+            fi
           done
 
       - uses: actions/upload-artifact@v7

--- a/checks/deployment-docs.nix
+++ b/checks/deployment-docs.nix
@@ -224,6 +224,347 @@
           touch "$out"
         '';
 
+        deployment-cache-backend-policy = pkgs.runCommand "deployment-cache-backend-policy" { } ''
+          ${pkgs.python3}/bin/python3 <<'PY'
+          import os
+          import re
+          import subprocess
+          import tempfile
+          from pathlib import Path
+
+          workflow = Path("${workflow}")
+          text = workflow.read_text()
+
+          def require(condition, message):
+              if not condition:
+                  raise SystemExit(message)
+
+          require(
+              re.search(
+                  r"deployment-cache-required-backends:\s*\n"
+                  r"\s+description:.*\n"
+                  r"\s+default:\s*'cachix'\s*\n"
+                  r"\s+required:\s*false\s*\n"
+                  r"\s+type:\s*string",
+                  text,
+              ),
+              "reusable workflow must expose deployment-cache-required-backends defaulting to cachix",
+          )
+          require(
+              re.search(
+                  r"deployment-cache-optional-timeout-seconds:\s*\n"
+                  r"\s+description:.*\n"
+                  r"\s+default:\s*'300'\s*\n"
+                  r"\s+required:\s*false\s*\n"
+                  r"\s+type:\s*string",
+                  text,
+              ),
+              "reusable workflow must expose configurable optional backend timeout defaulting to 300 seconds",
+          )
+          require(
+              "DEPLOYMENT_CACHE_REQUIRED_BACKENDS: ''${{ inputs.deployment-cache-required-backends }}" in text,
+              "cache push step must receive the required backend policy input",
+          )
+          require(
+              "DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS: ''${{ inputs.deployment-cache-optional-timeout-seconds }}" in text,
+              "cache push step must receive the optional backend timeout input",
+          )
+          require(
+              "backend_is_required()" in text and 'required=true' in text,
+              "cache push script must classify attempted backends as required or optional",
+          )
+          require(
+              'echo "::warning title=Optional deployment cache backend::backend=$backend $message"' in text,
+              "optional backend failures must emit GitHub warning annotations",
+          )
+          require(
+              'warn_optional_backend "$backend" "$message; continuing without this mirror backend"' in text,
+              "optional missing variables must warn and continue",
+          )
+          require(
+              re.search(
+                  r'if \[\[ "\$required" == true \]\]; then\s*\n'
+                  r'\s+echo "\$message" >&2\s*\n'
+                  r'\s+exit 1',
+                  text,
+              ),
+              "required missing variables must exit hard",
+          )
+          require(
+              'require_backend_vars "$backend" "$required" ATTIC_TOKEN ATTIC_CACHE ATTIC_SUBSTITUTER ATTIC_TRUSTED_PUBLIC_KEY' in text,
+              "Attic variables must be checked manually through the backend policy",
+          )
+          for forbidden in [
+              ': "''${ATTIC_TOKEN:?',
+              ': "''${ATTIC_CACHE:?',
+              ': "''${ATTIC_SUBSTITUTER:?',
+              ': "''${ATTIC_TRUSTED_PUBLIC_KEY:?',
+          ]:
+              require(forbidden not in text, f"Attic variable guard bypasses optional policy: {forbidden}")
+          require(
+              'timeout --kill-after=30s "''${DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS}s" "$@"' in text,
+              "optional backend commands must be wrapped in the configurable timeout",
+          )
+          require(
+              'if [[ "$required" == true ]]; then\n              "$@"' in text,
+              "required backend commands must run directly without the optional timeout wrapper",
+          )
+          require(
+              'Required deployment cache backend $backend failed during $label' in text,
+              "required backend command failures must exit hard",
+          )
+          require(
+              'if ! run_backend_command "$backend" "$required" "attic login"' in text,
+              "Attic login must honor required versus optional policy",
+          )
+          require(
+              'if ! run_backend_command "$backend" "$required" "cache push and substitute probe"' in text,
+              "cache push and substitute probe must honor required versus optional policy",
+          )
+          require(
+              "if: ''${{ always() && inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}" in text,
+              "cache push event artifact upload must remain available after optional backend failures",
+          )
+
+          def extract_cache_push_script():
+              lines = text.splitlines()
+              step_index = None
+              for index, line in enumerate(lines):
+                  if re.match(r"\s+- name: Push deployment closure caches", line):
+                      step_index = index
+                      break
+              require(step_index is not None, "cache push step not found")
+
+              run_index = None
+              for index in range(step_index + 1, len(lines)):
+                  if re.match(r"\s+run:\s*\|\s*$", lines[index]):
+                      run_index = index
+                      break
+                  if re.match(r"\s+- name:", lines[index]):
+                      break
+              require(run_index is not None, "cache push run block not found")
+
+              run_indent = len(lines[run_index]) - len(lines[run_index].lstrip())
+              block_indent = run_indent + 2
+              block = []
+              for line in lines[run_index + 1:]:
+                  if not line.strip():
+                      block.append("")
+                      continue
+                  indent = len(line) - len(line.lstrip())
+                  if indent <= run_indent:
+                      break
+                  require(indent >= block_indent, f"unexpected run block indentation: {line!r}")
+                  block.append(line[block_indent:])
+              return "\n".join(block) + "\n"
+
+          script = extract_cache_push_script()
+          require(
+              "''${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }}" in script,
+              "cache push script must still use the computed mcl flake command expression",
+          )
+          script = script.replace("''${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }}", "mcl")
+
+          with tempfile.TemporaryDirectory() as temp:
+              temp_path = Path(temp)
+              script_path = temp_path / "cache-policy.sh"
+              script_path.write_text(script)
+              subprocess.run(
+                  ["${pkgs.bash}/bin/bash", "-n", str(script_path)],
+                  check=True,
+              )
+
+              fake_bin = temp_path / "bin"
+              fake_bin.mkdir()
+              log_path = temp_path / "commands.log"
+              (fake_bin / "nix").write_text(
+                  """#!${pkgs.bash}/bin/bash
+          printf 'nix %s\\n' "$*" >> "$FAKE_LOG"
+          if [[ "''${NIX_FAIL_LOGIN:-}" == 1 ]]; then
+            exit 19
+          fi
+          exit 0
+          """
+              )
+              (fake_bin / "mcl").write_text(
+                  """#!${pkgs.bash}/bin/bash
+          backend=""
+          previous=""
+          for arg in "$@"; do
+            if [[ "$previous" == "--backend" ]]; then
+              backend="$arg"
+            fi
+            previous="$arg"
+          done
+          printf 'mcl backend=%s args=%s\\n' "$backend" "$*" >> "$FAKE_LOG"
+          mkdir -p .result
+          printf '{"phase":"cache-push","backend":"%s"}\\n' "$backend" >> .result/deployment-cache-push-events.jsonl
+          if [[ "''${MCL_SLEEP_BACKEND:-}" == "$backend" ]]; then
+            sleep 2
+          fi
+          if [[ "''${MCL_FAIL_BACKEND:-}" == "$backend" ]]; then
+            exit 23
+          fi
+          exit 0
+          """
+              )
+              os.chmod(fake_bin / "nix", 0o755)
+              os.chmod(fake_bin / "mcl", 0o755)
+
+              base_env = {
+                  "PATH": str(fake_bin) + ":${pkgs.coreutils}/bin",
+                  "FAKE_LOG": str(log_path),
+                  "DEPLOY_TARGET": "test-target",
+                  "DEPLOY_SYSTEM": "x86_64-linux",
+                  "DEPLOY_KIND": "server",
+                  "DEPLOY_STORE_PATH": "${pkgs.hello}",
+                  "DEPLOYMENT_CACHE_PUSH_BACKENDS": "cachix,attic",
+                  "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                  "DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS": "1",
+                  "CACHIX_CACHE": "required-cache",
+                  "CACHIX_AUTH_TOKEN": "required-token",
+                  "ATTIC_CACHE": "mirror-cache",
+                  "ATTIC_SUBSTITUTER": "https://attic.example/mirror-cache",
+                  "ATTIC_ENDPOINT": "",
+                  "ATTIC_TRUSTED_PUBLIC_KEY": "attic-public-key",
+                  "ATTIC_TOKEN": "attic-token",
+                  "DEPLOYMENT_TRUSTED_PUBLIC_KEYS": "",
+                  "DEPLOYMENT_TRUSTED_SUBSTITUTERS": "",
+              }
+
+              def run_case(
+                  name,
+                  env_updates,
+                  expected_returncode,
+                  stdout_contains=(),
+                  stderr_contains=(),
+                  log_contains=(),
+                  log_absent=(),
+                  expect_artifact=None,
+              ):
+                  log_path.write_text("")
+                  case_dir = temp_path / name
+                  case_dir.mkdir()
+                  home = case_dir / "home"
+                  home.mkdir()
+                  env = os.environ.copy()
+                  env.update(base_env)
+                  env["HOME"] = str(home)
+                  env.update(env_updates)
+
+                  result = subprocess.run(
+                      ["${pkgs.bash}/bin/bash", str(script_path)],
+                      cwd=case_dir,
+                      env=env,
+                      text=True,
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.PIPE,
+                  )
+                  require(
+                      result.returncode == expected_returncode,
+                      f"{name}: expected exit {expected_returncode}, got {result.returncode}\n"
+                      f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+                  )
+                  for needle in stdout_contains:
+                      require(needle in result.stdout, f"{name}: stdout missing {needle!r}: {result.stdout}")
+                  for needle in stderr_contains:
+                      require(needle in result.stderr, f"{name}: stderr missing {needle!r}: {result.stderr}")
+                  log = log_path.read_text()
+                  for needle in log_contains:
+                      require(needle in log, f"{name}: command log missing {needle!r}: {log}")
+                  for needle in log_absent:
+                      require(needle not in log, f"{name}: command log unexpectedly contained {needle!r}: {log}")
+                  if expect_artifact is not None:
+                      artifact = case_dir / ".result" / "deployment-cache-push-events.jsonl"
+                      has_artifact = artifact.exists() and artifact.read_text().strip()
+                      require(bool(has_artifact) == expect_artifact, f"{name}: artifact expectation failed")
+
+              run_case(
+                  "optional_attic_missing_vars",
+                  {"ATTIC_TOKEN": ""},
+                  0,
+                  stdout_contains=("::warning title=Optional deployment cache backend::backend=attic",),
+                  log_contains=("mcl backend=cachix",),
+                  log_absent=("nix shell", "mcl backend=attic"),
+                  expect_artifact=True,
+              )
+              run_case(
+                  "required_attic_missing_vars",
+                  {
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "attic",
+                      "ATTIC_TOKEN": "",
+                  },
+                  1,
+                  stderr_contains=("ATTIC_TOKEN required when deployment-cache-push-backends includes attic",),
+                  log_absent=("nix shell", "mcl backend="),
+                  expect_artifact=False,
+              )
+              run_case(
+                  "optional_attic_login_failure",
+                  {
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "NIX_FAIL_LOGIN": "1",
+                  },
+                  0,
+                  stdout_contains=("attic login failed with exit 19; continuing",),
+                  log_contains=("nix shell nixpkgs#attic-client -c attic login",),
+                  log_absent=("mcl backend=attic",),
+                  expect_artifact=False,
+              )
+              run_case(
+                  "required_attic_login_failure",
+                  {
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "attic",
+                      "NIX_FAIL_LOGIN": "1",
+                  },
+                  19,
+                  stderr_contains=("Required deployment cache backend attic failed during attic login",),
+                  log_contains=("nix shell nixpkgs#attic-client -c attic login",),
+                  expect_artifact=False,
+              )
+              run_case(
+                  "optional_attic_push_failure_preserves_artifact",
+                  {
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "MCL_FAIL_BACKEND": "attic",
+                  },
+                  0,
+                  stdout_contains=("cache push and substitute probe failed with exit 23; continuing",),
+                  log_contains=("nix shell nixpkgs#attic-client -c attic login", "mcl backend=attic"),
+                  expect_artifact=True,
+              )
+              run_case(
+                  "required_cachix_push_failure",
+                  {
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "cachix",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "MCL_FAIL_BACKEND": "cachix",
+                  },
+                  23,
+                  stderr_contains=("Required deployment cache backend cachix failed during cache push and substitute probe",),
+                  log_contains=("mcl backend=cachix",),
+                  expect_artifact=True,
+              )
+              run_case(
+                  "optional_attic_timeout",
+                  {
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "MCL_SLEEP_BACKEND": "attic",
+                  },
+                  0,
+                  stdout_contains=("cache push and substitute probe timed out after 1s; continuing",),
+                  log_contains=("mcl backend=attic",),
+                  expect_artifact=True,
+              )
+          PY
+          touch "$out"
+        '';
+
         deployment-general-private-split = pkgs.runCommand "deployment-general-private-split" { } ''
           forbidden='solunska|gpu-server|cache\.metacraft-labs\.com|metacraft-private-infrastructure'
           generic_files=$(find ${docs} ${skills} -type f \


### PR DESCRIPTION
## Summary

- Add `deployment-cache-required-backends` so workflows can distinguish required cache pushes from optional mirrors.
- Keep Cachix required by default while allowing Attic to warn and continue when its credentials, login, push, probe, or timeout path fails.
- Preserve cache push summary/artifact uploads under `always()` so optional backend failures still leave evidence.
- Strengthen the deployment cache backend policy check to syntax-check the generated Bash and simulate required vs optional backend behavior.

## Why

The production deploy path currently needs Cachix to remain the hard requirement while Attic is being migrated. This lets Attic run as a mirror without wedging deployments when the Attic endpoint or credentials are not ready, while still failing hard if a required backend fails.

## Validation

- `git diff --check origin/main..HEAD`
- `nix build --accept-flake-config .#checks.x86_64-linux.deployment-cache-backend-policy`
- `nix build --accept-flake-config .#checks.x86_64-linux.deployment-current-flow-inventory`

Verifier also previously ran the strengthened policy scenarios before committing the original change.