### PR TITLE
Disable Cachix with explicit sentinel

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -3,12 +3,12 @@ description: Installs Nix, configures binary caches, and optionally builds/activ
 
 inputs:
   push-to-cache:
-    description: Whether to use cachix or not
+    description: Whether to push to the configured Cachix cache
     type: boolean
     required: false
     default: false
   cachix-cache:
-    description: The name of the cachix cache to use
+    description: The Cachix cache name to use. Set to 'disabled', 'none', or 'false' to force-disable Cachix.
     required: false
     default: ''
   cachix-auth-token:
@@ -87,6 +87,20 @@ runs:
           echo "Nix is not installed, will install it"
         fi
 
+    - name: Normalize Cachix inputs
+      id: cachix
+      shell: bash
+      env:
+        INPUT_CACHIX_CACHE: ${{ inputs.cachix-cache }}
+      run: |
+        cachix_cache="$INPUT_CACHIX_CACHE"
+        case "$cachix_cache" in
+          "" | disabled | none | false)
+            cachix_cache=""
+            ;;
+        esac
+        printf 'cache=%s\n' "$cachix_cache" >> "$GITHUB_OUTPUT"
+
     - name: Install Nix
       uses: cachix/install-nix-action@v31
       if: steps.check-nix.outputs.has_nix != 'true'
@@ -122,16 +136,16 @@ runs:
 
         touch "$HOME/.config/nix/netrc"
         chmod 0600 "$HOME/.config/nix/netrc"
-        if [[ -n "${{ inputs.cachix-cache }}" && -n "${{ inputs.cachix-auth-token }}" ]]; then
+        if [[ -n "${{ steps.cachix.outputs.cache }}" && -n "${{ inputs.cachix-auth-token }}" ]]; then
           cat << EOF >> "$HOME/.config/nix/netrc"
-          machine ${{ inputs.cachix-cache }}.cachix.org password ${{ inputs.cachix-auth-token }}
+          machine ${{ steps.cachix.outputs.cache }}.cachix.org password ${{ inputs.cachix-auth-token }}
         EOF
         fi
 
     - uses: cachix/cachix-action@v15
-      if: ${{ fromJSON(inputs.push-to-cache || 'false') && inputs.cachix-cache != '' && inputs.cachix-auth-token != '' }}
+      if: ${{ fromJSON(inputs.push-to-cache || 'false') && steps.cachix.outputs.cache != '' && inputs.cachix-auth-token != '' }}
       with:
-        name: ${{ inputs.cachix-cache }}
+        name: ${{ steps.cachix.outputs.cache }}
         authToken: ${{ inputs.cachix-auth-token }}
 
     - name: Restore/Save Nix Store GHA Cache

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Generate Shard Matrix
         id: generate-matrix
         env:
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
@@ -198,7 +198,7 @@ jobs:
         id: generate-matrix
         shell: bash
         env:
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
@@ -243,7 +243,7 @@ jobs:
       - name: Generate CI matrix comment
         env:
           IS_INITIAL: 'true'
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           PRECALC_MATRIX: ${{ steps.merge.outputs.full_matrix }}
@@ -328,7 +328,7 @@ jobs:
           DEPLOYMENT_CACHE_PUSH_BACKENDS: ${{ inputs.deployment-cache-push-backends }}
           DEPLOYMENT_CACHE_REQUIRED_BACKENDS: ${{ inputs.deployment-cache-required-backends }}
           DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS: ${{ inputs.deployment-cache-optional-timeout-seconds }}
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           ATTIC_CACHE: ${{ vars.ATTIC_CACHE }}
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
@@ -589,7 +589,7 @@ jobs:
       - name: Print CI Matrix
         env:
           IS_INITIAL: 'false'
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           PRECALC_MATRIX: ${{
             needs.merge-matrices.result == 'success' &&
@@ -622,7 +622,7 @@ jobs:
       - name: Deploy
         if: inputs.run-cachix-deploy
         env:
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           CACHIX_ACTIVATE_TOKEN: '${{ secrets.CACHIX_ACTIVATE_TOKEN }}'
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}

--- a/checks/deployment-production-cutover.nix
+++ b/checks/deployment-production-cutover.nix
@@ -13,6 +13,7 @@ top@{ config, ... }:
       docs = ../docs/deployment;
       repoWorkflow = ../.github/workflows/ci.yml;
       workflow = ../.github/workflows/reusable-flake-checks-ci-matrix.yml;
+      setupNix = ../.github/setup-nix/action.yml;
       deployPrivateKey = pkgs.writeText "mcl-cutover-deploy-test-key" ''
         -----BEGIN OPENSSH PRIVATE KEY-----
         b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
@@ -461,6 +462,7 @@ top@{ config, ... }:
               gate = json.loads(Path("${docs}/production-cutover-gates.json").read_text())
               repo_workflow = Path("${repoWorkflow}").read_text()
               workflow = Path("${workflow}").read_text()
+              setup_nix = Path("${setupNix}").read_text()
               cutover_doc = Path("${docs}/production-cutover.md").read_text()
               deploy_spec = Path("${repoRoot}/packages/mcl/src/mcl/commands/deploy_spec.d").read_text()
 
@@ -512,6 +514,10 @@ top@{ config, ... }:
               assert "if: ''${{ always() && (inputs.push-deployment-caches || inputs.run-cachix-deploy) && !matrix.noop && matrix.deploymentTarget }}" in workflow, "deployment cache artifact upload must be limited to deployment targets"
               assert "DEPLOY_KIND: ''${{ matrix.deploymentKind }}" in workflow, "deployment cache push must receive the matrix deployment kind"
               assert '--kind "$DEPLOY_KIND"' in workflow, "deployment cache push must pass the deployment kind to mcl"
+              assert "Normalize Cachix inputs" in setup_nix, "setup-nix must normalize legacy Cachix cache inputs"
+              assert '"" | disabled | none | false)' in setup_nix, "setup-nix must treat the disabled Cachix sentinel as empty"
+              assert "steps.cachix.outputs.cache !=" in setup_nix, "setup-nix must gate Cachix action on normalized cache output"
+              assert "vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE" in workflow, "mcl workflow must not pass the disabled Cachix sentinel as a cache name"
               assert "mcl_flake_cmd }} deploy-spec" in workflow, "legacy fallback deploy-spec call disappeared"
               assert "cachix deploy activate" in deploy_spec, "fallback deploy-spec no longer exposes Cachix Deploy activation"
 


### PR DESCRIPTION
## Summary
- normalize the setup-nix Cachix input so CACHIX_CACHE=disabled/none/false behaves as no Cachix cache
- avoid passing the disabled sentinel into reusable workflow matrix/deploy steps
- add cutover policy assertions covering the sentinel behavior

## Verification
- nix build -L --no-accept-flake-config --extra-experimental-features pipe-operators --option substituters https://cache.nixos.org .#checks.x86_64-linux.deployment-production-cutover-simulation-vm .#checks.x86_64-linux.deployment-no-default-cachix-deploy-call .#checks.x86_64-linux.deployment-cache-backend-policy
- git diff --check