### PR TITLE
Migrate Cachix usage to Attic on dev

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -3,18 +3,10 @@ description: Installs Nix, configures binary caches, and optionally builds/activ
 
 inputs:
   push-to-cache:
-    description: Whether to push to the configured Cachix cache
+    description: Deprecated compatibility input; ignored. Use explicit Attic cache push steps instead.
     type: boolean
     required: false
     default: false
-  cachix-cache:
-    description: The Cachix cache name to use. Set to 'disabled', 'none', or 'false' to force-disable Cachix.
-    required: false
-    default: ''
-  cachix-auth-token:
-    description: Cachix auth token
-    required: false
-    default: ''
   trusted-public-keys:
     description: Trusted public keys
     required: false
@@ -36,7 +28,7 @@ inputs:
     default: 'gitlab.com'
     required: false
   nix-version:
-    description: Nix version to install
+    description: Deprecated compatibility input; ignored by the Determinate Nix installer.
     default: ''
     required: false
   use-direnv:
@@ -87,25 +79,11 @@ runs:
           echo "Nix is not installed, will install it"
         fi
 
-    - name: Normalize Cachix inputs
-      id: cachix
-      shell: bash
-      env:
-        INPUT_CACHIX_CACHE: ${{ inputs.cachix-cache }}
-      run: |
-        cachix_cache="$INPUT_CACHIX_CACHE"
-        case "$cachix_cache" in
-          "" | disabled | none | false)
-            cachix_cache=""
-            ;;
-        esac
-        printf 'cache=%s\n' "$cachix_cache" >> "$GITHUB_OUTPUT"
-
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: DeterminateSystems/nix-installer-action@v22
       if: steps.check-nix.outputs.has_nix != 'true'
       with:
-        install_url: ${{ inputs.nix-version != '' && format('https://releases.nixos.org/nix/nix-{0}/install', inputs.nix-version) || '' }}
+        determinate: false
 
     - name: Configure Nix
       shell: bash
@@ -128,6 +106,7 @@ runs:
           connect-timeout = 5
           narinfo-cache-negative-ttl = 120
           allow-import-from-derivation = true
+          experimental-features = nix-command flakes
 
           substituters = https://cache.nixos.org ${{inputs.substituters}}
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{inputs.trusted-public-keys}}
@@ -136,17 +115,13 @@ runs:
 
         touch "$HOME/.config/nix/netrc"
         chmod 0600 "$HOME/.config/nix/netrc"
-        if [[ -n "${{ steps.cachix.outputs.cache }}" && -n "${{ inputs.cachix-auth-token }}" ]]; then
-          cat << EOF >> "$HOME/.config/nix/netrc"
-          machine ${{ steps.cachix.outputs.cache }}.cachix.org password ${{ inputs.cachix-auth-token }}
-        EOF
-        fi
 
-    - uses: cachix/cachix-action@v15
-      if: ${{ fromJSON(inputs.push-to-cache || 'false') && steps.cachix.outputs.cache != '' && inputs.cachix-auth-token != '' }}
-      with:
-        name: ${{ steps.cachix.outputs.cache }}
-        authToken: ${{ inputs.cachix-auth-token }}
+    - name: Reset Nix flake fetcher cache
+      shell: bash
+      run: |
+        cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/nix"
+        rm -f "$cache_dir"/fetcher-cache-v*.sqlite*
+        rm -rf "$cache_dir"/gitv3 "$cache_dir"/tarballs
 
     - name: Restore/Save Nix Store GHA Cache
       uses: nix-community/cache-nix-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
         with:
           nix-version: ${{ matrix.nix-version }}
           push-to-cache: false
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           devshell: default
@@ -76,8 +74,6 @@ jobs:
         uses: ./.github/setup-nix
         with:
           push-to-cache: false
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           devshell: failing
@@ -95,8 +91,6 @@ jobs:
         uses: ./.github/setup-nix
         with:
           push-to-cache: false
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           devshell: default
@@ -119,8 +113,6 @@ jobs:
         uses: ./.github/setup-nix
         with:
           push-to-cache: false
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 
@@ -149,7 +141,6 @@ jobs:
             "aarch64-darwin"
           ]
         }
