### PR TITLE
[codex] enable pipe operators in setup-nix

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -181,7 +181,7 @@ runs:
           connect-timeout = 5
           narinfo-cache-negative-ttl = 120
           allow-import-from-derivation = true
-          experimental-features = nix-command flakes
+          experimental-features = nix-command flakes pipe-operators
 
           substituters = https://cache.nixos.org ${{inputs.substituters}}
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{inputs.trusted-public-keys}}
@@ -251,7 +251,7 @@ runs:
       shell: bash
       run: |
         echo "::group::Building Nix DevShell"
-        nix --extra-experimental-features "nix-command flakes" \
+        nix --extra-experimental-features "nix-command flakes pipe-operators" \
           print-dev-env "${{ steps.determine-devshell.outputs.flake-ref }}" >/dev/null
         echo "::endgroup::"
 


### PR DESCRIPTION
## Summary
- include `pipe-operators` in the Nix features written by `.github/setup-nix`
- include `pipe-operators` in the action's explicit `nix print-dev-env` check

## Why
Infra CI evaluates flakes that use the Nix `|>` operator. The setup action previously installed `experimental-features = nix-command flakes`, so later tools such as `nix-eval-jobs` still failed when evaluating those flakes.

## Validation
- `git diff --check -- .github/setup-nix/action.yml`
- pre-commit hooks during commit: editorconfig-checker, end-of-file-fixer, prettier
