### PR TITLE
Restore third-party dlang Cachix cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,11 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.metacraft-labs.com/metacraft-public"
+      "https://dlang-community.cachix.org"
     ];
     extra-trusted-public-keys = [
       "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
+      "dlang-community.cachix.org-1:eAX1RqX4PjTDPCAp/TvcZP+DYBco2nJBackkAJ2BsDQ="
     ];
   };
 


### PR DESCRIPTION
Restores the dlang-community.cachix.org third-party substituter and public key. This keeps the migration focused on our own Cachix accounts/caches while preserving useful upstream binary caches.