-      run-cachix-deploy: false
 
   test-act:
     runs-on: [self-hosted, nixos, x86-64-v3, bare-metal]
@@ -161,8 +152,6 @@ jobs:
         uses: ./.github/setup-nix
         with:
           push-to-cache: true
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           devshell: default
@@ -170,11 +159,16 @@ jobs:
       - name: Create `.gh-vars.env` and `.gh-secrets.env` files
         run: |
           {
-            echo 'CACHIX_CACHE=${{ vars.CACHIX_CACHE }}'
+            echo 'ATTIC_ENDPOINT=${{ vars.ATTIC_ENDPOINT }}'
+            echo 'ATTIC_CACHE=${{ vars.ATTIC_CACHE }}'
+            echo 'ATTIC_SUBSTITUTER=${{ vars.ATTIC_SUBSTITUTER }}'
+            echo 'ATTIC_TRUSTED_PUBLIC_KEY=${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}'
+            echo 'SUBSTITUTERS=${{ vars.SUBSTITUTERS }}'
+            echo 'TRUSTED_PUBLIC_KEYS=${{ vars.TRUSTED_PUBLIC_KEYS }}'
           } > .gh-vars.env
 
           {
-            echo 'CACHIX_AUTH_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN }}'
+            echo 'ATTIC_TOKEN=${{ secrets.ATTIC_TOKEN }}'
           } > .gh-secrets.env
 
       - name: Build `ci-image` and run the `lint` workflow inside it with `act`

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -32,24 +32,19 @@ on:
         default: '["self-hosted", "nixos", "x86-64-v2", "bare-metal"]'
         required: false
         type: string
-      run-cachix-deploy:
-        description: 'Deploy to cachix'
-        default: false
-        required: false
-        type: 'boolean'
       push-deployment-caches:
         description: 'Push deployment target closures to configured deployment cache backends'
         default: false
         required: false
         type: 'boolean'
       deployment-cache-push-backends:
-        description: 'Comma-separated cache push backends for deployment closures: cachix, attic, none'
-        default: 'cachix'
+        description: 'Comma-separated cache push backends for deployment closures: attic, none'
+        default: 'attic'
         required: false
         type: string
       deployment-cache-required-backends:
         description: 'Comma-separated attempted cache push backends that must succeed'
-        default: 'cachix'
+        default: 'attic'
         required: false
         type: string
       deployment-cache-optional-timeout-seconds:
@@ -58,12 +53,6 @@ on:
         required: false
         type: string
     secrets:
-      CACHIX_AUTH_TOKEN:
-        description: 'Cachix auth token'
-        required: false
-      CACHIX_ACTIVATE_TOKEN:
-        description: 'Cachix activate token'
-        required: false
       ATTIC_TOKEN:
         description: 'Attic push token for optional deployment closure mirroring'
         required: false
@@ -151,8 +140,6 @@ jobs:
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with: &setup-nix-no-push
           push-to-cache: false
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
@@ -164,8 +151,6 @@ jobs:
       - name: Generate Shard Matrix
         id: generate-matrix
         env:
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} shard-matrix
@@ -190,7 +175,13 @@ jobs:
     steps:
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
-        with: *setup-nix-no-push
+        with:
+          push-to-cache: false
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
+          nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
+          nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
 
       - uses: actions/checkout@v6.0.2
 
@@ -198,8 +189,6 @@ jobs:
         id: generate-matrix
         shell: bash
         env:
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
         run: |
@@ -230,10 +219,68 @@ jobs:
     steps:
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
-        with: *setup-nix-no-push
+        with:
+          push-to-cache: false
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
+          nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
+          nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
 
       - uses: actions/download-artifact@v8
         if: needs.eval-matrix.result == 'success'
