### PR TITLE
Reset Nix flake fetcher cache in setup action

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -142,6 +142,13 @@ runs:
         EOF
         fi
 
+    - name: Reset Nix flake fetcher cache
+      shell: bash
+      run: |
+        cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/nix"
+        rm -f "$cache_dir"/fetcher-cache-v*.sqlite*
+        rm -rf "$cache_dir"/gitv3 "$cache_dir"/tarballs
+
     - uses: cachix/cachix-action@v15
       if: ${{ fromJSON(inputs.push-to-cache || 'false') && steps.cachix.outputs.cache != '' && inputs.cachix-auth-token != '' }}
       with:


### PR DESCRIPTION
## Summary
- clear Nix flake fetcher/git archive cache after writing nix.conf
- prevents self-hosted runners from reusing stale GitHub archive metadata after private repo/org moves

## Test
- pre-commit hooks via git commit
- git diff --check