### PR TITLE
Remove stale Blocksense specs cache inventory entry

### DIFF
--- a/checks/cachix-removal-allowlist.json
+++ b/checks/cachix-removal-allowlist.json
@@ -37,7 +37,6 @@
       "path": "~/blocksense",
       "repositories": [
         { "name": "blocksense" },
-        { "name": "blocksense-specs" },
         { "name": "infra" },
         { "name": "zkVMs-benchmarks" },
         { "name": "zk-wars-website" }
@@ -80,7 +79,6 @@
     { "root": "metacraft", "repository": "tracing-formats-benchmarks", "reason": "M9 parallel migration window" },
     { "root": "metacraft", "repository": "DendrETH", "reason": "M9 parallel migration window" },
     { "root": "blocksense", "repository": "blocksense", "reason": "M9 parallel migration window" },
-    { "root": "blocksense", "repository": "blocksense-specs", "reason": "M9 parallel migration window" },
     { "root": "blocksense", "repository": "infra", "reason": "M9 parallel migration window" },
     { "root": "blocksense", "repository": "zkVMs-benchmarks", "reason": "M9 parallel migration window" },
     { "root": "blocksense", "repository": "zk-wars-website", "reason": "M9 parallel migration window" },

--- a/checks/consumer-flake-cachix-inventory.json
+++ b/checks/consumer-flake-cachix-inventory.json
@@ -77,7 +77,6 @@
       "path": "~/blocksense",
       "repositories": [
         { "name": "blocksense", "bucket": "blocksense-public" },
-        { "name": "blocksense-specs", "bucket": "blocksense-public" },
         { "name": "infra", "bucket": "blocksense-public" },
         { "name": "zkVMs-benchmarks", "bucket": "blocksense-public" },
         { "name": "zk-wars-website", "bucket": "blocksense-public" }


### PR DESCRIPTION
## Summary
- remove the nonexistent `blocksense-network/blocksense-specs` repo from the Attic/Cachix consumer inventory
- remove the same stale repo from the Cachix-removal allowlist

Blocksense specs live inside `blocksense-network/blocksense`, which remains mapped to `blocksense-public`.

## Validation
- `jq empty checks/consumer-flake-cachix-inventory.json checks/cachix-removal-allowlist.json`
- `git diff --check`
- `nix build -L --accept-flake-config .#checks.x86_64-linux.consumer-flake-cachix-inventory .#checks.x86_64-linux.consumer-flake-no-cachix-residual`