+        continue-on-error: true
+
+      - name: Regenerate CI matrix shards when artifacts are unavailable
+        if: needs.eval-matrix.result == 'success'
+        shell: bash
+        env:
+          EVAL_MATRIX: ${{ needs.shard-matrix.outputs.eval_matrix }}
+          MCL_FLAKE_CMD: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }}
+          EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
+          SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
+        run: |
+          set -euo pipefail
+
+          run_python() {
+            if command -v python3 >/dev/null 2>&1; then
+              python3 "$@"
+            else
+              nix shell nixpkgs#python3 --command python3 "$@"
+            fi
+          }
+
+          expected="$(
+            printf '%s' "$EVAL_MATRIX" |
+              run_python -c 'import json, sys; print(len(json.load(sys.stdin).get("include", [])))'
+          )"
+          actual="$(find . -mindepth 2 -maxdepth 2 -type f -name matrix-pre.json | wc -l)"
+          actual="${actual//[[:space:]]/}"
+
+          if [[ "$actual" == "$expected" ]]; then
+            echo "Found all $actual CI matrix shard artifact(s)."
+            exit 0
+          fi
+
+          echo "::warning title=Regenerating CI matrix shards::found $actual of $expected shard artifacts; regenerating locally"
+          read -r -a mcl_cmd <<< "$MCL_FLAKE_CMD"
+
+          while IFS=$'\t' read -r filename flake_attr_path; do
+            [[ -n "$filename" && -n "$flake_attr_path" ]] || continue
+
+            artifact_dir="${filename%.json}"
+            rm -rf -- "$artifact_dir" matrix-pre.json
+
+            "${mcl_cmd[@]}" -- ci-matrix \
+              --flake-attribute-path "$flake_attr_path" \
+              --is-initial
+
+            mkdir -p "$artifact_dir"
+            mv matrix-pre.json "$artifact_dir/matrix-pre.json"
+          done < <(
+            printf '%s' "$EVAL_MATRIX" |
+              run_python -c 'import json, sys; [print("{}\t{}".format(shard.get("filename", ""), shard.get("flakeAttrPath", ""))) for shard in json.load(sys.stdin).get("include", [])]'
+          )
 
       - name: Merge matrices
         if: needs.eval-matrix.result == 'success'
@@ -243,8 +290,6 @@ jobs:
       - name: Generate CI matrix comment
         env:
           IS_INITIAL: 'true'
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           PRECALC_MATRIX: ${{ steps.merge.outputs.full_matrix }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} print-table
@@ -295,9 +340,7 @@ jobs:
         if: ${{ !matrix.noop }}
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
-          push-to-cache: true
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          push-to-cache: false
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
@@ -311,14 +354,14 @@ jobs:
             '.#${{ matrix.attrPath }}'
 
       # Cache push runs only when the caller requests deployment cache
-      # publication, or when it requests legacy Cachix Deploy activation.
+      # publication.
       # On PR check runs the build itself already validates that the closure
       # is buildable; redoing the push + per-path substitute probe on every
       # matrix job would multiply runtime by 10x — a single NixOS system
       # closure has thousands of paths and the probe's nix-copy fallback
       # has timed out 6h+ jobs in the past (infra#965 first attempt).
       - name: Push deployment closure caches ${{ matrix.name }}
-        if: ${{ (inputs.push-deployment-caches || inputs.run-cachix-deploy) && !matrix.noop && matrix.deploymentTarget }}
+        if: ${{ inputs.push-deployment-caches && !matrix.noop && matrix.deploymentTarget }}
         shell: bash
         env:
           DEPLOY_TARGET: ${{ matrix.name }}
@@ -328,8 +371,6 @@ jobs:
           DEPLOYMENT_CACHE_PUSH_BACKENDS: ${{ inputs.deployment-cache-push-backends }}
           DEPLOYMENT_CACHE_REQUIRED_BACKENDS: ${{ inputs.deployment-cache-required-backends }}
           DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS: ${{ inputs.deployment-cache-optional-timeout-seconds }}
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           ATTIC_CACHE: ${{ vars.ATTIC_CACHE }}
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
           ATTIC_ENDPOINT: ${{ vars.ATTIC_ENDPOINT }}
@@ -471,13 +512,6 @@ jobs:
             fi
 
             case "$backend" in
