### PR TITLE
[codex] enable pipe operators for nix-diff action

### DIFF
--- a/.github/workflows/reusable-nix-diff.yml
+++ b/.github/workflows/reusable-nix-diff.yml
@@ -142,6 +142,9 @@ jobs:
         id: nix-diff-full
         continue-on-error: true
         uses: natsukium/nix-diff-action@v1.1.0
+        env:
+          NIX_CONFIG: |
+            experimental-features = nix-command flakes pipe-operators
         with:
           mode: full
           comment-strategy: update
@@ -153,6 +156,9 @@ jobs:
         if: steps.nix-diff-full.outcome == 'failure'
         continue-on-error: true
         uses: natsukium/nix-diff-action@v1.1.0
+        env:
+          NIX_CONFIG: |
+            experimental-features = nix-command flakes pipe-operators
         with:
           mode: diff-only
           build: false


### PR DESCRIPTION
## Summary
- set `NIX_CONFIG` for both `natsukium/nix-diff-action` invocations in the reusable nix-diff workflow
- enable `nix-command`, `flakes`, and `pipe-operators` for the action's internal `nix path-info` calls

## Why
Infra PRs can fail `nix-diff` while evaluating base `live` systems that use the `|>` operator, because the third-party action does not pass `--accept-flake-config` or extra Nix feature flags to its internal Nix commands.

## Validation
- `git diff --check -- .github/workflows/reusable-nix-diff.yml`
- pre-commit hooks during commit: editorconfig-checker, end-of-file-fixer, prettier
