### PR TITLE
fix(mcl/ci-matrix): cap isCached HTTP requests at 10s connect / 30s data

### DIFF
--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -1269,8 +1269,24 @@ bool isCached(in Package pkg, string binaryCacheHttpEndpoint, in string[string] 
     import std.algorithm : canFind;
     import std.string : lineSplitter;
     import std.net.curl : HTTP, httpGet = get, HTTPStatusException;
+    import core.time : dur;
 
     auto http = HTTP();
+    // Without these timeouts a single slow / unresponsive cache server
+    // blocks the entire `ci-matrix` cache-status sweep indefinitely.
+    // ``checkCacheStatus`` iterates packages in parallel and calls
+    // ``isCached`` per (package, cache URL), so one stuck narinfo GET
+    // can hang the whole shard-matrix step until GitHub Actions kills
+    // the job at its 6 h hard ceiling (observed on PRs against
+    // ``nix-blockchain-development`` and on the same repo's main
+    // branch CI -- ``Generate Shard Matrix`` consistently times out
+    // at 6 h with orphan ``nix-eval-jobs`` and ``.mcl-wrapped``
+    // processes still running).  Cap each request at 10 s to connect
+    // and 30 s of total transfer time so a single misbehaving
+    // narinfo lookup degrades gracefully instead of taking down the
+    // whole pipeline.
+    http.connectTimeout = dur!"seconds"(10);
+    http.dataTimeout = dur!"seconds"(30);
     foreach (name, value; httpHeaders)
         http.addRequestHeader(name, value);
 


### PR DESCRIPTION
## Summary
- ``mcl ci-matrix`` (and via it, ``mcl shard-matrix``) iterates packages in parallel and calls ``isCached(url, ...)`` per (package, cache URL).  ``std.net.curl.httpGet`` in D has **no default timeout**, so when one binary-cache server stops responding for a single narinfo lookup, the whole sweep hangs.
- In practice this means ``Generate Shard Matrix`` runs for the full 6h GitHub Actions job ceiling on every PR (and on ``nix-blockchain-development``'s main-branch CI -- April 2026 history shows the identical 6h cancellation pattern), then gets cancelled with orphan ``nix-eval-jobs`` and ``.mcl-wrapped`` processes still running.
- Cap each narinfo HTTP request at 10s to connect and 30s of total transfer time so one slow cache server degrades to a per-package timeout error instead of taking down the whole CI step.

## Reproduce
- Pick any PR or branch CI run for ``metacraft-labs/nix-blockchain-development`` (e.g. https://github.com/metacraft-labs/nix-blockchain-development/pull/557).
- ``ci / shard-matrix`` step starts, enumerates ~35 packages in ~30 s, then hangs silently.  After 6 h the job is cancelled by GitHub Actions; the step shows ``Terminate orphan process: pid ... (nix-eval-jobs)`` / ``(.mcl-wrapped)`` in the cleanup log.
- Same pattern on main: https://github.com/metacraft-labs/nix-blockchain-development/actions/runs/24315841978 -- ``Generate Shard Matrix`` started 2026-04-12T20:36:09Z, cancelled 2026-04-13T02:36:14Z (exactly 6h00m05s).

## Test plan
- [x] Patch builds cleanly (3-line addition in ``packages/mcl/src/mcl/commands/ci_matrix.d``; only adds ``import core.time : dur;`` and two property assignments on the ``HTTP`` handle).
- [ ] CI on this branch passes the existing ``mcl`` unit tests (no behavior change for fast / healthy caches, only adds an upper bound on a previously-unbounded wait).
- [ ] On merge: PR #557 in ``nix-blockchain-development`` (and other downstream PRs) advances past ``Generate Shard Matrix`` instead of timing out at 6 h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)