-              cachix)
-                if ! require_backend_vars "$backend" "$required" CACHIX_CACHE CACHIX_AUTH_TOKEN; then
-                  continue
-                fi
-                cache="$CACHIX_CACHE"
-                substituter="https://${CACHIX_CACHE}.cachix.org"
-                ;;
               attic)
                 if ! require_backend_vars "$backend" "$required" ATTIC_TOKEN ATTIC_CACHE ATTIC_SUBSTITUTER ATTIC_TRUSTED_PUBLIC_KEY; then
                   continue
@@ -492,9 +526,10 @@ jobs:
                   continue
                 fi
 
-                attic_endpoint="$ATTIC_ENDPOINT"
+                attic_endpoint="${ATTIC_ENDPOINT:-}"
                 if [[ -z "$attic_endpoint" ]]; then
-                  attic_endpoint="${ATTIC_SUBSTITUTER%/$ATTIC_CACHE}"
+                  attic_cache_suffix="/$ATTIC_CACHE"
+                  attic_endpoint="${ATTIC_SUBSTITUTER%"$attic_cache_suffix"}"
                 fi
                 attic_endpoint="${attic_endpoint%/}/"
                 if ! run_backend_command "$backend" "$required" "attic login" \
@@ -555,7 +590,7 @@ jobs:
               --target "$DEPLOY_TARGET" \
               --system "$DEPLOY_SYSTEM" \
               --kind "$DEPLOY_KIND" \
-              --transport cachix-agent \
+              --transport attic-ci \
               --event-log .result/deployment-cache-push-events.jsonl \
               "${substituter_args[@]}" \
               "${trusted_args[@]}" \
@@ -566,7 +601,8 @@ jobs:
           done
 
       - uses: actions/upload-artifact@v7
-        if: ${{ always() && (inputs.push-deployment-caches || inputs.run-cachix-deploy) && !matrix.noop && matrix.deploymentTarget }}
+        if: ${{ always() && inputs.push-deployment-caches && !matrix.noop && matrix.deploymentTarget }}
+        continue-on-error: true
         with:
           name: deployment-cache-push-${{ github.run_id }}-${{ strategy.job-index }}
           path: .result/deployment-cache-push-events.jsonl
@@ -584,13 +620,18 @@ jobs:
     steps:
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
-        with: *setup-nix-no-push
+        with:
+          push-to-cache: false
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
+          nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
+          nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
 
       - name: Print CI Matrix
         env:
           IS_INITIAL: 'false'
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           PRECALC_MATRIX: ${{
             needs.merge-matrices.result == 'success' &&
             needs.merge-matrices.outputs.full_matrix ||
@@ -615,55 +656,3 @@ jobs:
             contains(needs.*.result, 'failure') ||
             contains(needs.*.result, 'cancelled')
           )
-
-      - uses: actions/checkout@v6.0.2
-        if: inputs.run-cachix-deploy
-
-      - name: Deploy
-        if: inputs.run-cachix-deploy
-        env:
-          CACHIX_CACHE: ${{ vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE || '' }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          CACHIX_ACTIVATE_TOKEN: '${{ secrets.CACHIX_ACTIVATE_TOKEN }}'
-          SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
-          MCL_DEPLOY_EVENT_LOG: .result/deployment-events.jsonl
-          PRECALC_MATRIX: ${{
-            needs.merge-matrices.result == 'success' &&
-            needs.merge-matrices.outputs.full_matrix ||
-            needs.shard-matrix.outputs.full_matrix
-            }}
-        run: |
-          mkdir -p .result
-          ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} deploy-spec
-
-      - name: Generate Deployment Summary
-        if: always() && inputs.run-cachix-deploy
-        run: |
-          if [[ -f .result/deployment-events.jsonl ]]; then
-            # `--` separates `nix run` flags from mcl's flags. Without it,
-            # `nix run` greedily parses `--output` as one of its own and
-            # exits with "unrecognised flag '--output'".
-            ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} -- deploy-status summarize \
-              .result/deployment-events.jsonl \
-              --output .result/deployment-summary.md \
-              --json-output .result/deployment-summary.json
-            cat .result/deployment-summary.md >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo '# Deployment Summary'
-              echo
-              echo 'No deployment events were written.'
-            } | tee .result/deployment-summary.md >> "$GITHUB_STEP_SUMMARY"
-            printf '{"finalState":"unknown","targetCount":0,"failureCount":0,"targets":[]}\n' \
-              > .result/deployment-summary.json
-          fi
-
-      - uses: actions/upload-artifact@v7
-        if: always() && inputs.run-cachix-deploy
-        with:
-          name: deployment-events-${{ github.run_id }}
-          path: |
-            .result/deployment-events.jsonl
-            .result/deployment-summary.md
-            .result/deployment-summary.json
-          if-no-files-found: warn

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -14,9 +14,6 @@ on:
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
-      CACHIX_AUTH_TOKEN:
-        description: 'Cachix auth token'
-        required: false
       NIX_GITLAB_TOKEN:
         description: GitLab token to add as access-token in nix.conf
         required: false
