### PR TITLE
Refresh Cachix documentation examples for Attic

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ jobs:
   ci:
     uses: metacraft-labs/nixos-modules/.github/workflows/reusable-flake-checks-ci-matrix.yml@main
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      CACHIX_ACTIVATE_TOKEN: ${{ secrets.CACHIX_ACTIVATE_TOKEN }}
+      ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
     with:
       runners: | # json
         {
@@ -55,7 +54,6 @@ jobs:
     uses: metacraft-labs/nixos-modules/.github/workflows/reusable-lint.yml@main
     secrets:
       NIX_GITHUB_TOKEN: ${{ secrets.NIX_GITHUB_TOKEN }}
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 ```
 
 #### [`reusable-update-flake-lock.yml`](.github/workflows/reusable-update-flake-lock.yml)
@@ -67,7 +65,6 @@ jobs:
   update-flake-lock:
     uses: metacraft-labs/nixos-modules/.github/workflows/reusable-update-flake-lock.yml@main
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       CREATE_PR_APP_ID: ${{ secrets.APP_ID }}
       CREATE_PR_APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       NIX_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +83,6 @@ jobs:
   update-packages:
     uses: metacraft-labs/nixos-modules/.github/workflows/reusable-update-flake-packages.yml@main
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       CREATE_PR_APP_ID: ${{ secrets.APP_ID }}
       CREATE_PR_APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 ```

--- a/docs/virtualisation/vm-images.md
+++ b/docs/virtualisation/vm-images.md
@@ -300,7 +300,9 @@ jobs:
   build-vm:
     runs-on: ubuntu-latest
     steps:
-      - uses: cachix/install-nix-action@v24
+      - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          determinate: false
 
       - name: Build VM image
         run: |
@@ -321,8 +323,8 @@ VM images are large but reproducible. Use binary caches:
 # In flake.nix
 {
   nixConfig = {
-    extra-substituters = [ "https://your-cache.cachix.org" ];
-    extra-trusted-public-keys = [ "your-cache.cachix.org-1:..." ];
+    extra-substituters = [ "https://cache.metacraft-labs.com/your-cache" ];
+    extra-trusted-public-keys = [ "your-cache:..." ];
   };
 }
 ```


### PR DESCRIPTION
Removes remaining Cachix setup examples from README and VM image docs. The reusable workflow examples now show Attic where cache-push credentials are needed, and VM docs use the Determinate installer plus Attic-style cache URLs.