### PR TITLE
[codex] Fix Attic deployment cache closure proof

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -490,23 +490,24 @@ jobs:
             if [[ -n "$substituter" ]]; then
               substituter_args+=(--substituter "$substituter" --require-substitute)
             fi
-            # Probe across every trusted substituter that target hosts
-            # configure (deployment cache + auxiliary caches +
-            # cache.nixos.org). The integrity check passes if ANY trusted
-            # substituter resolves a path — matching the realistic deploy
-            # environment instead of demanding exhaustive coverage on the
-            # primary cache. cache.nixos.org is hard-coded because every
-            # NixOS host trusts it implicitly via nix.conf defaults and it
-            # is not typically listed in repo SUBSTITUTERS.
-            for extra_substituter in $DEPLOYMENT_TRUSTED_SUBSTITUTERS https://cache.nixos.org; do
-              [[ "$extra_substituter" == "$substituter" ]] && continue
-              substituter_args+=(--substituter "$extra_substituter")
-            done
-            # cache.nixos.org's signing key is universally trusted on NixOS
-            # hosts; add it to the probe's trusted-public-keys list so
-            # nix copy --from cache.nixos.org accepts the signatures.
-            trusted_args+=(--trusted-public-key
-              "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=")
+            if [[ "$backend" != attic ]]; then
+              # Probe across every trusted substituter that target hosts
+              # configure (deployment cache + auxiliary caches +
+              # cache.nixos.org). The integrity check passes if ANY trusted
+              # substituter resolves a path — matching the realistic deploy
+              # environment instead of demanding exhaustive coverage on the
+              # primary cache. Attic is excluded because its required proof
+              # must show the Attic backend itself covers the closure.
+              for extra_substituter in $DEPLOYMENT_TRUSTED_SUBSTITUTERS https://cache.nixos.org; do
+                [[ "$extra_substituter" == "$substituter" ]] && continue
+                substituter_args+=(--substituter "$extra_substituter")
+              done
+              # cache.nixos.org's signing key is universally trusted on NixOS
+              # hosts; add it to the probe's trusted-public-keys list so
+              # nix copy --from cache.nixos.org accepts the signatures.
+              trusted_args+=(--trusted-public-key
+                "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=")
+            fi
 
             if ! run_backend_command "$backend" "$required" "cache push and substitute probe" \
               ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} -- cache push-closure \

--- a/checks/deployment-docs.nix
+++ b/checks/deployment-docs.nix
@@ -550,6 +550,48 @@
                   expect_artifact=True,
               )
               run_case(
+                  "attic_probe_uses_only_attic_substituter",
+                  {
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "attic",
+                      "DEPLOYMENT_TRUSTED_SUBSTITUTERS": "https://aux.example https://mirror.example",
+                      "DEPLOYMENT_TRUSTED_PUBLIC_KEYS": "aux-public-key",
+                  },
+                  0,
+                  log_contains=(
+                      "mcl backend=attic",
+                      "--substituter https://attic.example/mirror-cache --require-substitute",
+                      "--trusted-public-key aux-public-key",
+                      "--trusted-public-key attic-public-key",
+                  ),
+                  log_absent=(
+                      "--substituter https://aux.example",
+                      "--substituter https://mirror.example",
+                      "--substituter https://cache.nixos.org",
+                      "cache.nixos.org-1:",
+                  ),
+                  expect_artifact=True,
+              )
+              run_case(
+                  "cachix_probe_keeps_fallback_substituters",
+                  {
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "cachix",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "DEPLOYMENT_TRUSTED_SUBSTITUTERS": "https://aux.example",
+                      "DEPLOYMENT_TRUSTED_PUBLIC_KEYS": "aux-public-key",
+                  },
+                  0,
+                  log_contains=(
+                      "mcl backend=cachix",
+                      "--substituter https://required-cache.cachix.org --require-substitute",
+                      "--substituter https://aux.example",
+                      "--substituter https://cache.nixos.org",
+                      "--trusted-public-key aux-public-key",
+                      "cache.nixos.org-1:",
+                  ),
+                  expect_artifact=True,
+              )
+              run_case(
                   "optional_attic_timeout",
                   {
                       "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",

--- a/packages/mcl/src/mcl/utils/cache_backends.d
+++ b/packages/mcl/src/mcl/utils/cache_backends.d
@@ -120,7 +120,8 @@ CachePushPlan cachePushPlan(CachePushRequest request)
         case CacheBackend.attic:
             return CachePushPlan(
                 commandName: "attic push",
-                argv: ["attic", "push", request.cache] ~ request.storePaths,
+                argv: ["attic", "push", "--ignore-upstream-cache-filter", request.cache]
+                    ~ request.storePaths,
                 controller: "attic",
                 substituters: substituters,
                 externalCommand: true,
@@ -682,7 +683,9 @@ unittest
         eventLogPath: eventLog,
     ), &fakeRunner, &fakeRunner) == 0);
 
-    assert(commands.any!(cmd => cmd == ["attic", "push", "example-deploy-cache", root]));
+    assert(commands.any!(cmd => cmd == [
+        "attic", "push", "--ignore-upstream-cache-filter", "example-deploy-cache", root,
+    ]));
 
     auto events = eventLog.readText.splitLines
         .filter!(line => line.strip != "")


### PR DESCRIPTION
## Summary

Fixes the deployment cache path for Attic so required Attic pushes actually prove the Attic backend contains the full deployment closure.

- `mcl cache push-closure --backend attic` now passes `--ignore-upstream-cache-filter` to `attic push`, preventing Attic from skipping closure paths that are available from upstream caches.
- The reusable CI workflow no longer adds auxiliary substituters or `cache.nixos.org` as fallback probe sources for the Attic backend. Required Attic proof now means Attic itself covers the closure.
- Cachix behavior is preserved: Cachix still probes auxiliary target substituters and `cache.nixos.org`.

## Root Cause

The previous main workflow pushed to Attic successfully, but Attic's upstream-cache filter could omit public dependencies. The subsequent probe allowed those omitted paths to be satisfied by auxiliary substituters or `cache.nixos.org`, so CI passed while live host verification later found missing paths in Attic.

## Validation

- `nix develop --command dub --root ./packages/mcl/ test -- -i "test_cache_push_closure_invokes_backend"`
- `nix build .#checks.x86_64-linux.deployment-cache-backend-policy`
- `git diff --check`
- verifier subagent review confirmed the tests prove Attic-only probing while preserving Cachix fallback probing