### PR TITLE
Use public Attic keys for cache migration

### DIFF
--- a/checks/consumer-flake-attic.nix
+++ b/checks/consumer-flake-attic.nix
@@ -20,6 +20,7 @@
                 self'.packages.attic-migrate-flake
                 pkgs.diffutils
                 pkgs.gnugrep
+                pkgs.python3
               ];
             }
             ''
@@ -61,7 +62,9 @@
 
               grep -q 'https://cache.metacraft-labs.com/metacraft-public' fixture/flake.nix
               grep -q 'https://cache.metacraft-labs.com/metacraft-codetracer' fixture/flake.nix
-              test "$(grep -c 'metacraft-private-infrastructure:' fixture/flake.nix)" -eq 1
+              grep -q 'metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q=' fixture/flake.nix
+              grep -q 'metacraft-codetracer:9OV9wCDX560bt5/MrD4dlqnPpCitAEjpoqhNfQpWY3U=' fixture/flake.nix
+              ! grep -q 'metacraft-private-infrastructure:' fixture/flake.nix
               grep -q 'knownCachixOutsideNixConfig = "https://mcl-public-cache.cachix.org"' fixture/flake.nix
               grep -q 'unknownCachixOutsideNixConfig = "https://surprise.cachix.org"' fixture/flake.nix
               ! grep -q 'mcl-public-cache.cachix.org-1:' fixture/flake.nix
@@ -81,6 +84,69 @@
               fi
               grep -q 'surprise.cachix.org' unknown/flake.nix
               grep -q 'refusing to edit unknown Cachix' unknown.err
