### PR TITLE
[codex] Use Attic cache in nixos-modules nixConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,11 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://mcl-public-cache.cachix.org"
+      "https://cache.metacraft-labs.com/metacraft-public"
       "https://dlang-community.cachix.org"
     ];
     extra-trusted-public-keys = [
-      "mcl-public-cache.cachix.org-1:OcUzMeoSAwNEd3YCaEbNjLV5/Gd+U5VFxdN2WGHfpCI="
+      "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
       "dlang-community.cachix.org-1:eAX1RqX4PjTDPCAp/TvcZP+DYBco2nJBackkAJ2BsDQ="
     ];
   };


### PR DESCRIPTION
## Summary

- replace the Metacraft public Cachix nixConfig entry with the metacraft-public Attic substituter and key
- keep the external dlang-community Cachix cache unchanged

## Validation

- `git diff --check`
- `/nix/store/lbmkfrm0dp8xi3ksdamn5n9pg1qk6f0k-nix-2.34.7/bin/nix flake metadata --json --no-accept-flake-config --option substituters https://cache.nixos.org`