### PR TITLE
[codex] Run shared workflows on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
         include:
           - runner: ['self-hosted', 'nixos', 'x86-64-v2', 'bare-metal']
             nix-version: ''
-          - runner: ubuntu-latest
+          - runner: ['self-hosted', 'nixos', 'x86-64-v2', 'bare-metal']
             nix-version: 2.28.5
-          - runner: ubuntu-latest
+          - runner: ['self-hosted', 'nixos', 'x86-64-v2', 'bare-metal']
             nix-version: 2.33.0
     runs-on: ${{ matrix.runner }}
     steps:
@@ -60,7 +60,7 @@ jobs:
   # `.github/setup-nix/tests/devshell-fixture/`.
   test-setup-nix-devshell:
     name: Validate setup-nix devShell build-failure detection
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos, x86-64-v2, bare-metal]
     steps:
       - name: Checkout first to use locally defined actions
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -23,13 +23,13 @@ on:
         required: false
         type: string
       non-nix-runner:
-        description: 'Runner labels for non-nix tasks (initial comment, mcl reference compute)'
-        default: 'ubuntu-latest'
+        description: 'JSON-encoded runner labels for non-nix tasks (initial comment, mcl reference compute)'
+        default: '["self-hosted", "nixos", "x86-64-v2", "bare-metal"]'
         required: false
         type: string
       results-runner:
         description: 'JSON-encoded runner labels for Final Results and deploy orchestration'
-        default: '"ubuntu-latest"'
+        default: '["self-hosted", "nixos", "x86-64-v2", "bare-metal"]'
         required: false
         type: string
       run-cachix-deploy:
@@ -77,7 +77,7 @@ on:
 jobs:
   compute-mcl-ref:
     name: Compute MCL Reference
-    runs-on: ${{ inputs.non-nix-runner }}
+    runs-on: ${{ fromJSON(inputs.non-nix-runner) }}
     outputs:
       workflow_sha: ${{ steps.compute.outputs.workflow_sha }}
       mcl_flake_cmd: ${{ steps.compute.outputs.mcl_flake_cmd }}
@@ -125,7 +125,7 @@ jobs:
 
   post-initial-comment:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ inputs.non-nix-runner }}