+
+              python3 - <<'PY'
+              import json
+              import subprocess
+              import tempfile
+              import textwrap
+              from pathlib import Path
+
+              inventory = json.loads(Path("${inventory}").read_text())
+              migration = inventory["atticMigration"]
+              base_url = migration["baseUrl"].rstrip("/")
+              caches = migration["cachixCaches"]
+              assert caches, "no Attic migration Cachix caches declared"
+
+              repo_buckets = {
+                  repo["bucket"]
+                  for root in inventory["roots"]
+                  for repo in root["repositories"]
+              }
+              mapped_buckets = {cache["bucket"] for cache in caches}
+              missing_buckets = repo_buckets - mapped_buckets
+              assert not missing_buckets, f"repository bucket(s) lack migration mapping: {sorted(missing_buckets)}"
+
+              public_keys_by_bucket = {}
+              for cache in caches:
+                  for field in ("host", "bucket", "publicKey"):
+                      assert cache.get(field), f"migration cache lacks {field}: {cache}"
+                  expected_prefix = f"{cache['bucket']}:"
+                  assert cache["publicKey"].startswith(expected_prefix), cache
+                  previous = public_keys_by_bucket.setdefault(cache["bucket"], cache["publicKey"])
+                  assert previous == cache["publicKey"], cache
+
+              public_keys = set(public_keys_by_bucket.values())
+              assert len(public_keys) == len(public_keys_by_bucket), public_keys_by_bucket
+              assert not any(key.startswith("metacraft-private-infrastructure:") for key in public_keys)
+
+              with tempfile.TemporaryDirectory() as temp:
+                  temp_path = Path(temp)
+                  for cache in caches:
+                      case = temp_path / cache["host"]
+                      case.mkdir()
+                      fake_key = f"{cache['host']}-1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                      (case / "flake.nix").write_text(textwrap.dedent(f"""
+                      {{
+                        nixConfig = {{
+                          extra-substituters = [ "https://{cache['host']}" ];
+                          extra-trusted-public-keys = [ "{fake_key}" ];
+                        }};
+                        outputs = {{ self }}: {{}};
+                      }}
+                      """))
+
+                      subprocess.run(["attic-migrate-flake", str(case)], check=True)
+                      migrated = (case / "flake.nix").read_text()
+                      expected_url = f"{base_url}/{cache['bucket']}"
+                      assert expected_url in migrated, (cache, migrated)
+                      assert cache["publicKey"] in migrated, (cache, migrated)
+                      assert f"https://{cache['host']}" not in migrated, (cache, migrated)
+                      assert f"{cache['host']}-1:" not in migrated, (cache, migrated)
+                      assert "metacraft-private-infrastructure:" not in migrated, (cache, migrated)
+                      for other_key in public_keys - {cache["publicKey"]}:
+                          assert other_key not in migrated, (cache, other_key, migrated)
+              PY
 
               touch "$out"
             '';
@@ -262,18 +328,23 @@
               agent_harbor="$blocksense/agent-harbor"
               mkdir -p "$metacraft" "$blocksense" "$agent_harbor"
 
-              jq -r '.roots[] as $root | $root.repositories[] | [$root.name, .name] | @tsv' ${inventory} |
-                while IFS="$(printf '\t')" read -r root_name repo_name; do
+              jq -r '.roots[] as $root | $root.repositories[] | [$root.name, .name, .bucket] | @tsv' ${inventory} |
+                while IFS="$(printf '\t')" read -r root_name repo_name bucket; do
                   case "$root_name" in
-                    metacraft) root="$metacraft"; cache="mcl-public-cache" ;;
-                    blocksense) root="$blocksense"; cache="blocksense" ;;
-                    agent-harbor) root="$agent_harbor"; cache="mcl-public-cache" ;;
+                    metacraft) root="$metacraft" ;;
+                    blocksense) root="$blocksense" ;;
+                    agent-harbor) root="$agent_harbor" ;;
                     *) echo "unknown root $root_name" >&2; exit 1 ;;
                   esac
+                  cache_host="$(jq -r --arg bucket "$bucket" '.atticMigration.cachixCaches[] | select(.bucket == $bucket) | .host' ${inventory} | head -n1)"
+                  if [ -z "$cache_host" ]; then
+                    echo "missing Cachix migration host for bucket $bucket" >&2
+                    exit 1
+                  fi
                   mkdir -p "$root/$repo_name"
                   cat > "$root/$repo_name/flake.nix" <<EOF
               {
-                nixConfig.extra-substituters = [ "https://$cache.cachix.org" ];
+                nixConfig.extra-substituters = [ "https://$cache_host" ];
                 outputs = { self }: {};
               }
               EOF
@@ -318,7 +389,7 @@
               mkdir -p "$metacraft/nixos-modules" "$blocksense/blocksense" "$agent_harbor/main"
               echo 'https://mcl-public-cache.cachix.org' > "$metacraft/nixos-modules/flake.nix"
               echo 'https://blocksense.cachix.org' > "$blocksense/blocksense/flake.nix"
-              echo 'https://mcl-public-cache.cachix.org' > "$agent_harbor/main/flake.nix"
+              echo 'https://agent-harbor.cachix.org' > "$agent_harbor/main/flake.nix"
 
               consumer-flake-no-cachix-residual \
                 --allowlist ${allowlist} \

--- a/checks/consumer-flake-cachix-inventory.json
+++ b/checks/consumer-flake-cachix-inventory.json
@@ -1,5 +1,35 @@
 {
   "capturedAt": "2026-06-05",
+  "atticMigration": {
+    "baseUrl": "https://cache.metacraft-labs.com",
+    "cachixCaches": [
+      {
+        "host": "agent-harbor.cachix.org",
+        "bucket": "agent-harbor",
+        "publicKey": "agent-harbor:MjT3Kx9Dimt/yD8cTA4UwZbZV+b4esSFcnzIplbkJ1o="
+      },
+      {
+        "host": "blocksense.cachix.org",
+        "bucket": "blocksense-public",
+        "publicKey": "blocksense-public:OOgTc0ye1FONCiVHMrbpScc/HP+lX3uoU0EfwzX6ypE="
+      },
+      {
+        "host": "metacraft-labs-codetracer.cachix.org",
+        "bucket": "metacraft-codetracer",
+        "publicKey": "metacraft-codetracer:9OV9wCDX560bt5/MrD4dlqnPpCitAEjpoqhNfQpWY3U="
+      },
+      {
+        "host": "mcl-blockchain-packages.cachix.org",
+        "bucket": "metacraft-public",
+        "publicKey": "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
+      },
+      {
+        "host": "mcl-public-cache.cachix.org",
+        "bucket": "metacraft-public",
+        "publicKey": "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
+      }
+    ]
+  },
   "roots": [
     {
       "name": "metacraft",

--- a/scripts/attic-migrate-flake
+++ b/scripts/attic-migrate-flake
@@ -7,9 +7,15 @@ from pathlib import Path
 
 
 ATTIC_BASE_URL = "https://cache.metacraft-labs.com"
-ATTIC_PUBLIC_KEY = "metacraft-private-infrastructure:TWjFAlGXK9Mky5VG3PBln2MqYz4XPw3MTHHVPYZiAhE="
+ATTIC_BUCKET_PUBLIC_KEYS = {
+    "agent-harbor": "agent-harbor:MjT3Kx9Dimt/yD8cTA4UwZbZV+b4esSFcnzIplbkJ1o=",
+    "blocksense-public": "blocksense-public:OOgTc0ye1FONCiVHMrbpScc/HP+lX3uoU0EfwzX6ypE=",
+    "metacraft-codetracer": "metacraft-codetracer:9OV9wCDX560bt5/MrD4dlqnPpCitAEjpoqhNfQpWY3U=",
+    "metacraft-public": "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q=",
+}
 
 DEFAULT_BUCKETS = {
+    "agent-harbor.cachix.org": "agent-harbor",
     "blocksense.cachix.org": "blocksense-public",
     "metacraft-labs-codetracer.cachix.org": "metacraft-codetracer",
     "mcl-blockchain-packages.cachix.org": "metacraft-public",
@@ -28,6 +34,17 @@ def resolve_flake_path(path_arg: str) -> Path:
 
 def attic_url(base_url: str, bucket: str) -> str:
     return f"{base_url.rstrip('/')}/{bucket}"
+
+
+def attic_public_key(bucket: str, public_key_override: str | None = None) -> str:
+    if public_key_override is not None:
+        return public_key_override
+    try:
+        return ATTIC_BUCKET_PUBLIC_KEYS[bucket]
+    except KeyError as error:
+        raise ValueError(
+            f"no Attic public key is known for bucket {bucket!r}; pass --attic-public-key for a custom bucket"
+        ) from error
 
 
 def unknown_cachix_hosts(text: str) -> set[str]:
@@ -139,21 +156,28 @@ def top_level_nix_config_block(text: str) -> tuple[int, int] | None:
     return None
 
 
-def replace_known_entries(text: str, base_url: str, public_key: str, bucket_override: str | None) -> str:
+def replace_known_entries(text: str, base_url: str, public_key: str | None, bucket_override: str | None) -> str:
+    url_buckets: set[str] = set()
+    key_buckets: set[str] = set()
+
     def replace_url(match: re.Match[str]) -> str:
         host = match.group(1)
         bucket = bucket_override or DEFAULT_BUCKETS[host]
+        url_buckets.add(bucket)
         return attic_url(base_url, bucket)
 
     def replace_key(match: re.Match[str]) -> str:
-        return public_key
+        host = match.group(1).split("-1:", 1)[0]
+        bucket = bucket_override or DEFAULT_BUCKETS[host]
+        key_buckets.add(bucket)
+        return attic_public_key(bucket, public_key)
 
     migrated = URL_RE.sub(replace_url, text)
     migrated = KEY_RE.sub(replace_key, migrated)
 
     dedupe_values = {
-        public_key,
-        *(attic_url(base_url, bucket_override or bucket) for bucket in DEFAULT_BUCKETS.values()),
+        *(attic_public_key(bucket, public_key) for bucket in key_buckets),
+        *(attic_url(base_url, bucket) for bucket in url_buckets),
     }
     return dedupe_quoted_list_lines(migrated, dedupe_values)
 
@@ -186,8 +210,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--attic-base-url", default=ATTIC_BASE_URL, help=f"Attic base URL (default: {ATTIC_BASE_URL})")
     parser.add_argument(
         "--attic-public-key",
-        default=ATTIC_PUBLIC_KEY,
-        help="Trusted public key to use for replacement extra-trusted-public-keys entries",
+        help="Trusted public key override for replacement extra-trusted-public-keys entries",
     )
     return parser.parse_args()
 
@@ -227,12 +250,16 @@ def main() -> int:
         print("attic-migrate-flake: pass --bucket only after adding this cache to DEFAULT_BUCKETS", file=sys.stderr)
         return 65
 
-    migrated_block = replace_known_entries(
-        original_block,
-        base_url=args.attic_base_url,
-        public_key=args.attic_public_key,
-        bucket_override=args.bucket,
-    )
+    try:
+        migrated_block = replace_known_entries(
+            original_block,
+            base_url=args.attic_base_url,
+            public_key=args.attic_public_key,
+            bucket_override=args.bucket,
+        )
+    except ValueError as error:
+        print(f"attic-migrate-flake: {error}", file=sys.stderr)
+        return 65
     migrated = original[:block_start] + migrated_block + original[block_end:]
 
     if migrated == original:


### PR DESCRIPTION
## Summary
- map known Cachix hosts to their Attic bucket-specific public signing keys
- add the Agent Harbor Cachix host to the migration mapping
- extend consumer migration tests so private-key reuse, swapped bucket keys, and missing bucket/key mappings are caught

## Verification
- `nix build .#checks.x86_64-linux.attic-migrate-flake`
- `nix build .#checks.x86_64-linux.attic-migrate-flake-idempotent`
- `nix build .#checks.x86_64-linux.consumer-flake-cachix-inventory`
- `nix build .#checks.x86_64-linux.consumer-flake-no-cachix-residual`
- `python3 -m py_compile scripts/attic-migrate-flake`
- `jq empty checks/consumer-flake-cachix-inventory.json`
- `nixfmt --check checks/consumer-flake-attic.nix`
- `prettier --check checks/consumer-flake-cachix-inventory.json`
- `git diff --check`
