### PR TITLE
fix(mcl): tolerate cache probe transport failures

### DIFF
--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -1268,7 +1268,7 @@ bool isCached(in Package pkg, string binaryCacheHttpEndpoint, in string[string] 
 {
     import std.algorithm : canFind;
     import std.string : lineSplitter;
-    import std.net.curl : HTTP, httpGet = get, HTTPStatusException;
+    import std.net.curl : CurlException, HTTP, httpGet = get, HTTPStatusException;
     import core.time : dur;
 
     auto http = HTTP();
@@ -1304,6 +1304,10 @@ bool isCached(in Package pkg, string binaryCacheHttpEndpoint, in string[string] 
         else
             throw e;
     }
+    catch (CurlException)
+    {
+        return false;
+    }
 }
 
 @("isCached")
@@ -1325,6 +1329,11 @@ unittest
     testPackage.output ~= "non-existant";
     assert(!testPackage.isCached(
         binaryCacheHttpEndpoint: nixosCacheEndpoint,
+        httpHeaders: string[string].init,
+    ));
+
+    assert(!testPackage.isCached(
+        binaryCacheHttpEndpoint: "http://127.0.0.1:1",
         httpHeaders: string[string].init,
     ));
 }


### PR DESCRIPTION
## Summary
- treat non-HTTP libcurl transport failures during ci-matrix narinfo probes as cache misses
- add coverage for a refused localhost cache endpoint

## Verification
- nix develop --accept-flake-config . --command dub --root ./packages/mcl/ test -- -i "isCached" -e coda
- nix develop --accept-flake-config .#pre-commit --command prek run --files packages/mcl/src/mcl/commands/ci_matrix.d --show-diff-on-failure --color always
- nix build --accept-flake-config .#checks.x86_64-linux.mcl