### PR TITLE
Add Attic consumer migration tooling

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -74,3 +74,6 @@ repomix-terraform-shared *args:
         --header-text "Shared Terraform Infrastructure - Reusable CI Workflow, Dev Shell, and Policy Scripts" \
         --include "{{REPOMIX_TERRAFORM_SHARED_PATTERNS}}" \
         {{args}}
+
+attic-migrate-flake path *args:
+  nix run --accept-flake-config .#attic-migrate-flake -- {{path}} {{args}}

--- a/checks/cachix-removal-allowlist.json
+++ b/checks/cachix-removal-allowlist.json
@@ -1,0 +1,91 @@
+{
+  "enforce": false,
+  "roots": [
+    {
+      "name": "metacraft",
+      "path": "~/metacraft",
+      "repositories": [
+        { "name": "infra" },
+        { "name": "nixos-modules" },
+        { "name": "codetracer" },
+        { "name": "codetracer-native-backend" },
+        { "name": "codetracer-native-recorder" },
+        { "name": "codetracer-browser-extension" },
+        { "name": "codetracer-ci" },
+        { "name": "codetracer-trace-format" },
+        { "name": "codetracer-visual-replay" },
+        { "name": "codetracer-cairo-recorder" },
+        { "name": "codetracer-cardano-recorder" },
+        { "name": "codetracer-circom-recorder" },
+        { "name": "codetracer-flow-recorder" },
+        { "name": "codetracer-fuel-recorder" },
+        { "name": "codetracer-leo-recorder" },
+        { "name": "codetracer-miden-recorder" },
+        { "name": "codetracer-move-recorder" },
+        { "name": "codetracer-polkavm-recorder" },
+        { "name": "codetracer-solana-recorder" },
+        { "name": "codetracer-ton-recorder" },
+        { "name": "nix-blockchain-development" },
+        { "name": "nix-codetracer-toolchains" },
+        { "name": "ctfs-poc" },
+        { "name": "tracing-formats-benchmarks" },
+        { "name": "DendrETH" }
+      ]
+    },
+    {
+      "name": "blocksense",
+      "path": "~/blocksense",
+      "repositories": [
+        { "name": "blocksense" },
+        { "name": "blocksense-specs" },
+        { "name": "infra" },
+        { "name": "zkVMs-benchmarks" },
+        { "name": "zk-wars-website" }
+      ]
+    },
+    {
+      "name": "agent-harbor",
+      "path": "~/blocksense/agent-harbor",
+      "repositories": [
+        { "name": "main" },
+        { "name": "infra" },
+        { "name": "rebase-staging" }
+      ]
+    }
+  ],
+  "allowedRepositories": [
+    { "root": "metacraft", "repository": "infra", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "nixos-modules", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-native-backend", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-native-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-browser-extension", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-ci", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-trace-format", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-visual-replay", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-cairo-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-cardano-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-circom-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-flow-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-fuel-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-leo-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-miden-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-move-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-polkavm-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-solana-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "codetracer-ton-recorder", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "nix-blockchain-development", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "nix-codetracer-toolchains", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "ctfs-poc", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "tracing-formats-benchmarks", "reason": "M9 parallel migration window" },
+    { "root": "metacraft", "repository": "DendrETH", "reason": "M9 parallel migration window" },
+    { "root": "blocksense", "repository": "blocksense", "reason": "M9 parallel migration window" },
+    { "root": "blocksense", "repository": "blocksense-specs", "reason": "M9 parallel migration window" },
+    { "root": "blocksense", "repository": "infra", "reason": "M9 parallel migration window" },
+    { "root": "blocksense", "repository": "zkVMs-benchmarks", "reason": "M9 parallel migration window" },
+    { "root": "blocksense", "repository": "zk-wars-website", "reason": "M9 parallel migration window" },
+    { "root": "agent-harbor", "repository": "main", "reason": "M9 parallel migration window" },
+    { "root": "agent-harbor", "repository": "infra", "reason": "M9 parallel migration window" },
+    { "root": "agent-harbor", "repository": "rebase-staging", "reason": "M9 parallel migration window" }
+  ]
+}

--- a/checks/consumer-flake-attic.nix
+++ b/checks/consumer-flake-attic.nix
@@ -1,0 +1,352 @@
+{ ... }:
+{
+  perSystem =
+    {
+      pkgs,
+      self',
+      ...
+    }:
+    let
+      inventory = ./consumer-flake-cachix-inventory.json;
+      allowlist = ./cachix-removal-allowlist.json;
+      action = ../modules/attic-push-flake-outputs/action.yml;
+    in
+    {
+      checks = {
+        attic-migrate-flake-idempotent =
+          pkgs.runCommand "attic-migrate-flake-idempotent"
+            {
+              nativeBuildInputs = [
+                self'.packages.attic-migrate-flake
+                pkgs.diffutils
+                pkgs.gnugrep
+              ];
+            }
+            ''
+              mkdir -p fixture
+              cat > fixture/flake.nix <<'EOF'
+              {
+                description = "fixture";
+                passthru = {
+                  knownCachixOutsideNixConfig = "https://mcl-public-cache.cachix.org";
+                  unknownCachixOutsideNixConfig = "https://surprise.cachix.org";
+                };
+                nixConfig = {
+                  extra-substituters = [
+                    "https://mcl-public-cache.cachix.org"
+                    "https://metacraft-labs-codetracer.cachix.org"
+                  ];
+                  extra-trusted-public-keys = [
+                    "mcl-public-cache.cachix.org-1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                    "metacraft-labs-codetracer.cachix.org-1:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
+                  ];
+                };
+                outputs = { self }: {};
+              }
+              EOF
+
+              attic-migrate-flake --dry-run fixture | grep -q 'cache.metacraft-labs.com'
+              grep -q 'mcl-public-cache.cachix.org' fixture/flake.nix
+
+              if attic-migrate-flake --check fixture; then
+                echo "check mode should fail before migration" >&2
+                exit 1
+              fi
+
+              attic-migrate-flake fixture
+              cp fixture/flake.nix migrated.once
+              attic-migrate-flake fixture
+              diff -u migrated.once fixture/flake.nix
+              attic-migrate-flake --check fixture
+
+              grep -q 'https://cache.metacraft-labs.com/metacraft-public' fixture/flake.nix
+              grep -q 'https://cache.metacraft-labs.com/metacraft-codetracer' fixture/flake.nix
+              test "$(grep -c 'metacraft-private-infrastructure:' fixture/flake.nix)" -eq 1
+              grep -q 'knownCachixOutsideNixConfig = "https://mcl-public-cache.cachix.org"' fixture/flake.nix
+              grep -q 'unknownCachixOutsideNixConfig = "https://surprise.cachix.org"' fixture/flake.nix
+              ! grep -q 'mcl-public-cache.cachix.org-1:' fixture/flake.nix
+
+              mkdir -p unknown
+              cat > unknown/flake.nix <<'EOF'
+              {
+                nixConfig = {
+                  extra-substituters = [ "https://surprise.cachix.org" ];
+                };
+                outputs = { self }: {};
+              }
+              EOF
+              if attic-migrate-flake unknown 2>unknown.err; then
+                echo "unknown cachix cache should fail" >&2
+                exit 1
+              fi
+              grep -q 'surprise.cachix.org' unknown/flake.nix
+              grep -q 'refusing to edit unknown Cachix' unknown.err
+
+              touch "$out"
+            '';
+
+        attic-push-flake-outputs-action =
+          pkgs.runCommand "attic-push-flake-outputs-action"
+            {
+              nativeBuildInputs = [
+                pkgs.bash
+                pkgs.python3
+              ];
+            }
+            ''
+              python3 - <<'PY'
+              import os
+              import subprocess
+              import tempfile
+              from pathlib import Path
+
+              action = Path("${action}").read_text()
+              required = [
+                  "endpoint:",
+                  "cache:",
+                  "token:",
+                  "attributes:",
+                  "ATTIC_TOKEN",
+                  "attic login --set-default",
+                  "nix build",
+                  "--print-out-paths",
+                  "attic push",
+                  "missing required input",
+              ]
+              for needle in required:
+                  assert needle in action, needle
+
+              lines = action.splitlines()
+              blocks = []
+              for index, line in enumerate(lines):
+                  if line.strip() != "run: |":
+                      continue
+                  indent = len(line) - len(line.lstrip()) + 2
+                  block = []
+                  for child in lines[index + 1:]:
+                      if child.strip() and len(child) - len(child.lstrip()) < indent:
+                          break
+                      block.append(child[indent:] if len(child) >= indent else "")
+                  blocks.append("\n".join(block) + "\n")
+              assert blocks, "no composite action run blocks found"
+
+              with tempfile.TemporaryDirectory() as temp:
+                  temp_path = Path(temp)
+                  for index, block in enumerate(blocks):
+                      path = temp_path / f"block-{index}.bash"
+                      path.write_text(block)
+                      subprocess.run(["${pkgs.bash}/bin/bash", "-n", str(path)], check=True)
+
+                  fake_bin = temp_path / "bin"
+                  fake_bin.mkdir()
+                  fake_attic_log = temp_path / "attic.log"
+                  fake_nix_log = temp_path / "nix.log"
+
+                  (fake_bin / "attic").write_text("""#!${pkgs.bash}/bin/bash
+              set -euo pipefail
+              printf '%s\\n' "$*" >> "$FAKE_ATTIC_LOG"
+              if [ "''${FAKE_ATTIC_FAIL_PATH:-}" != "" ] && [ "$1" = "push" ]; then
+                last="''${!#}"
+                if [ "$last" = "$FAKE_ATTIC_FAIL_PATH" ]; then
+                  echo "fake attic push failed for $last" >&2
+                  exit 23
+                fi
+              fi
+              """)
+                  (fake_bin / "nix").write_text("""#!${pkgs.bash}/bin/bash
+              set -euo pipefail
+              printf '%s\\n' "$*" >> "$FAKE_NIX_LOG"
+              attr="''${!#}"
+              case "$attr" in
+                ".#checks.x86_64-linux.bar")
+                  printf '%s\\n' /nix/store/bar
+                  ;;
+                ".#packages.x86_64-linux.foo")
+                  printf '%s\\n' /nix/store/foo-one /nix/store/foo-two
+                  ;;
+                "github:metacraft/example#prebuilt")
+                  printf '%s\\n' /nix/store/prebuilt
+                  ;;
+                *)
+                  echo "unexpected attr $attr" >&2
+                  exit 44
+                  ;;
+              esac
+              """)
+                  for tool in fake_bin.iterdir():
+                      tool.chmod(0o755)
+
+                  script_paths = []
+                  for index, block in enumerate(blocks):
+                      path = temp_path / f"run-{index}.bash"
+                      path.write_text(block)
+                      script_paths.append(path)
+
+                  base_env = os.environ.copy()
+                  base_env.update({
+                      "PATH": f"{fake_bin}:{base_env['PATH']}",
+                      "FAKE_ATTIC_LOG": str(fake_attic_log),
+                      "FAKE_NIX_LOG": str(fake_nix_log),
+                      "INPUT_ENDPOINT": "https://cache.metacraft-labs.test",
+                      "INPUT_CACHE": "metacraft-public",
+                      "INPUT_TOKEN": "",
+                      "INPUT_FLAKE": ".",
+                      "INPUT_ATTRIBUTES": "packages.x86_64-linux.foo, checks.x86_64-linux.bar\ngithub:metacraft/example#prebuilt packages.x86_64-linux.foo",
+                      "INPUT_EXTRA_NIX_ARGS": "",
+                      "INPUT_EXTRA_ATTIC_PUSH_ARGS": "--jobs 2",
+                      "ATTIC_TOKEN": "test-token",
+                  })
+
+                  missing_env = base_env.copy()
+                  missing_env["INPUT_TOKEN"] = ""
+                  missing_env.pop("ATTIC_TOKEN", None)
+                  result = subprocess.run(
+                      ["${pkgs.bash}/bin/bash", str(script_paths[0])],
+                      env=missing_env,
+                      text=True,
+                      capture_output=True,
+                  )
+                  assert result.returncode == 64, result
+                  assert "missing required input(s): token or ATTIC_TOKEN" in result.stderr, result.stderr
+
+                  subprocess.run(["${pkgs.bash}/bin/bash", str(script_paths[0])], env=base_env, check=True)
+                  subprocess.run(["${pkgs.bash}/bin/bash", str(script_paths[1])], env=base_env, check=True)
+
+                  attic_log = fake_attic_log.read_text().splitlines()
+                  assert attic_log[0] == "login --set-default attic-push-flake-outputs https://cache.metacraft-labs.test test-token", attic_log
+                  assert attic_log[1:] == [
+                      "push --jobs 2 metacraft-public /nix/store/bar",
+                      "push --jobs 2 metacraft-public /nix/store/prebuilt",
+                      "push --jobs 2 metacraft-public /nix/store/foo-one",
+                      "push --jobs 2 metacraft-public /nix/store/foo-two",
+                  ], attic_log
+
+                  nix_log = fake_nix_log.read_text()
+                  for attr in [
+                      ".#checks.x86_64-linux.bar",
+                      "github:metacraft/example#prebuilt",
+                      ".#packages.x86_64-linux.foo",
+                  ]:
+                      assert f"--print-out-paths {attr}" in nix_log.replace("\n", " "), nix_log
+
+                  fake_attic_log.write_text("")
+                  fake_nix_log.write_text("")
+                  fail_env = base_env.copy()
+                  fail_env["INPUT_ATTRIBUTES"] = "packages.x86_64-linux.foo"
+                  fail_env["FAKE_ATTIC_FAIL_PATH"] = "/nix/store/foo-two"
+                  result = subprocess.run(
+                      ["${pkgs.bash}/bin/bash", str(script_paths[1])],
+                      env=fail_env,
+                      text=True,
+                      capture_output=True,
+                  )
+                  assert result.returncode == 23, result
+                  assert "fake attic push failed for /nix/store/foo-two" in result.stderr, result.stderr
+              PY
+
+              touch "$out"
+            '';
+
+        consumer-flake-cachix-inventory =
+          pkgs.runCommand "consumer-flake-cachix-inventory"
+            {
+              nativeBuildInputs = [
+                self'.packages.consumer-flake-cachix-inventory-tool
+                pkgs.jq
+              ];
+            }
+            ''
+              roots="$PWD/roots"
+              metacraft="$roots/metacraft"
+              blocksense="$roots/blocksense"
+              agent_harbor="$blocksense/agent-harbor"
+              mkdir -p "$metacraft" "$blocksense" "$agent_harbor"
+
+              jq -r '.roots[] as $root | $root.repositories[] | [$root.name, .name] | @tsv' ${inventory} |
+                while IFS="$(printf '\t')" read -r root_name repo_name; do
+                  case "$root_name" in
+                    metacraft) root="$metacraft"; cache="mcl-public-cache" ;;
+                    blocksense) root="$blocksense"; cache="blocksense" ;;
+                    agent-harbor) root="$agent_harbor"; cache="mcl-public-cache" ;;
+                    *) echo "unknown root $root_name" >&2; exit 1 ;;
+                  esac
+                  mkdir -p "$root/$repo_name"
+                  cat > "$root/$repo_name/flake.nix" <<EOF
+              {
+                nixConfig.extra-substituters = [ "https://$cache.cachix.org" ];
+                outputs = { self }: {};
+              }
+              EOF
+                done
+
+              consumer-flake-cachix-inventory \
+                --inventory ${inventory} \
+                --root metacraft="$metacraft" \
+                --root blocksense="$blocksense" \
+                --root agent-harbor="$agent_harbor"
+
+              mkdir -p "$metacraft/new-cache-user"
+              cat > "$metacraft/new-cache-user/flake.nix" <<'EOF'
+              { nixConfig.extra-substituters = [ "https://mcl-public-cache.cachix.org" ]; outputs = { self }: {}; }
+              EOF
+              if consumer-flake-cachix-inventory \
+                --inventory ${inventory} \
+                --root metacraft="$metacraft" \
+                --root blocksense="$blocksense" \
+                --root agent-harbor="$agent_harbor" 2>err; then
+                echo "inventory should fail on unexpected cachix user" >&2
+                exit 1
+              fi
+              grep -q 'new-cache-user' err
+
+              touch "$out"
+            '';
+
+        consumer-flake-no-cachix-residual =
+          pkgs.runCommand "consumer-flake-no-cachix-residual"
+            {
+              nativeBuildInputs = [
+                self'.packages.consumer-flake-no-cachix-residual-tool
+                pkgs.jq
+              ];
+            }
+            ''
+              roots="$PWD/roots"
+              metacraft="$roots/metacraft"
+              blocksense="$roots/blocksense"
+              agent_harbor="$blocksense/agent-harbor"
+              mkdir -p "$metacraft/nixos-modules" "$blocksense/blocksense" "$agent_harbor/main"
+              echo 'https://mcl-public-cache.cachix.org' > "$metacraft/nixos-modules/flake.nix"
+              echo 'https://blocksense.cachix.org' > "$blocksense/blocksense/flake.nix"
+              echo 'https://mcl-public-cache.cachix.org' > "$agent_harbor/main/flake.nix"
+
+              consumer-flake-no-cachix-residual \
+                --allowlist ${allowlist} \
+                --root metacraft="$metacraft" \
+                --root blocksense="$blocksense" \
+                --root agent-harbor="$agent_harbor"
+
+              consumer-flake-no-cachix-residual \
+                --allowlist ${allowlist} \
+                --root metacraft="$metacraft" \
+                --root blocksense="$blocksense" \
+                --root agent-harbor="$agent_harbor" \
+                --enforce
+
+              empty_allowlist="$PWD/empty-allowlist.json"
+              jq '.allowedRepositories = [] | .enforce = true' ${allowlist} > "$empty_allowlist"
+              if consumer-flake-no-cachix-residual \
+                --allowlist "$empty_allowlist" \
+                --root metacraft="$metacraft" \
+                --root blocksense="$blocksense" \
+                --root agent-harbor="$agent_harbor" 2>err; then
+                echo "no-residual check should fail when enforced without allowlist" >&2
+                exit 1
+              fi
+              grep -q 'residual cachix.org references found' err
+
+              touch "$out"
+            '';
+      };
+    };
+}

