### PR TITLE
[codex] Give deploy agent a writable Nix cache

### DIFF
--- a/checks/deployment-pull-agent.nix
+++ b/checks/deployment-pull-agent.nix
@@ -119,6 +119,7 @@ top@{ config, ... }:
       staticService = staticSystem.config.systemd.services.mcl-deploy-agent;
       staticTimer = staticSystem.config.systemd.timers.mcl-deploy-agent;
       staticExecStart = staticService.serviceConfig.ExecStart;
+      staticEnvironment = staticService.serviceConfig.Environment or [ ];
       staticFailures = lib.flatten [
         (lib.optional (
           !lib.hasInfix "flock -n /run/lock/mcl-test-pull-agent.lock" staticExecStart
@@ -150,6 +151,15 @@ top@{ config, ... }:
         (lib.optional (
           !lib.hasInfix "--dry-run" staticExecStart
         ) "pull-agent service does not pass dry-run")
+        (lib.optional (
+          staticService.serviceConfig.CacheDirectory != "mcl-deploy-agent"
+        ) "pull-agent service does not provision a writable cache directory")
+        (lib.optional (
+          !(builtins.elem "HOME=/var/cache/mcl-deploy-agent" staticEnvironment)
+        ) "pull-agent service does not set HOME to its writable cache directory")
+        (lib.optional (
+          !(builtins.elem "XDG_CACHE_HOME=/var/cache/mcl-deploy-agent" staticEnvironment)
+        ) "pull-agent service does not set XDG_CACHE_HOME to its writable cache directory")
         (lib.optional (
           staticTimer.timerConfig.OnActiveSec != "7min"
         ) "timer initial activation interval drifted")

--- a/modules/deployment/pull-agent.nix
+++ b/modules/deployment/pull-agent.nix
@@ -190,6 +190,11 @@
           serviceConfig = {
             Type = "oneshot";
             ExecStart = "${pkgs.util-linux}/bin/flock -n ${escapeShellArg cfg.lockFile} ${agentCommand}";
+            CacheDirectory = "mcl-deploy-agent";
+            Environment = [
+              "HOME=/var/cache/mcl-deploy-agent"
+              "XDG_CACHE_HOME=/var/cache/mcl-deploy-agent"
+            ];
             NoNewPrivileges = true;
             ProtectHome = true;
             PrivateTmp = true;


### PR DESCRIPTION
## Summary

- give `mcl-deploy-agent.service` a systemd-managed writable cache directory
- set `HOME` and `XDG_CACHE_HOME` to that cache directory so production `nix copy` does not try to write under `/root`
- extend the static pull-agent check to lock in the writable cache environment

## Root cause

On Solunska, the pull agent accepted the CI-published manifest and started applying it, but the production restore path failed with `error: creating directory '/root/.cache/nix': Read-only file system`. The unit keeps `ProtectHome = true`, so Nix needs an explicit writable cache location.

## Validation

- `nix build -L .#checks.x86_64-linux.deployment-pull-agent-static`
- `nix build -L .#checks.x86_64-linux.deployment-pull-agent-latest-vm`
