### PR TITLE
[codex] Run deploy final results off fleet runners

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -27,6 +27,11 @@ on:
         default: 'ubuntu-latest'
         required: false
         type: string
+      results-runner:
+        description: 'JSON-encoded runner labels for Final Results and deploy orchestration'
+        default: '"ubuntu-latest"'
+        required: false
+        type: string
       run-cachix-deploy:
         description: 'Deploy to cachix'
         default: false
@@ -534,7 +539,7 @@ jobs:
           if-no-files-found: warn
 
   results:
-    runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
+    runs-on: ${{ fromJSON(inputs.results-runner) }}
     name: Final Results
     needs: [compute-mcl-ref, build, shard-matrix, merge-matrices]
     if: always()

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ jobs:
           "x86_64-linux": ["self-hosted", "nixos", "x86-64-v3", "bare-metal"],
           "aarch64-darwin": ["self-hosted", "macOS", "aarch64-darwin"]
         }
+      # JSON-encoded runner for Final Results and deploy orchestration.
+      # Defaults to the off-target GitHub-hosted runner "ubuntu-latest".
+      results-runner: '"ubuntu-latest"'
 ```
 
 #### [`reusable-lint.yml`](.github/workflows/reusable-lint.yml)

--- a/checks/deployment-production-cutover.nix
+++ b/checks/deployment-production-cutover.nix
@@ -479,6 +479,22 @@ top@{ config, ... }:
               assert re.search(r"run-cachix-deploy:\s*false", repo_workflow), "generic repo CI must keep Cachix Deploy off by default"
               assert "run-cachix-deploy:" in workflow, "workflow no longer exposes the legacy deploy gate"
               assert re.search(r"run-cachix-deploy:.*?default:\s*false", workflow, re.S), "legacy deploy gate must default false in the reusable workflow"
+              assert re.search(
+                  r"results-runner:\s*\n"
+                  r"\s+description:.*\n"
+                  r"\s+default:\s*'\"ubuntu-latest\"'\s*\n"
+                  r"\s+required:\s*false\s*\n"
+                  r"\s+type:\s*string",
+                  workflow,
+              ), "workflow must expose results-runner defaulting to off-target ubuntu-latest"
+              results_job_match = re.search(
+                  r"(?ms)^  results:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+                  workflow,
+              )
+              assert results_job_match is not None, "workflow results job disappeared"
+              results_job = results_job_match.group("body")
+              assert "runs-on: ''${{ fromJSON(inputs.results-runner) }}" in results_job, "Final Results must run on the results-runner input"
+              assert "runs-on: ''${{ fromJSON(inputs.runners).x86_64-linux }}" not in results_job, "Final Results must not run on the x86_64-linux fleet runner map"
               assert "if: inputs.run-cachix-deploy" in workflow, "legacy deploy step must remain explicitly gated"
               assert "if: ''${{ inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}" in workflow, "deployment cache push must be limited to deployment targets"
               assert "if: ''${{ always() && inputs.run-cachix-deploy && !matrix.noop && matrix.deploymentTarget }}" in workflow, "deployment cache artifact upload must be limited to deployment targets"

--- a/docs/deployment/current-cachix-flow.md
+++ b/docs/deployment/current-cachix-flow.md
@@ -18,7 +18,9 @@ Deployment is optional and is gated by the workflow input
 '.#${{ matrix.attrPath }}'` for each matrix item.
 6. `build` then runs `cachix push ${{ vars.CACHIX_CACHE }}
 ${{ matrix.output }}` for each built output.
-7. `results` prints the final matrix and updates the pull request comment.
+7. `results` runs on the JSON-encoded `results-runner` input, which defaults
+   to the off-target GitHub-hosted runner `"ubuntu-latest"`. It prints the
+   final matrix and updates the pull request comment.
 8. When `inputs.run-cachix-deploy` is true, `results` checks out the repository
    and runs `mcl deploy-spec`.
 
@@ -58,6 +60,7 @@ journald logs, activation generation, health-check output, or rollback status.
 | Cache name           | GitHub variable `CACHIX_CACHE`                                                                        | Used by setup, push, and `mcl` cache-status checks.                      |
 | Substituters         | GitHub variable `SUBSTITUTERS` plus default cache URLs supplied to `mcl`                              | Used for Nix setup and cache-status checks.                              |
 | Trusted public keys  | GitHub variable `TRUSTED_PUBLIC_KEYS`                                                                 | Required for substituter trust on runners.                               |
+| Results runner       | Workflow input `results-runner`, JSON default `"ubuntu-latest"`                                       | Keeps deploy orchestration off the fleet self-hosted runner by default.  |
 | Deploy token         | Secret `CACHIX_ACTIVATE_TOKEN`                                                                        | Passed only to the deploy step environment.                              |
 | Cache push token     | Secret `CACHIX_AUTH_TOKEN`                                                                            | Used by setup, cache push, and cache-status checks.                      |
 | Source access tokens | `NIX_GITHUB_TOKEN`, `NIX_GITLAB_TOKEN`, `NIX_GITLAB_DOMAIN`                                           | Used by Nix access-token setup.                                          |


### PR DESCRIPTION
## Summary

- add a `results-runner` input to the reusable flake CI matrix workflow
- default Final Results and deploy orchestration to the off-target GitHub-hosted runner `ubuntu-latest`
- document the new input and assert the Final Results job no longer uses the fleet `x86_64-linux` runner map

## Root Cause

Infra main CI failed after all build/cache jobs had passed because the reusable workflow's Final Results job landed on `gpu-server-002-mcl-002`. The deploy step then orchestrated fleet deployment from a runner hosted by the fleet being deployed, and the runner received a shutdown signal during deployment.

## Validation

- `git diff --check`
- JSON scalar/array parse sanity check for `fromJSON(inputs.results-runner)`
- `nix build -L .#checks.x86_64-linux.deployment-no-default-cachix-deploy-call .#checks.x86_64-linux.deployment-current-flow-inventory .#checks.x86_64-linux.deployment-production-cutover-simulation-vm`
