### PR TITLE
Add extra Attic cache mappings

### DIFF
--- a/checks/consumer-flake-attic.nix
+++ b/checks/consumer-flake-attic.nix
@@ -98,6 +98,23 @@
               caches = migration["cachixCaches"]
               assert caches, "no Attic migration Cachix caches declared"
 
+              required_mappings = {
+                  "nix-blockchain-development.cachix.org": (
+                      "metacraft-public",
+                      "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q=",
+                  ),
+                  "blocksense-infra.cachix.org": (
+                      "blocksense-public",
+                      "blocksense-public:OOgTc0ye1FONCiVHMrbpScc/HP+lX3uoU0EfwzX6ypE=",
+                  ),
+              }
+              caches_by_host = {cache["host"]: cache for cache in caches}
+              for host, (bucket, public_key) in required_mappings.items():
+                  assert host in caches_by_host, f"{host} missing from Attic migration inventory"
+                  cache = caches_by_host[host]
+                  assert cache["bucket"] == bucket, cache
+                  assert cache["publicKey"] == public_key, cache
+
               repo_buckets = {
                   repo["bucket"]
                   for root in inventory["roots"]

--- a/checks/consumer-flake-cachix-inventory.json
+++ b/checks/consumer-flake-cachix-inventory.json
@@ -14,6 +14,11 @@
         "publicKey": "blocksense-public:OOgTc0ye1FONCiVHMrbpScc/HP+lX3uoU0EfwzX6ypE="
       },
       {
+        "host": "blocksense-infra.cachix.org",
+        "bucket": "blocksense-public",
+        "publicKey": "blocksense-public:OOgTc0ye1FONCiVHMrbpScc/HP+lX3uoU0EfwzX6ypE="
+      },
+      {
         "host": "metacraft-labs-codetracer.cachix.org",
         "bucket": "metacraft-codetracer",
         "publicKey": "metacraft-codetracer:9OV9wCDX560bt5/MrD4dlqnPpCitAEjpoqhNfQpWY3U="
@@ -25,6 +30,11 @@
       },
       {
         "host": "mcl-public-cache.cachix.org",
+        "bucket": "metacraft-public",
+        "publicKey": "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
+      },
+      {
+        "host": "nix-blockchain-development.cachix.org",
         "bucket": "metacraft-public",
         "publicKey": "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
       }

--- a/scripts/attic-migrate-flake
+++ b/scripts/attic-migrate-flake
@@ -17,9 +17,11 @@ ATTIC_BUCKET_PUBLIC_KEYS = {
 DEFAULT_BUCKETS = {
     "agent-harbor.cachix.org": "agent-harbor",
     "blocksense.cachix.org": "blocksense-public",
+    "blocksense-infra.cachix.org": "blocksense-public",
     "metacraft-labs-codetracer.cachix.org": "metacraft-codetracer",
     "mcl-blockchain-packages.cachix.org": "metacraft-public",
     "mcl-public-cache.cachix.org": "metacraft-public",
+    "nix-blockchain-development.cachix.org": "metacraft-public",
 }
 
 URL_RE = re.compile(r"https?://([A-Za-z0-9][A-Za-z0-9-]*\.cachix\.org)")


### PR DESCRIPTION
## Summary
- map nix-blockchain-development.cachix.org to the metacraft-public Attic bucket
- map blocksense-infra.cachix.org to the blocksense-public Attic bucket
- extend inventory and migration tests for these additional known Cachix hosts

## Verification
- python3 -m py_compile scripts/attic-migrate-flake
- jq empty checks/consumer-flake-cachix-inventory.json
- nix develop .#pre-commit -c nixfmt --check checks/consumer-flake-attic.nix
- nix develop .#pre-commit -c prettier --check checks/consumer-flake-cachix-inventory.json
- nix build .#checks.x86_64-linux.attic-migrate-flake
- nix build .#checks.x86_64-linux.attic-migrate-flake-idempotent
- nix build .#checks.x86_64-linux.consumer-flake-cachix-inventory
- nix build .#checks.x86_64-linux.consumer-flake-no-cachix-residual
- git diff --check