### PR TITLE
Fix Terraform drift backend resolution

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -311,7 +311,7 @@ jobs:
           fi
 
           nix develop --accept-flake-config --command bash -euo pipefail -c \
-            'age -d -i "$1" "$2" > "$3"' \
+            "age -d -i \"\$1\" \"\$2\" > \"\$3\"" \
             bash "$RUNNER_TEMP/ci-key" "$AGENIX_SECRET_PATH" "$token_file" >/dev/null
 
           TOKEN="$(<"$token_file")"
@@ -695,7 +695,7 @@ jobs:
           fi
 
           nix develop --accept-flake-config --command bash -euo pipefail -c \
-            'age -d -i "$1" "$2" > "$3"' \
+            "age -d -i \"\$1\" \"\$2\" > \"\$3\"" \
             bash "$RUNNER_TEMP/ci-key" "$AGENIX_SECRET_PATH" "$token_file" >/dev/null
 
           TOKEN="$(<"$token_file")"
@@ -832,6 +832,7 @@ jobs:
     if: >-
       inputs.mode == 'drift'
       && (inputs.credentials_env_name != '' || inputs.agenix_plan_secret_path != '' || inputs.aws_plan_role_arn != '' || inputs.aws_drift_role_arn != '')
+    needs: offline-checks
     runs-on: ${{ fromJSON(inputs.runner) }}
     steps:
       - name: Checkout
@@ -869,7 +870,7 @@ jobs:
           fi
 
           nix develop --accept-flake-config --command bash -euo pipefail -c \
-            'age -d -i "$1" "$2" > "$3"' \
+            "age -d -i \"\$1\" \"\$2\" > \"\$3\"" \
             bash "$RUNNER_TEMP/ci-key" "$AGENIX_SECRET_PATH" "$token_file" >/dev/null
 
           TOKEN="$(<"$token_file")"
@@ -899,18 +900,40 @@ jobs:
           role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
 
       - name: Init
+        env:
+          BACKEND_CONFIG_FILE: ${{ inputs.backend_config_file }}
+          WORKING_DIRECTORY: ${{ inputs.working_directory }}
         run: |
-          cd ${{ inputs.working_directory }}
+          set -euo pipefail
+
+          backend_config_files="${BACKEND_CONFIG_FILE:-}"
+
+          cd "$WORKING_DIRECTORY"
+
+          backend_args=()
+          while IFS= read -r backend_config_file; do
+            [ -n "$backend_config_file" ] || continue
+            if [[ "$backend_config_file" = /* ]]; then
+              backend_path="$backend_config_file"
+            else
+              backend_path="$GITHUB_WORKSPACE/$backend_config_file"
+            fi
+            if [ ! -f "$backend_path" ]; then
+              echo "::error::Backend config file does not exist: $backend_path"
+              exit 1
+            fi
+            backend_args+=("-backend-config=$(realpath --relative-to="$PWD" "$backend_path")")
+          done < <(printf '%s\n' "$backend_config_files" | tr ',' '\n')
+
           tofu_bin="$(nix develop --accept-flake-config --command bash -euo pipefail -c 'command -v tofu' | tail -n 1)"
-          env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" init \
-            ${{ inputs.backend_config_file != '' && format('-backend-config=../{0}', inputs.backend_config_file) || '' }}
+          env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" init -input=false "${backend_args[@]}"
 
       - name: Detect drift
         id: drift
         run: |
           cd ${{ inputs.working_directory }}
           tofu_bin="$(nix develop --accept-flake-config --command bash -euo pipefail -c 'command -v tofu' | tail -n 1)"
-          env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" plan -detailed-exitcode 2>&1 | tee /tmp/drift-plan.txt || {
+          env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" plan -input=false -no-color -detailed-exitcode 2>&1 | tee /tmp/drift-plan.txt || {
             exit_code=$?
             if [ "$exit_code" -eq 2 ]; then
               echo "drift_detected=true" >> "$GITHUB_OUTPUT"

--- a/docs/Terraform-Shared-Infrastructure.status.org
+++ b/docs/Terraform-Shared-Infrastructure.status.org
@@ -2,8 +2,8 @@
 
 * Document
   :PROPERTIES:
-  :next_steps: Verify M1/M2 deliverables in consuming repos; begin integration testing
-  :last_updated: 2026-03-13
+  :next_steps: Roll out reusable drift backend fix to consuming repos; verify scheduled drift in Agent Harbor, Metacraft, and Blocksense
+  :last_updated: 2026-06-23
   :current_milestone: M2 (done)
   :END:
 
@@ -21,6 +21,12 @@
   Rather than duplicating CI workflows, policy scripts, and dev shell additions
   in each repo, the shared infrastructure lives here in nixos-modules and is
   consumed by downstream repos.
+
+  2026-06-23 integration note: Agent Harbor now consumes the reusable workflow
+  for AWS and Cloudflare Terraform roots backed by AWS S3 state. Its PR plan
+  and merge-to-live apply path have been proven in CI. Scheduled drift checks
+  still need a production run after the reusable drift job resolves backend
+  config files the same way as plan/apply jobs.
 
   Consuming repos and their dependencies on this status doc's milestones:
   - [[https://github.com/nickolay-kondratyev/blocksense-infra][blocksense/infra]] — Cloudflare resource management ([[https://github.com/nickolay-kondratyev/blocksense-infra/blob/main/docs/Cloudflare-Agent-Harbor.status.org][status]])
@@ -348,7 +354,7 @@
 
     - test_name: verify_drift_detection_schedule
       description: Scheduled drift detection job runs on main, detects intentional drift, and alerts
-      status: pending
+      status: pending after 2026-06-23 backend resolver fix lands in a consuming repo
 
     - test_name: verify_terranix_mode
       description: When Terranix flag is set, terranix runs before tofu init to generate .tf.json files


### PR DESCRIPTION
## Summary

- Fix reusable Terraform drift checks to resolve `backend_config_file` relative to the repository root, matching the plan/apply jobs.
- Make drift checks depend on `offline-checks`, so scheduled drift does not bypass Terranix/validate/tests.
- Update the shared Terraform status doc with the Agent Harbor integration state and the remaining drift verification step.
- Clean up the nested agenix decrypt command quoting so `actionlint` passes with ShellCheck enabled.

## Validation

- `actionlint .github/workflows/reusable-terraform-ci.yml`
- `git diff --check`

## Notes

This is a shared workflow hardening change. It should not create or modify any cloud resources by itself; consuming repos pick it up through `metacraft-labs/nixos-modules/.github/workflows/reusable-terraform-ci.yml@main` after merge.
