### PR TITLE
Remove external Cachix substituter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,9 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.metacraft-labs.com/metacraft-public"
-      "https://dlang-community.cachix.org"
     ];
     extra-trusted-public-keys = [
       "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
-      "dlang-community.cachix.org-1:eAX1RqX4PjTDPCAp/TvcZP+DYBco2nJBackkAJ2BsDQ="
     ];
   };
 


### PR DESCRIPTION
Removes the remaining Cachix substituter/key from nixConfig on the default dev branch, leaving the Metacraft Attic cache as the configured non-NixOS substituter. Transitive github:cachix/* Nix tooling inputs are unchanged.