--- a/checks/consumer-flake-cachix-inventory.json
+++ b/checks/consumer-flake-cachix-inventory.json
@@ -1,0 +1,56 @@
+{
+  "capturedAt": "2026-06-05",
+  "roots": [
+    {
+      "name": "metacraft",
+      "path": "~/metacraft",
+      "repositories": [
+        { "name": "infra", "bucket": "metacraft-public" },
+        { "name": "nixos-modules", "bucket": "metacraft-public" },
+        { "name": "codetracer", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-native-backend", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-native-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-browser-extension", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-ci", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-trace-format", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-visual-replay", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-cairo-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-cardano-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-circom-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-flow-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-fuel-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-leo-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-miden-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-move-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-polkavm-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-solana-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "codetracer-ton-recorder", "bucket": "metacraft-codetracer" },
+        { "name": "nix-blockchain-development", "bucket": "metacraft-public" },
+        { "name": "nix-codetracer-toolchains", "bucket": "metacraft-codetracer" },
+        { "name": "ctfs-poc", "bucket": "metacraft-public" },
+        { "name": "tracing-formats-benchmarks", "bucket": "metacraft-public" },
+        { "name": "DendrETH", "bucket": "metacraft-public" }
+      ]
+    },
+    {
+      "name": "blocksense",
+      "path": "~/blocksense",
+      "repositories": [
+        { "name": "blocksense", "bucket": "blocksense-public" },
+        { "name": "blocksense-specs", "bucket": "blocksense-public" },
+        { "name": "infra", "bucket": "blocksense-public" },
+        { "name": "zkVMs-benchmarks", "bucket": "blocksense-public" },
+        { "name": "zk-wars-website", "bucket": "blocksense-public" }
+      ]
+    },
+    {
+      "name": "agent-harbor",
+      "path": "~/blocksense/agent-harbor",
+      "repositories": [
+        { "name": "main", "bucket": "agent-harbor" },
+        { "name": "infra", "bucket": "agent-harbor" },
+        { "name": "rebase-staging", "bucket": "agent-harbor" }
+      ]
+    }
+  ]
+}

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -10,6 +10,7 @@
     ./deployment-production-cutover.nix
     ./deployment-pull-agent.nix
     ./deployment-reconciler.nix
+    ./consumer-flake-attic.nix
     ./linux-vm-cloud-init
     ./netbird-with-agenix.nix
     ./packages-ci-matrix.nix

--- a/modules/attic-push-flake-outputs/action.yml
+++ b/modules/attic-push-flake-outputs/action.yml
@@ -1,0 +1,124 @@
+name: Attic Push Flake Outputs
+description: Build selected flake attributes and push their realized output paths to an Attic cache.
+
+inputs:
+  endpoint:
+    description: Attic API endpoint, for example https://cache.metacraft-labs.com.
+    required: true
+  cache:
+    description: Attic cache/bucket name to push to.
+    required: true
+  token:
+    description: Attic push token. Defaults to the ATTIC_TOKEN environment variable.
+    required: false
+    default: ''
+  flake:
+    description: Flake reference or path containing the attributes.
+    required: false
+    default: '.'
+  attributes:
+    description: Newline, comma, or space separated flake attribute list to build and push.
+    required: true
+  extra-nix-args:
+    description: Extra arguments appended to nix build.
+    required: false
+    default: ''
+  extra-attic-push-args:
+    description: Extra arguments appended to attic push.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Validate Attic push inputs
+      shell: bash
+      env:
+        INPUT_ENDPOINT: ${{ inputs.endpoint }}
+        INPUT_CACHE: ${{ inputs.cache }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_ATTRIBUTES: ${{ inputs.attributes }}
+      run: |
+        set -euo pipefail
+
+        token="${INPUT_TOKEN:-${ATTIC_TOKEN:-}}"
+        missing=()
+        [ -n "$INPUT_ENDPOINT" ] || missing+=("endpoint")
+        [ -n "$INPUT_CACHE" ] || missing+=("cache")
+        [ -n "$token" ] || missing+=("token or ATTIC_TOKEN")
+        [ -n "$INPUT_ATTRIBUTES" ] || missing+=("attributes")
+
+        if [ "${#missing[@]}" -gt 0 ]; then
+          printf 'attic-push-flake-outputs: missing required input(s): %s\n' "$(IFS=', '; echo "${missing[*]}")" >&2
+          exit 64
+        fi
+
+        command -v nix >/dev/null || {
+          echo "attic-push-flake-outputs: nix is required on PATH" >&2
+          exit 127
+        }
+        command -v attic >/dev/null || {
+          echo "attic-push-flake-outputs: attic is required on PATH" >&2
+          exit 127
+        }
+
+    - name: Push flake outputs to Attic
+      shell: bash
+      env:
+        INPUT_ENDPOINT: ${{ inputs.endpoint }}
+        INPUT_CACHE: ${{ inputs.cache }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_FLAKE: ${{ inputs.flake }}
+        INPUT_ATTRIBUTES: ${{ inputs.attributes }}
+        INPUT_EXTRA_NIX_ARGS: ${{ inputs.extra-nix-args }}
+        INPUT_EXTRA_ATTIC_PUSH_ARGS: ${{ inputs.extra-attic-push-args }}
+      run: |
+        set -euo pipefail
+
+        token="${INPUT_TOKEN:-${ATTIC_TOKEN:-}}"
+        workdir="$(mktemp -d)"
+        trap 'rm -rf "$workdir"' EXIT
+
+        printf '%s\n' "$INPUT_ATTRIBUTES" \
+          | sed 's/[[:space:],]\+/\n/g' \
+          | sed '/^$/d' \
+          | sort -u > "$workdir/attributes"
+
+        if [ ! -s "$workdir/attributes" ]; then
+          echo "attic-push-flake-outputs: attributes did not contain any flake attributes" >&2
+          exit 64
+        fi
+
+        attic login --set-default attic-push-flake-outputs "$INPUT_ENDPOINT" "$token"
+
+        while IFS= read -r attr; do
+          case "$attr" in
+            *'#'*)
+              flake_attr="$attr"
+              ;;
+            *)
+              flake_attr="${INPUT_FLAKE}#${attr}"
+              ;;
+          esac
+
+          echo "::group::Build ${flake_attr}"
+          nix build \
+            --extra-experimental-features "nix-command flakes" \
+            --no-link \
+            --print-out-paths \
+            ${INPUT_EXTRA_NIX_ARGS} \
+            "$flake_attr" > "$workdir/outputs"
+          echo "::endgroup::"
+
+          if [ ! -s "$workdir/outputs" ]; then
+            echo "attic-push-flake-outputs: nix build produced no output paths for ${flake_attr}" >&2
+            exit 65
+          fi
+
+          echo "::group::Push ${flake_attr} outputs to ${INPUT_CACHE}"
+          while IFS= read -r output_path; do
+            [ -n "$output_path" ] || continue
+            attic push ${INPUT_EXTRA_ATTIC_PUSH_ARGS} "$INPUT_CACHE" "$output_path"
+          done < "$workdir/outputs"
+          echo "::endgroup::"
+        done < "$workdir/attributes"

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -60,7 +60,28 @@
       };
 
       packages = {
+        attic-migrate-flake = pkgs.writeShellApplication {
+          name = "attic-migrate-flake";
+          runtimeInputs = [ pkgs.python3 ];
+          text = ''
+            exec python3 ${../scripts/attic-migrate-flake} "$@"
+          '';
+        };
         cachix-deploy-metrics = pkgs.callPackage ./cachix-deploy-metrics { };
+        consumer-flake-cachix-inventory-tool = pkgs.writeShellApplication {
+          name = "consumer-flake-cachix-inventory";
+          runtimeInputs = [ pkgs.python3 ];
+          text = ''
+            exec python3 ${../scripts/consumer-flake-cachix-inventory} "$@"
+          '';
+        };
+        consumer-flake-no-cachix-residual-tool = pkgs.writeShellApplication {
+          name = "consumer-flake-no-cachix-residual";
+          runtimeInputs = [ pkgs.python3 ];
+          text = ''
+            exec python3 ${../scripts/consumer-flake-no-cachix-residual} "$@"
+          '';
+        };
         lido-withdrawals-automation = pkgs.callPackage ./lido-withdrawals-automation { };
         pyroscope = pkgs.callPackage ./pyroscope { };
         random-alerts = pkgs.callPackage ./random-alerts { };

--- a/scripts/attic-migrate-flake
+++ b/scripts/attic-migrate-flake
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+
+ATTIC_BASE_URL = "https://cache.metacraft-labs.com"
+ATTIC_PUBLIC_KEY = "metacraft-private-infrastructure:TWjFAlGXK9Mky5VG3PBln2MqYz4XPw3MTHHVPYZiAhE="
+
+DEFAULT_BUCKETS = {
+    "blocksense.cachix.org": "blocksense-public",
+    "metacraft-labs-codetracer.cachix.org": "metacraft-codetracer",
+    "mcl-blockchain-packages.cachix.org": "metacraft-public",
+    "mcl-public-cache.cachix.org": "metacraft-public",
+}
+
+URL_RE = re.compile(r"https?://([A-Za-z0-9][A-Za-z0-9-]*\.cachix\.org)")
+KEY_RE = re.compile(r"([A-Za-z0-9][A-Za-z0-9-]*\.cachix\.org-1:[A-Za-z0-9+/=]+)")
+IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_'-]*")
+
+
+def resolve_flake_path(path_arg: str) -> Path:
+    path = Path(path_arg).expanduser()
+    return path / "flake.nix" if path.is_dir() else path
+
+
+def attic_url(base_url: str, bucket: str) -> str:
+    return f"{base_url.rstrip('/')}/{bucket}"
+
+
+def unknown_cachix_hosts(text: str) -> set[str]:
+    hosts = set(URL_RE.findall(text))
+    hosts.update(key.split("-1:", 1)[0] for key in KEY_RE.findall(text))
+    return hosts - set(DEFAULT_BUCKETS)
+
+
+def skip_ws(text: str, index: int) -> int:
+    while index < len(text) and text[index].isspace():
+        index += 1
+    return index
+
+
+def find_matching_brace(text: str, open_index: int) -> int:
+    depth = 0
+    index = open_index
+    state = "normal"
+    while index < len(text):
+        char = text[index]
+        nxt = text[index + 1] if index + 1 < len(text) else ""
+
+        if state == "line-comment":
+            if char == "\n":
+                state = "normal"
+        elif state == "block-comment":
+            if char == "*" and nxt == "/":
+                state = "normal"
+                index += 1
+        elif state == "string":
+            if char == "\\":
+                index += 1
+            elif char == '"':
+                state = "normal"
+        else:
+            if char == "#":
+                state = "line-comment"
+            elif char == "/" and nxt == "*":
+                state = "block-comment"
+                index += 1
+            elif char == '"':
+                state = "string"
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return index
+
+        index += 1
+
+    return -1
+
+
+def top_level_nix_config_block(text: str) -> tuple[int, int] | None:
+    depth = 0
+    index = 0
+    state = "normal"
+    while index < len(text):
+        char = text[index]
+        nxt = text[index + 1] if index + 1 < len(text) else ""
+
+        if state == "line-comment":
+            if char == "\n":
+                state = "normal"
+        elif state == "block-comment":
+            if char == "*" and nxt == "/":
+                state = "normal"
+                index += 1
+        elif state == "string":
+            if char == "\\":
+                index += 1
+            elif char == '"':
+                state = "normal"
+        else:
+            if char == "#":
+                state = "line-comment"
+            elif char == "/" and nxt == "*":
+                state = "block-comment"
+                index += 1
+            elif char == '"':
+                state = "string"
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            elif depth == 1 and text.startswith("nixConfig", index):
+                before = text[index - 1] if index > 0 else ""
+                after = text[index + len("nixConfig")] if index + len("nixConfig") < len(text) else ""
+                if (before and IDENT_RE.fullmatch(before)) or (after and IDENT_RE.fullmatch(after)):
+                    index += 1
+                    continue
+
+                cursor = skip_ws(text, index + len("nixConfig"))
+                if cursor >= len(text) or text[cursor] != "=":
+                    index += 1
+                    continue
+                cursor = skip_ws(text, cursor + 1)
+                if cursor >= len(text) or text[cursor] != "{":
+                    index += 1
+                    continue
+                close = find_matching_brace(text, cursor)
+                if close < 0:
+                    raise ValueError("unclosed top-level nixConfig block")
+                return cursor, close + 1
+
+        index += 1
+
+    return None
+
+
+def replace_known_entries(text: str, base_url: str, public_key: str, bucket_override: str | None) -> str:
+    def replace_url(match: re.Match[str]) -> str:
+        host = match.group(1)
+        bucket = bucket_override or DEFAULT_BUCKETS[host]
+        return attic_url(base_url, bucket)
+
+    def replace_key(match: re.Match[str]) -> str:
+        return public_key
+
+    migrated = URL_RE.sub(replace_url, text)
+    migrated = KEY_RE.sub(replace_key, migrated)
+
+    dedupe_values = {
+        public_key,
+        *(attic_url(base_url, bucket_override or bucket) for bucket in DEFAULT_BUCKETS.values()),
+    }
+    return dedupe_quoted_list_lines(migrated, dedupe_values)
+
+
+def dedupe_quoted_list_lines(text: str, values: set[str]) -> str:
+    result = text
+    for value in sorted(values, key=len, reverse=True):
+        seen = False
+        pattern = re.compile(rf'^(?P<indent>\s*)"{re.escape(value)}";?\s*\n', re.MULTILINE)
+
+        def keep_first(match: re.Match[str]) -> str:
+            nonlocal seen
+            if seen:
+                return ""
+            seen = True
+            return match.group(0)
+
+        result = pattern.sub(keep_first, result)
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Rewrite known Cachix nixConfig entries in a flake.nix to Metacraft Attic entries."
+    )
+    parser.add_argument("path", help="Path to a consumer repo or its flake.nix")
+    parser.add_argument("--check", action="store_true", help="Do not write; exit 1 if changes are needed")
+    parser.add_argument("--dry-run", action="store_true", help="Do not write; print a unified diff when changes are needed")
+    parser.add_argument("--bucket", help="Override the Attic bucket for all known Cachix entries in this flake")
+    parser.add_argument("--attic-base-url", default=ATTIC_BASE_URL, help=f"Attic base URL (default: {ATTIC_BASE_URL})")
+    parser.add_argument(
+        "--attic-public-key",
+        default=ATTIC_PUBLIC_KEY,
+        help="Trusted public key to use for replacement extra-trusted-public-keys entries",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    flake_path = resolve_flake_path(args.path)
+    if flake_path.name != "flake.nix":
+        print(f"attic-migrate-flake: expected a repo directory or flake.nix, got {flake_path}", file=sys.stderr)
+        return 64
+    if not flake_path.exists():
+        print(f"attic-migrate-flake: file not found: {flake_path}", file=sys.stderr)
+        return 66
+
+    original = flake_path.read_text()
+    try:
+        block_span = top_level_nix_config_block(original)
+    except ValueError as error:
+        print(f"attic-migrate-flake: {error}", file=sys.stderr)
+        return 65
+
+    if block_span is None:
+        print(f"attic-migrate-flake: no top-level nixConfig block found in {flake_path}")
+        return 0
+
+    block_start, block_end = block_span
+    original_block = original[block_start:block_end]
+    unknown = unknown_cachix_hosts(original_block)
+    if unknown:
+        print(
+            "attic-migrate-flake: refusing to edit unknown Cachix entr"
+            + ("y" if len(unknown) == 1 else "ies")
+            + ": "
+            + ", ".join(sorted(unknown)),
+            file=sys.stderr,
+        )
+        print("attic-migrate-flake: pass --bucket only after adding this cache to DEFAULT_BUCKETS", file=sys.stderr)
+        return 65
+
+    migrated_block = replace_known_entries(
+        original_block,
+        base_url=args.attic_base_url,
+        public_key=args.attic_public_key,
+        bucket_override=args.bucket,
+    )
+    migrated = original[:block_start] + migrated_block + original[block_end:]
+
+    if migrated == original:
+        print(f"attic-migrate-flake: no changes needed for {flake_path}")
+        return 0
+
+    if args.dry_run or args.check:
+        if args.dry_run:
+            diff = difflib.unified_diff(
+                original.splitlines(keepends=True),
+                migrated.splitlines(keepends=True),
+                fromfile=str(flake_path),
+                tofile=str(flake_path),
+            )
+            sys.stdout.writelines(diff)
+        else:
+            print(f"attic-migrate-flake: {flake_path} needs Attic nixConfig migration", file=sys.stderr)
+        return 1 if args.check else 0
+
+    flake_path.write_text(migrated)
+    print(f"attic-migrate-flake: migrated {flake_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/consumer-flake-cachix-inventory
+++ b/scripts/consumer-flake-cachix-inventory
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def default_inventory_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "checks" / "consumer-flake-cachix-inventory.json"
+
+
+def parse_root_overrides(values: list[str]) -> dict[str, Path]:
+    overrides: dict[str, Path] = {}
+    for value in values:
+        if "=" not in value:
+            raise SystemExit(f"--root must be NAME=PATH, got {value!r}")
+        name, path = value.split("=", 1)
+        overrides[name] = Path(path).expanduser()
+    return overrides
+
+
+def child_roots(root: Path, root_paths: dict[str, Path], root_name: str) -> list[Path]:
+    children: list[Path] = []
+    resolved_root = root.resolve()
+    for name, path in root_paths.items():
+        if name == root_name or not path.exists():
+            continue
+        resolved_path = path.resolve()
+        if resolved_path == resolved_root:
+            continue
+        try:
+            resolved_path.relative_to(resolved_root)
+        except ValueError:
+            continue
+        children.append(resolved_path)
+    return children
+
+
+def nix_files(root: Path, pruned_roots: list[Path]) -> list[Path]:
+    if not root.exists():
+        return []
+    ignored = {".git", ".direnv", "result", "node_modules"}
+    files: list[Path] = []
+    resolved_pruned_roots = [path.resolve() for path in pruned_roots]
+
+    def walk(directory: Path) -> None:
+        for path in directory.iterdir():
+            if path.name in ignored:
+                continue
+            resolved_path = path.resolve()
+            if any(resolved_path == pruned for pruned in resolved_pruned_roots):
+                continue
+            if path.is_dir():
+                walk(path)
+            elif path.suffix == ".nix":
+                files.append(path)
+
+    walk(root)
+    return files
+
+
+def has_cachix_reference(path: Path) -> bool:
+    try:
+        return "cachix." in path.read_text(errors="ignore")
+    except OSError:
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify the M9 consumer flake Cachix inventory.")
+    parser.add_argument("--inventory", default=str(default_inventory_path()))
+    parser.add_argument("--root", action="append", default=[], help="Override an inventory root path as NAME=PATH")
+    args = parser.parse_args()
+
+    inventory_path = Path(args.inventory)
+    inventory = json.loads(inventory_path.read_text())
+    overrides = parse_root_overrides(args.root)
+    root_paths = {
+        root["name"]: overrides.get(root["name"], Path(root["path"]).expanduser())
+        for root in inventory["roots"]
+    }
+
+    errors: list[str] = []
+    for root in inventory["roots"]:
+        root_name = root["name"]
+        root_path = root_paths[root_name]
+        repos = root["repositories"]
+        expected = {repo["name"] for repo in repos}
+        observed: set[str] = set()
+        unexpected: set[str] = set()
+
+        if not root_path.exists():
+            errors.append(f"{root_name}: root does not exist: {root_path}")
+            continue
+
+        repo_paths = [(repo["name"], root_path / repo["name"]) for repo in repos]
+        for file_path in nix_files(root_path, child_roots(root_path, root_paths, root_name)):
+            if not has_cachix_reference(file_path):
+                continue
+            matched = [name for name, path in repo_paths if file_path == path or path in file_path.parents]
+            if matched:
+                observed.add(max(matched, key=len))
+            else:
+                unexpected.add(str(file_path.relative_to(root_path)))
+
+        missing = expected - observed
+        if missing:
+            errors.append(f"{root_name}: expected Cachix references missing from: {', '.join(sorted(missing))}")
+        if unexpected:
+            errors.append(f"{root_name}: unexpected Cachix references found in: {', '.join(sorted(unexpected))}")
+
+    if errors:
+        print("consumer-flake-cachix-inventory: inventory mismatch", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("consumer-flake-cachix-inventory: inventory matches")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/consumer-flake-no-cachix-residual
+++ b/scripts/consumer-flake-no-cachix-residual
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+SCAN_SUFFIXES = {".nix", ".yml", ".yaml", ".md", ".sh"}
+SCAN_NAMES = {".gitlab-ci.yml", "Justfile"}
+
+
+def default_allowlist_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "checks" / "cachix-removal-allowlist.json"
+
+
+def parse_root_overrides(values: list[str]) -> dict[str, Path]:
+    overrides: dict[str, Path] = {}
+    for value in values:
+        if "=" not in value:
+            raise SystemExit(f"--root must be NAME=PATH, got {value!r}")
+        name, path = value.split("=", 1)
+        overrides[name] = Path(path).expanduser()
+    return overrides
+
+
+def should_scan(path: Path) -> bool:
+    return path.name in SCAN_NAMES or path.suffix in SCAN_SUFFIXES
+
+
+def child_roots(root: Path, root_paths: dict[str, Path], root_name: str) -> list[Path]:
+    children: list[Path] = []
+    resolved_root = root.resolve()
+    for name, path in root_paths.items():
+        if name == root_name or not path.exists():
+            continue
+        resolved_path = path.resolve()
+        if resolved_path == resolved_root:
+            continue
+        try:
+            resolved_path.relative_to(resolved_root)
+        except ValueError:
+            continue
+        children.append(resolved_path)
+    return children
+
+
+def scan(root: Path, pruned_roots: list[Path]) -> list[Path]:
+    ignored = {".git", ".direnv", "result", "node_modules"}
+    matches: list[Path] = []
+    resolved_pruned_roots = [path.resolve() for path in pruned_roots]
+
+    def walk(directory: Path) -> None:
+        for path in directory.iterdir():
+            if path.name in ignored:
+                continue
+            resolved_path = path.resolve()
+            if any(resolved_path == pruned for pruned in resolved_pruned_roots):
+                continue
+            if path.is_dir():
+                walk(path)
+                continue
+            if not should_scan(path):
+                continue
+            try:
+                if "cachix.org" in path.read_text(errors="ignore"):
+                    matches.append(path)
+            except OSError:
+                continue
+
+    walk(root)
+    return matches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check for residual cachix.org references under consumer roots.")
+    parser.add_argument("--allowlist", default=str(default_allowlist_path()))
+    parser.add_argument("--root", action="append", default=[], help="Override an allowlist root path as NAME=PATH")
+    parser.add_argument("--enforce", action="store_true", help="Fail on non-allowlisted matches")
+    args = parser.parse_args()
+
+    allowlist = json.loads(Path(args.allowlist).read_text())
+    overrides = parse_root_overrides(args.root)
+    enforce = args.enforce or bool(allowlist.get("enforce", False))
+    allowed = {
+        (entry["root"], entry["repository"])
+        for entry in allowlist.get("allowedRepositories", [])
+    }
+    root_paths = {
+        root["name"]: overrides.get(root["name"], Path(root["path"]).expanduser())
+        for root in allowlist["roots"]
+    }
+
+    residual: list[tuple[str, str, str]] = []
+    tolerated: list[tuple[str, str, str]] = []
+
+    for root in allowlist["roots"]:
+        root_name = root["name"]
+        root_path = root_paths[root_name]
+        if not root_path.exists():
+            if enforce:
+                residual.append((root_name, "<root>", f"missing root {root_path}"))
+            continue
+        repositories = root["repositories"]
+        repo_paths = [(repo["name"], root_path / repo["name"]) for repo in repositories]
+        for path in scan(root_path, child_roots(root_path, root_paths, root_name)):
+            matched = [name for name, repo_path in repo_paths if path == repo_path or repo_path in path.parents]
+            repo = max(matched, key=len) if matched else "<untracked>"
+            record = (root_name, repo, str(path.relative_to(root_path)))
+            if (root_name, repo) in allowed:
+                tolerated.append(record)
+            else:
+                residual.append(record)
+
+    for root_name, repo, path in tolerated:
+        print(f"consumer-flake-no-cachix-residual: tolerated {root_name}/{repo}: {path}")
+
+    if residual and enforce:
+        print("consumer-flake-no-cachix-residual: residual cachix.org references found", file=sys.stderr)
+        for root_name, repo, path in residual:
+            print(f"- {root_name}/{repo}: {path}", file=sys.stderr)
+        return 1
+
+    if residual:
+        print(f"consumer-flake-no-cachix-residual: gate disabled; observed {len(residual)} residual reference(s)")
+    else:
+        print("consumer-flake-no-cachix-residual: no residual cachix.org references")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add shared `attic-push-flake-outputs` composite action for consumer flake output pushes
- add `attic-migrate-flake` helper scoped to top-level `nixConfig` migration
- add consumer Cachix inventory and gated no-residual scanners with nested-root pruning
- add focused tests for migration idempotency/refusal, action execution paths, and inventory/residual behavior

## Validation
Implementation and review agents ran:
- `nix flake show --accept-flake-config --json`
- `nix build --accept-flake-config --print-build-logs .#checks.x86_64-linux.attic-migrate-flake-idempotent .#checks.x86_64-linux.attic-push-flake-outputs-action .#checks.x86_64-linux.consumer-flake-cachix-inventory .#checks.x86_64-linux.consumer-flake-no-cachix-residual`
- `nix build --accept-flake-config --print-build-logs .#attic-migrate-flake .#consumer-flake-cachix-inventory-tool .#consumer-flake-no-cachix-residual-tool`
- `nix build --accept-flake-config --print-build-logs .#checks.x86_64-linux.deployment-cache-backend-policy .#checks.x86_64-linux.deployment-cachix-fallback-simulation .#checks.x86_64-linux.deployment-no-default-cachix-deploy-call .#checks.x86_64-linux.deployment-parallel-cache-push-local .#checks.x86_64-linux.reusable-flake-checks-mcl-ref`
- `git diff --check`

Full `nix flake check` was intentionally not run locally because this repo includes VM/image-heavy checks outside this tooling slice.