+    runs-on: ${{ fromJSON(inputs.non-nix-runner) }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/reusable-merge.yml
+++ b/.github/workflows/reusable-merge.yml
@@ -3,6 +3,11 @@ name: Merge Branch
 on:
   workflow_call:
     inputs:
+      runner:
+        description: 'JSON-encoded list of runner labels'
+        default: '["self-hosted", "nixos", "x86-64-v2", "bare-metal"]'
+        required: false
+        type: string
       source_branch:
         description: 'The source branch to merge from (e.g., main, testnet)'
         required: true
@@ -17,7 +22,7 @@ permissions:
 
 jobs:
   merge:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -130,10 +130,10 @@ jobs:
   # ---------------------------------------------------------------------------
   # Job 1: Offline checks (no credentials required)
   # Runs in ALL modes: pr, apply, drift
-  # Fork PRs run on GitHub-hosted runners; everything else on self-hosted.
+  # All modes run on the configured self-hosted runner labels.
   # ---------------------------------------------------------------------------
   offline-checks:
-    runs-on: ${{ inputs.mode == 'pr' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || fromJSON(inputs.runner) }}
+    runs-on: ${{ fromJSON(inputs.runner) }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/trigger-downstream-flake-update.yml
+++ b/.github/workflows/trigger-downstream-flake-update.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-downstream-repo:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos, x86-64-v2, bare-metal]
 
     strategy:
       matrix:

--- a/checks/deployment-production-cutover.nix
+++ b/checks/deployment-production-cutover.nix
@@ -482,13 +482,22 @@ top@{ config, ... }:
               assert "push-deployment-caches:" in workflow, "workflow no longer exposes the deployment cache publish gate"
               assert re.search(r"push-deployment-caches:.*?default:\s*false", workflow, re.S), "deployment cache publish gate must default false in the reusable workflow"
               assert re.search(
-                  r"results-runner:\s*\n"
+                  r"non-nix-runner:\s*\n"
                   r"\s+description:.*\n"
-                  r"\s+default:\s*'\"ubuntu-latest\"'\s*\n"
+                  r"\s+default:\s*'\[\"self-hosted\",\s*\"nixos\",\s*\"x86-64-v2\",\s*\"bare-metal\"\]'\s*\n"
                   r"\s+required:\s*false\s*\n"
                   r"\s+type:\s*string",
                   workflow,
-              ), "workflow must expose results-runner defaulting to off-target ubuntu-latest"
+              ), "workflow must expose non-nix-runner defaulting to self-hosted labels"
+              assert re.search(
+                  r"results-runner:\s*\n"
+                  r"\s+description:.*\n"
+                  r"\s+default:\s*'\[\"self-hosted\",\s*\"nixos\",\s*\"x86-64-v2\",\s*\"bare-metal\"\]'\s*\n"
+                  r"\s+required:\s*false\s*\n"
+                  r"\s+type:\s*string",
+                  workflow,
+              ), "workflow must expose results-runner defaulting to self-hosted labels"
+              assert "runs-on: ''${{ fromJSON(inputs.non-nix-runner) }}" in workflow, "non-nix helper jobs must use JSON runner labels"
               results_job_match = re.search(
                   r"(?ms)^  results:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
                   workflow,

--- a/docs/Terraform-Shared-Infrastructure.status.org
+++ b/docs/Terraform-Shared-Infrastructure.status.org
@@ -252,7 +252,7 @@
 
     Safety gates (shared — consuming repos enable via workflow inputs):
     - [X] Fork-PR guard: credentialed plan skipped at job level for fork PRs
-    - [X] Fork PRs run offline checks on GitHub-hosted runners only
+    - [X] Fork PRs run offline checks on configured self-hosted runners only
     - [X] Denylist CI step: blocks dangerous HCL constructs (data "external",
           exec provisioners, null_resource, unpinned remote sources); configurable
           provider allowlist per consuming repo
@@ -311,7 +311,7 @@
       status: pending
 
     - test_name: verify_fork_guard
-      description: Fork PRs skip credentialed plan and run only offline checks on GitHub-hosted runners
+      description: Fork PRs skip credentialed plan and run only offline checks on configured self-hosted runners
       status: pending
 
     - test_name: verify_denylist

--- a/docs/deployment/current-cachix-flow.md
+++ b/docs/deployment/current-cachix-flow.md
@@ -23,8 +23,8 @@ for backward compatibility.
    `build` runs `mcl cache push-closure` for each deployment target and the
    configured `deployment-cache-push-backends`.
 7. `results` runs on the JSON-encoded `results-runner` input, which defaults
-   to the off-target GitHub-hosted runner `"ubuntu-latest"`. It prints the
-   final matrix and updates the pull request comment.
+   to self-hosted Linux fleet runner labels. It prints the final matrix and
+   updates the pull request comment.
 8. When `inputs.run-cachix-deploy` is true, `results` checks out the repository
    and runs `mcl deploy-spec`.
 
@@ -65,7 +65,7 @@ journald logs, activation generation, health-check output, or rollback status.
 | Attic cache          | GitHub variables `ATTIC_CACHE`, `ATTIC_SUBSTITUTER`, `ATTIC_TRUSTED_PUBLIC_KEY`                       | Used when `deployment-cache-push-backends` includes `attic`.              |
 | Substituters         | GitHub variable `SUBSTITUTERS` plus default cache URLs supplied to `mcl`                              | Used for Nix setup and cache-status checks.                               |
 | Trusted public keys  | GitHub variable `TRUSTED_PUBLIC_KEYS`                                                                 | Required for substituter trust on runners.                                |
-| Results runner       | Workflow input `results-runner`, JSON default `"ubuntu-latest"`                                       | Keeps deploy orchestration off the fleet self-hosted runner by default.   |
+| Results runner       | Workflow input `results-runner`, JSON default `["self-hosted", "nixos", "x86-64-v2", "bare-metal"]`   | Keeps deploy orchestration on self-hosted runners by default.             |
 | Deploy token         | Secret `CACHIX_ACTIVATE_TOKEN`                                                                        | Passed only to the deploy step environment.                               |
 | Cache push tokens    | Secrets `CACHIX_AUTH_TOKEN`, `ATTIC_TOKEN`                                                            | Used by setup, optional cache pushes, and cache-status checks.            |
 | Source access tokens | `NIX_GITHUB_TOKEN`, `NIX_GITLAB_TOKEN`, `NIX_GITLAB_DOMAIN`                                           | Used by Nix access-token setup.                                           |


### PR DESCRIPTION
## Summary

- Default reusable CI helper jobs to self-hosted runner labels instead of `ubuntu-latest`.
- Remove the reusable Terraform fork-PR fallback to GitHub-hosted runners.
- Move nixos-modules standalone workflow jobs off `ubuntu-latest`.
- Update deployment/Terraform docs and checks for self-hosted-only defaults.

## Validation

- `nix build -L --accept-flake-config .#checks.x86_64-linux.deployment-current-flow-inventory .#checks.x86_64-linux.deployment-no-default-cachix-deploy-call .#checks.x86_64-linux.terraform`
- `rg -n "ubuntu-latest|macos-latest|windows-latest" .github/workflows` returned no matches
- `git diff --check`