@@ -34,8 +31,6 @@ jobs:
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
           nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
           nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 

--- a/.github/workflows/reusable-nix-diff.yml
+++ b/.github/workflows/reusable-nix-diff.yml
@@ -19,9 +19,6 @@ on:
         required: false
         type: string
     secrets:
-      CACHIX_AUTH_TOKEN:
-        description: 'Cachix auth token'
-        required: false
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
         required: false
@@ -47,8 +44,6 @@ jobs:
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
           push-to-cache: false
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}

--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -116,9 +116,6 @@ on:
       NIX_GITHUB_TOKEN:
         description: 'GitHub token for Nix flake fetches'
         required: false
-      CACHIX_AUTH_TOKEN:
-        description: 'Cachix auth token for binary cache'
-        required: false
 
 permissions:
   contents: read
@@ -143,8 +140,6 @@ jobs:
         with:
           push-to-cache: false
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 
@@ -289,8 +284,6 @@ jobs:
         with:
           push-to-cache: false
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 
@@ -634,8 +627,6 @@ jobs:
         with:
           push-to-cache: false
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 
@@ -783,8 +774,6 @@ jobs:
         with:
           push-to-cache: false
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 

--- a/.github/workflows/reusable-update-flake-lock.yml
+++ b/.github/workflows/reusable-update-flake-lock.yml
@@ -27,9 +27,6 @@ on:
       NIX_GITLAB_TOKEN:
         description: GitLab token to add as access-token in nix.conf
         required: false
-      CACHIX_AUTH_TOKEN:
-        description: 'Cachix auth token'
-        required: false
       CREATE_PR_APP_ID:
         description: ID of the GitHub App used for opening pull requests.
         required: true
@@ -65,8 +62,6 @@ jobs:
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
           nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
           nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 

--- a/.github/workflows/reusable-update-flake-packages.yml
+++ b/.github/workflows/reusable-update-flake-packages.yml
@@ -17,9 +17,6 @@ on:
       NIX_GITLAB_TOKEN:
         description: GitLab token to add as access-token in nix.conf
         required: false
-      CACHIX_AUTH_TOKEN:
-        description: 'Cachix auth token'
-        required: false
       CREATE_PR_APP_ID:
         description: ID of the GitHub App used for opening pull requests.
         required: true
@@ -48,8 +45,6 @@ jobs:
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
           nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
           nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -13,7 +13,6 @@ jobs:
     uses: ./.github/workflows/reusable-update-flake-lock.yml
     secrets:
       NIX_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       CREATE_PR_APP_ID: ${{ secrets.CREATE_PR_APP_ID }}
       CREATE_PR_APP_PRIVATE_KEY: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
       GIT_GPG_SIGNING_SECRET_KEY: ${{ secrets.GIT_GPG_SIGNING_SECRET_KEY }}


### PR DESCRIPTION
Migrates the default dev branch reusable workflows from Cachix to Attic, matching the already-merged main-branch migration. Removes Cachix auth/cache inputs and the Cachix deploy path while keeping Attic deployment-cache push support.