### PR TITLE
ci: allow reusable PR comment updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,10 @@ jobs:
 
   ci:
     uses: ./.github/workflows/reusable-flake-checks-ci-matrix.yml
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     secrets: inherit
     with:
       runners: |

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -102,6 +102,10 @@ jobs:
   post-initial-comment:
     if: github.event_name == 'pull_request'
     runs-on: ${{ inputs.non-nix-runner }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: 'Post initial package status comment'
         uses: metacraft-labs/nixos-modules/.github/sticky-comment@main
@@ -114,6 +118,10 @@ jobs:
   shard-matrix:
     needs: compute-mcl-ref
     runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
@@ -186,6 +194,10 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runners).x86_64-linux }}
     needs: [compute-mcl-ref, shard-matrix, eval-matrix]
     name: Merge matrices
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     outputs:
       build_matrix: ${{ steps.merge.outputs.build_matrix }}
       full_matrix: ${{ steps.merge.outputs.full_matrix }}
@@ -543,6 +555,10 @@ jobs:
     name: Final Results
     needs: [compute-mcl-ref, build, shard-matrix, merge-matrices]
     if: always()
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main

--- a/.github/workflows/reusable-nix-diff.yml
+++ b/.github/workflows/reusable-nix-diff.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runner) }}
     permissions:
       contents: read
+      issues: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
Fixes reusable workflow token permissions for PR comment writers.

Changes:
- add `issues: write` to reusable nix-diff, which updates PR comments after uploading diff artifacts
- add explicit minimal comment permissions to reusable CI matrix jobs that call sticky-comment

Validation:
- `git diff --check -- .github/workflows/reusable-nix-diff.yml .github/workflows/reusable-flake-checks-ci-matrix.yml`
- pre-commit hooks during commit

actionlint is not installed locally.