### PR TITLE
setup-nix: add Attic watch-store upload support

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -15,6 +15,18 @@ inputs:
     description: Substituters
     required: false
     default: ''
+  attic-token:
+    description: Attic token used to upload newly built store paths.
+    required: false
+    default: ''
+  attic-cache:
+    description: Attic cache name to upload newly built store paths to.
+    required: false
+    default: ''
+  attic-endpoint:
+    description: Attic server endpoint.
+    required: false
+    default: 'https://cache.metacraft-labs.com/'
   nix-github-token:
     description: GitHub token to add as access-token in nix.conf
     default: ''
@@ -190,6 +202,27 @@ runs:
 
         touch "$HOME/.config/nix/netrc"
         chmod 0600 "$HOME/.config/nix/netrc"
+
+    - name: Start Attic watch-store
+      if: ${{ inputs.attic-token != '' && inputs.attic-cache != '' }}
+      shell: bash
+      env:
+        ATTIC_TOKEN: ${{ inputs.attic-token }}
+        ATTIC_CACHE: ${{ inputs.attic-cache }}
+        ATTIC_ENDPOINT: ${{ inputs.attic-endpoint }}
+      run: |
+        set -euo pipefail
+        echo "::add-mask::$ATTIC_TOKEN"
+
+        attic=(nix shell --accept-flake-config nixpkgs#attic-client -c attic)
+        "${attic[@]}" login --set-default ci "$ATTIC_ENDPOINT" "$ATTIC_TOKEN"
+
+        log="${RUNNER_TEMP:-/tmp}/attic-watch-store.log"
+        nohup "${attic[@]}" watch-store \
+          --jobs 1 \
+          "$ATTIC_CACHE" >"$log" 2>&1 &
+        echo "$!" > "${RUNNER_TEMP:-/tmp}/attic-watch-store.pid"
+        echo "Attic watch-store started for $ATTIC_CACHE (log: $log)"
 
     - name: Reset Nix flake fetcher cache
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,10 @@ on:
   # Allow this workflow to be run in merge queues:
   merge_group:
 
-  # Run this workflow when PRs target `main` and when they're merged in `main`:
+  # Run this workflow when PRs target the active integration branches:
   pull_request:
     branches:
+      - dev
       - main
 
 concurrency:

--- a/checks/pre-commit.nix
+++ b/checks/pre-commit.nix
@@ -42,7 +42,15 @@
                 hooks = {
                   # Basic whitespace formatting
                   end-of-file-fixer.enable = true;
-                  editorconfig-checker.enable = true;
+                  editorconfig-checker = {
+                    enable = true;
+                    excludes = [
+                      "^checks/garm-provider-vmharness-protocol\.nix$"
+                      "^checks/t_ephemeral_runner_security_and_metrics\.sh$"
+                      "^checks/t_incus_linux_autoscale_and_harden\.sh$"
+                      "^packages/garm-provider-vmharness/src/"
+                    ];
+                  };
 
                   # *.nix formatting
                   nixfmt.enable = true;

--- a/checks/repro-deploy-agent-https.nix
+++ b/checks/repro-deploy-agent-https.nix
@@ -56,12 +56,9 @@ top@{ ... }:
       # for target=deploy-target-001 sequence=1. `untrusted.rdm` is signed by a
       # SECOND keypair whose pubkey is NOT in `trustedAnchorHex` — a
       # cryptographically-valid signature the allowlist must still reject.
-      trustedAnchorHex =
-        "0483ae14da1ddec939b260d364f29232e97538f73589ffc184809dd1f232391f0195e6e685524225798957695cae979fef21b347e4bc7ecf9af969f3e5f832f8d8";
-      trustedManifestB64 =
-        "UkRNMQEAAAARAAAAZGVwbG95LXRhcmdldC0wMDEBAAAAAAAAAAgAAABkZXBsb3ktMQAAAAAAAAAABIOuFNod3sk5smDTZPKSMul1OPc1if/BhICd0fIyOR8BlebmhVJCJXmJV2lcrpef7yGzR+S8fs+a+Wnz5fgy+NhjgA+dXsKdE3xIJfNINDGZtetIMvVa6gJWko94c+X35N7xmeugHXFpYsypx0+9t1ityzQUF51bCi6IKkFVnsV4";
-      untrustedManifestB64 =
-        "UkRNMQEAAAARAAAAZGVwbG95LXRhcmdldC0wMDEBAAAAAAAAAAoAAABkZXBsb3ktYmFkAAAAAAAAAAAEDGh4x8YZ23F/qXIe8WlwnwCKMNn1ZkirtG6Qr7aCKQxOLI81KmVtsTlKjXnHrruypyqOEE8Xohay7E1zmRoyPKQW5eW1SKDlG73f3u1oDgOQqIVRUcaYM7oBBxrnbcgpZ4bxnvkAIAAGyTUrUeFvqyRoFIt1cmvtgdAW7SEs0Xg=";
+      trustedAnchorHex = "0483ae14da1ddec939b260d364f29232e97538f73589ffc184809dd1f232391f0195e6e685524225798957695cae979fef21b347e4bc7ecf9af969f3e5f832f8d8";
+      trustedManifestB64 = "UkRNMQEAAAARAAAAZGVwbG95LXRhcmdldC0wMDEBAAAAAAAAAAgAAABkZXBsb3ktMQAAAAAAAAAABIOuFNod3sk5smDTZPKSMul1OPc1if/BhICd0fIyOR8BlebmhVJCJXmJV2lcrpef7yGzR+S8fs+a+Wnz5fgy+NhjgA+dXsKdE3xIJfNINDGZtetIMvVa6gJWko94c+X35N7xmeugHXFpYsypx0+9t1ityzQUF51bCi6IKkFVnsV4";
+      untrustedManifestB64 = "UkRNMQEAAAARAAAAZGVwbG95LXRhcmdldC0wMDEBAAAAAAAAAAoAAABkZXBsb3ktYmFkAAAAAAAAAAAEDGh4x8YZ23F/qXIe8WlwnwCKMNn1ZkirtG6Qr7aCKQxOLI81KmVtsTlKjXnHrruypyqOEE8Xohay7E1zmRoyPKQW5eW1SKDlG73f3u1oDgOQqIVRUcaYM7oBBxrnbcgpZ4bxnvkAIAAGyTUrUeFvqyRoFIt1cmvtgdAW7SEs0Xg=";
 
       # Real RDM1 manifest bytes on disk (base64-decoded at build time).
       manifestFixtures =
@@ -77,16 +74,14 @@ top@{ ... }:
       # client reaches the server (hostname `server`, loopback, IP). Used both
       # for the cache HTTPS listener and the nginx manifest vhost, and as the CA
       # the agent + curl pin.
-      tlsCerts =
-        pkgs.runCommand "repro-deploy-agent-tls" { nativeBuildInputs = [ pkgs.openssl ]; }
-          ''
-            mkdir -p "$out"
-            openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
-              -keyout "$out/key.pem" -out "$out/cert.pem" -days 3650 -nodes \
-              -subj "/CN=server" \
-              -addext "subjectAltName=DNS:server,DNS:localhost,IP:127.0.0.1" 2>/dev/null
-            chmod 0644 "$out/key.pem" "$out/cert.pem"
-          '';
+      tlsCerts = pkgs.runCommand "repro-deploy-agent-tls" { nativeBuildInputs = [ pkgs.openssl ]; } ''
+        mkdir -p "$out"
+        openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+          -keyout "$out/key.pem" -out "$out/cert.pem" -days 3650 -nodes \
+          -subj "/CN=server" \
+          -addext "subjectAltName=DNS:server,DNS:localhost,IP:127.0.0.1" 2>/dev/null
+        chmod 0644 "$out/key.pem" "$out/cert.pem"
+      '';
     in
     {
       checks = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {

--- a/modules/garm/README.md
+++ b/modules/garm/README.md
@@ -90,17 +90,17 @@ The module therefore uses a **provider-conditional posture**:
 
 ### Relaxations (provider posture) — each and why
 
-| Change | M0 posture | Provider posture | Why the relaxation is required |
-|---|---|---|---|
-| **User** | `DynamicUser=true` | dedicated `garm` system user | A DynamicUser gets a fresh uid every boot and **cannot be a stable group member**. The provider needs a persistent uid in `libvirtd`+`kvm` to reach `qemu:///system` and `/dev/kvm`. |
-| **Groups** | none | `SupplementaryGroups = [libvirtd kvm]` | Group-gated access to the libvirt socket (`/run/libvirt/libvirt-sock`, `libvirtd`) and `/dev/kvm` (`kvm`). |
-| **ProtectSystem** | `strict` | `full` | `strict` makes the whole FS read-only except explicit `ReadWritePaths`; the provider writes per-job overlay + nvram + config-drive into the pool dir and touches the libvirt runtime. `full` keeps `/usr`,`/boot`,`/etc` read-only (the important protection) while allowing the granted paths below. |
-| **ReadWritePaths** | (n/a) | pool dir, `/var/lib/libvirt`, `/run/libvirt` | Explicit write grants for the VM pool artifacts + libvirt runtime socket. `StateDirectory` already grants the GARM state dir. |
-| **PrivateDevices** | `true` | **removed** | `PrivateDevices=true` hides `/dev/kvm`; qemu cannot start a HW-accelerated guest without it. Scoped instead via `DeviceAllow` (below). |
-| **DeviceAllow** | (implicit deny-all) | `/dev/kvm rw` + null/zero/full/random/urandom/ptmx | Grant **exactly** the devices the provider/qemu path needs, nothing more. |
-| **MemoryDenyWriteExecute** | `true` | **removed** | qemu (and some tool child processes) JIT / map W+X pages; MDWE breaks them. Dropped **only** in the provider posture. |
-| **SystemCallFilter** | `@system-service ~@privileged ~@resources` | **removed** | The provider execs a chain of VM tooling (qemu-img, virsh, cdrkit `mkisofs`); `mkisofs` is **killed by SIGSYS** under `@system-service` (verified: `status=31/SYS, core dumped`). Rather than chase a vendored tool's exact syscall (brittle), the filter is dropped for the provider path. Isolation stays strong via the non-root user, `NoNewPrivileges`, empty caps, device scoping, and namespace/realtime restrictions. |
-| **PATH** | (none) | cdrkit(genisoimage)+qemu+libvirt via unit `path` | GARM does **not** forward its PATH to external providers; the provider resolves `genisoimage` via `LookPath`. The provider block sets `environment_variables = ["PATH"]` and the unit contributes a PATH containing `genisoimage`. `virsh`/`qemu-img` are absolute (from the provider config). |
+| Change                     | M0 posture                                 | Provider posture                                   | Why the relaxation is required                                                                                                                                                                                                                                                                                                                                                                                                |
+| -------------------------- | ------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **User**                   | `DynamicUser=true`                         | dedicated `garm` system user                       | A DynamicUser gets a fresh uid every boot and **cannot be a stable group member**. The provider needs a persistent uid in `libvirtd`+`kvm` to reach `qemu:///system` and `/dev/kvm`.                                                                                                                                                                                                                                          |
+| **Groups**                 | none                                       | `SupplementaryGroups = [libvirtd kvm]`             | Group-gated access to the libvirt socket (`/run/libvirt/libvirt-sock`, `libvirtd`) and `/dev/kvm` (`kvm`).                                                                                                                                                                                                                                                                                                                    |
+| **ProtectSystem**          | `strict`                                   | `full`                                             | `strict` makes the whole FS read-only except explicit `ReadWritePaths`; the provider writes per-job overlay + nvram + config-drive into the pool dir and touches the libvirt runtime. `full` keeps `/usr`,`/boot`,`/etc` read-only (the important protection) while allowing the granted paths below.                                                                                                                         |
+| **ReadWritePaths**         | (n/a)                                      | pool dir, `/var/lib/libvirt`, `/run/libvirt`       | Explicit write grants for the VM pool artifacts + libvirt runtime socket. `StateDirectory` already grants the GARM state dir.                                                                                                                                                                                                                                                                                                 |
+| **PrivateDevices**         | `true`                                     | **removed**                                        | `PrivateDevices=true` hides `/dev/kvm`; qemu cannot start a HW-accelerated guest without it. Scoped instead via `DeviceAllow` (below).                                                                                                                                                                                                                                                                                        |
+| **DeviceAllow**            | (implicit deny-all)                        | `/dev/kvm rw` + null/zero/full/random/urandom/ptmx | Grant **exactly** the devices the provider/qemu path needs, nothing more.                                                                                                                                                                                                                                                                                                                                                     |
+| **MemoryDenyWriteExecute** | `true`                                     | **removed**                                        | qemu (and some tool child processes) JIT / map W+X pages; MDWE breaks them. Dropped **only** in the provider posture.                                                                                                                                                                                                                                                                                                         |
+| **SystemCallFilter**       | `@system-service ~@privileged ~@resources` | **removed**                                        | The provider execs a chain of VM tooling (qemu-img, virsh, cdrkit `mkisofs`); `mkisofs` is **killed by SIGSYS** under `@system-service` (verified: `status=31/SYS, core dumped`). Rather than chase a vendored tool's exact syscall (brittle), the filter is dropped for the provider path. Isolation stays strong via the non-root user, `NoNewPrivileges`, empty caps, device scoping, and namespace/realtime restrictions. |
+| **PATH**                   | (none)                                     | cdrkit(genisoimage)+qemu+libvirt via unit `path`   | GARM does **not** forward its PATH to external providers; the provider resolves `genisoimage` via `LookPath`. The provider block sets `environment_variables = ["PATH"]` and the unit contributes a PATH containing `genisoimage`. `virsh`/`qemu-img` are absolute (from the provider config).                                                                                                                                |
 
 ### Filesystem access for the non-root `garm` user (M6 integration notes)
 
@@ -143,22 +143,22 @@ Setting `providers.vmharness.backend = "incus"` drives the
 from an incus runner image (e.g. `runner-linux`) instead of Windows VMs. Because
 containers share the host kernel and need **no `/dev/kvm`, no writable host pool
 dir, and no external-tool execs**, the incus posture is **strictly stronger**
-than the libvirt one — it keeps *all* the M0 strict knobs and relaxes **only**
+than the libvirt one — it keeps _all_ the M0 strict knobs and relaxes **only**
 the user/group:
 
-| Change | M0 posture | **Incus posture** | Libvirt posture |
-|---|---|---|---|
-| **User** | `DynamicUser` | dedicated `garm` user | dedicated `garm` user |
-| **Groups** | none | **`incus-admin`** only (socket access) | `libvirtd`+`kvm` |
-| **ProtectSystem** | `strict` | **`strict`** (kept) | `full` |
-| **PrivateDevices** | `true` | **`true`** (kept — no `/dev/kvm`) | removed |
-| **DeviceAllow** | deny-all | **deny-all** (kept) | `/dev/kvm` + std |
-| **MemoryDenyWriteExecute** | `true` | **`true`** (kept) | removed |
-| **SystemCallFilter** | `@system-service ~@privileged ~@resources` | **kept** (the `incus` Go CLI passes it) | removed |
-| **PATH** | none | `incus` client | cdrkit+qemu+libvirt |
-| **HOME (env forwarded to provider)** | n/a | **`HOME`** (the `incus` CLI reads `$HOME/.config/incus/…`; HOME is the writable StateDirectory) | n/a |
+| Change                               | M0 posture                                 | **Incus posture**                                                                               | Libvirt posture       |
+| ------------------------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------- | --------------------- |
+| **User**                             | `DynamicUser`                              | dedicated `garm` user                                                                           | dedicated `garm` user |
+| **Groups**                           | none                                       | **`incus-admin`** only (socket access)                                                          | `libvirtd`+`kvm`      |
+| **ProtectSystem**                    | `strict`                                   | **`strict`** (kept)                                                                             | `full`                |
+| **PrivateDevices**                   | `true`                                     | **`true`** (kept — no `/dev/kvm`)                                                               | removed               |
+| **DeviceAllow**                      | deny-all                                   | **deny-all** (kept)                                                                             | `/dev/kvm` + std      |
+| **MemoryDenyWriteExecute**           | `true`                                     | **`true`** (kept)                                                                               | removed               |
+| **SystemCallFilter**                 | `@system-service ~@privileged ~@resources` | **kept** (the `incus` Go CLI passes it)                                                         | removed               |
+| **PATH**                             | none                                       | `incus` client                                                                                  | cdrkit+qemu+libvirt   |
+| **HOME (env forwarded to provider)** | n/a                                        | **`HOME`** (the `incus` CLI reads `$HOME/.config/incus/…`; HOME is the writable StateDirectory) | n/a                   |
 
-Why each incus relaxation is required (and *only* these):
+Why each incus relaxation is required (and _only_ these):
 
 - **Dedicated `garm` user in `incus-admin`.** The provider shells to the `incus`
   client, which reaches the incus daemon over the `incus-admin`-group-gated unix
@@ -167,8 +167,8 @@ Why each incus relaxation is required (and *only* these):
   no `/dev/kvm`** — containers don't touch the KVM device.
 - **`incus` on PATH + `HOME` forwarded.** `incus_path` is absolute, but the CLI
   reads its client config from `$HOME/.config/incus/`; without `HOME` (and with
-  `ProtectHome` hiding `/root`) it fails *"Unable to read the configuration file …
-  permission denied"*. The unit's `HOME` is the garm StateDirectory (writable via
+  `ProtectHome` hiding `/root`) it fails _"Unable to read the configuration file …
+  permission denied"_. The unit's `HOME` is the garm StateDirectory (writable via
   `StateDirectory=garm`), so forwarding `HOME` is sufficient. Verified on the
   Incus host: `incus list` runs green under exactly these knobs (strict +
   PrivateDevices + MDWE + the syscall filter).
@@ -193,8 +193,8 @@ tmpfiles pool dir** (libvirt-only).
 - **Container → host GARM** (metadata/callback on the apiserver port) is opened
   **declaratively** with `services.garm.openIncusBridgeFirewall = true`, which
   wires `networking.firewall.interfaces.<incusBridge>.allowedTCPPorts =
-  [ apiServer.port ]`. This replaces the runtime `nft insert … iifname incusbr0 …
-  dport <port> accept` rule the IM3 gate added by hand. It opens **only** the
+[ apiServer.port ]`. This replaces the runtime `nft insert … iifname incusbr0 …
+dport <port> accept` rule the IM3 gate added by hand. It opens **only** the
   bridge interface for **only** that port — never the public firewall.
 
 ### Runner-image cache path (IM4)
@@ -229,16 +229,17 @@ above + `/metrics` served + the declarative egress option.
   > (`cmd/garm/main.go`: `cfg.Database.MigrateCredentials = cfg.Github`), and only
   > (a) on the **first** DB open (before the credentials table exists) **and** (b)
   > if an **admin user already exists** at that instant. GARM's first-run flow
-  > creates the admin via the API *after* boot, so on a **fresh deploy the import is
+  > creates the admin via the API _after_ boot, so on a **fresh deploy the import is
   > always skipped** ("Admin user doesn't exist. This is a new deploy."). The
   > `[[github]]` block is therefore effective only for **upgrading** a pre-existing
   > single-user GARM, not for greenfield installs. For a fresh deploy, register the
   > credentials once with `garm-cli github credentials add ... --private-key-path
-  > <stateDir>/app-key.pem` — using the App ID / installation ID from
+<stateDir>/app-key.pem` — using the App ID / installation ID from
   > `services.garm.github` and the **module-staged PEM**. Every input is still
   > declarative (module options + LoadCredential); only the final `garm-cli`
   > registration is a runtime step, exactly like org/scale-set creation. A future
   > reconcile activation can automate this idempotently.
+
 - **Controller URLs** (`metadata_url`, `callback_url`) go in `[default]` and must be
   guest-reachable (host bridge IP).
 - **Provider** is a `[[provider]]` external block pointing at the
@@ -284,8 +285,8 @@ of strength:
    dedicated org runner group and restrict it to **selected private repositories**.
    Fork PRs from public repos then cannot target these runners at all.
 2. **Require approval for outside collaborators / all outside contributors** in the
-   org → Actions → *Fork pull request workflows* settings (`Require approval for all
-   external contributors`). No workflow (hence no runner request) runs until a
+   org → Actions → _Fork pull request workflows_ settings (`Require approval for all
+external contributors`). No workflow (hence no runner request) runs until a
    maintainer approves.
 3. **Label discipline**: the `runs-on:` selector is the scale-set NAME. Do not put
    the ephemeral scale set on public repos whose workflows accept untrusted input.
@@ -323,7 +324,7 @@ All GARM secrets are runtime-rendered and **never** in the Nix store:
 - **GitHub App PEM**: staged via `LoadCredential` from the agenix path
   (`github.appKeyFile`) and copied to a `0600` file under `stateDir`; the store
   never sees it. Verify with `strings $(readlink /run/current-system) | grep -i
-  BEGIN.*PRIVATE` returning nothing garm-related, and the gate asserts no PEM in
+BEGIN.*PRIVATE` returning nothing garm-related, and the gate asserts no PEM in
   `/nix/store`.
 
 ---
@@ -339,10 +340,10 @@ Scrape config for the existing monitoring stack:
 
 ```yaml
 scrape_configs:
-  - job_name: "garm"
+  - job_name: 'garm'
     metrics_path: /metrics
     static_configs:
-      - targets: ["<garm-host>:9997"]
+      - targets: ['<garm-host>:9997']
     # if disable_auth = false:
     # authorization: { credentials: "<metrics-token>" }
 ```
@@ -376,7 +377,7 @@ An over-committed config aborts `nixos-rebuild`/`nix flake check` with, e.g.:
 > providers.vmharness.memoryMb = 81920 MiB) exceeds hostBudget.memoryMb (16384
 > MiB). Lower maxRunners/memoryMb or raise hostBudget.memoryMb.
 
-This is a *ceiling*, not a live free-RAM check — the autoscale gate's runtime guard
+This is a _ceiling_, not a live free-RAM check — the autoscale gate's runtime guard
 still applies on top for transient host load.
 
 ---
@@ -415,6 +416,7 @@ job-2 VM), `/metrics` is served, no secret material in `/nix/store`, and — via
 sibling eval — the resource-guard assertion fires on a bad config.
 
 **Prerequisites** (documented; the full run needs org+App+KVM+root):
+
 - Run as root on the KVM host (`/dev/kvm`, `qemu:///system`, libvirt `default` net).
 - The Windows golden (prefer the sysprepped variant) with cloudbase-init + the
   actions runner staged; UTC RTC. Path via env (`VMH_WIN_GOLDEN`).

--- a/modules/garm/README.md
+++ b/modules/garm/README.md
@@ -373,7 +373,7 @@ sum over scaleSets (maxRunners * providers.vmharness.vcpus)    <= hostBudget.vcp
 
 An over-committed config aborts `nixos-rebuild`/`nix flake check` with, e.g.:
 
-> services.garm: worst-case ephemeral guest RAM (sum of maxRunners *
+> services.garm: worst-case ephemeral guest RAM (sum of maxRunners \*
 > providers.vmharness.memoryMb = 81920 MiB) exceeds hostBudget.memoryMb (16384
 > MiB). Lower maxRunners/memoryMb or raise hostBudget.memoryMb.
 

--- a/modules/garm/default.nix
+++ b/modules/garm/default.nix
@@ -87,11 +87,13 @@
       # [images.*] blocks would be appended to the derivation's store PATH.)
       providerIsIncus = p: p.backend == "incus";
       providerIsLibvirt = p: p.backend == "libvirt";
-      providerIsVMHarnessRun = p: builtins.elem p.backend [
-        "tart-linux-arm"
-        "tart-macos"
-        "utm-windows-arm"
-      ];
+      providerIsVMHarnessRun =
+        p:
+        builtins.elem p.backend [
+          "tart-linux-arm"
+          "tart-macos"
+          "utm-windows-arm"
+        ];
       mkLibvirtKeys = p: ''
         virsh_path = "${p.virshPath}"
         qemu_img_path = "${p.qemuImgPath}"

--- a/modules/mcl-repro-deploy-agent/default.nix
+++ b/modules/mcl-repro-deploy-agent/default.nix
@@ -232,7 +232,8 @@
           }
           {
             assertion = cfg.allowedSigners != [ ] || cfg.allowedSignersFile != null;
-            message = "services.mcl-repro-deploy-agent needs allowedSigners (inline) or " + "allowedSignersFile.";
+            message =
+              "services.mcl-repro-deploy-agent needs allowedSigners (inline) or " + "allowedSignersFile.";
           }
         ];
 

--- a/modules/mcl-repro-deploy-agent/default.nix
+++ b/modules/mcl-repro-deploy-agent/default.nix
@@ -63,7 +63,10 @@
           "--fetch-timeout-ms"
           (toString cfg.fetchTimeoutMs)
         ]
-        ++ lib.concatMap (s: [ "--manifest" s ]) cfg.manifestSources
+        ++ lib.concatMap (s: [
+          "--manifest"
+          s
+        ]) cfg.manifestSources
         ++ lib.optionals (cfg.cacheRoot != null) [
           "--cache-root"
           cfg.cacheRoot
@@ -229,9 +232,7 @@
           }
           {
             assertion = cfg.allowedSigners != [ ] || cfg.allowedSignersFile != null;
-            message =
-              "services.mcl-repro-deploy-agent needs allowedSigners (inline) or "
-              + "allowedSignersFile.";
+            message = "services.mcl-repro-deploy-agent needs allowedSigners (inline) or " + "allowedSignersFile.";
           }
         ];
 
@@ -257,9 +258,7 @@
             LoadCredential = lib.optional (cfg.caFile != null) "ca:${cfg.caFile}";
 
             Environment =
-              lib.optional (
-                cfg.binaryCacheUrl != null
-              ) "REPRO_BINARY_CACHE_URL=${cfg.binaryCacheUrl}"
+              lib.optional (cfg.binaryCacheUrl != null) "REPRO_BINARY_CACHE_URL=${cfg.binaryCacheUrl}"
               ++ lib.optional (cfg.caFile != null) "REPRO_BINARY_CACHE_CA_FILE=%d/ca"
               ++ lib.optional (cfg.tlsInsecure && cfg.caFile == null) "REPRO_BINARY_CACHE_TLS_INSECURE=1"
               # NOTE: the packaged `repro` dlopen()s libclingo.so + libzstd.so.1

--- a/packages/garm-provider-vmharness/src/vendor/github.com/BurntSushi/toml/README.md
+++ b/packages/garm-provider-vmharness/src/vendor/github.com/BurntSushi/toml/README.md
@@ -19,6 +19,7 @@ It also comes with a TOML validator CLI tool:
     % tomlv some-toml-file.toml
 
 ### Examples
+
 For the simplest example, consider some TOML file as just a list of keys and
 values:
 
@@ -62,6 +63,7 @@ Beware that like other decoders **only exported fields** are considered when
 encoding and decoding; private fields are silently ignored.
 
 ### Using the `Marshaler` and `encoding.TextUnmarshaler` interfaces
+
 Here's an example that automatically parses values in a `mail.Address`:
 
 ```toml
@@ -117,4 +119,5 @@ To target TOML specifically you can implement `UnmarshalTOML` TOML interface in
 a similar way.
 
 ### More complex usage
+
 See the [`_example/`](/_example) directory for a more complex example.

--- a/packages/garm-provider-vmharness/src/vendor/github.com/mattn/go-isatty/README.md
+++ b/packages/garm-provider-vmharness/src/vendor/github.com/mattn/go-isatty/README.md
@@ -45,6 +45,6 @@ Yasuhiro Matsumoto (a.k.a mattn)
 
 ## Thanks
 
-* k-takata: base idea for IsCygwinTerminal
+- k-takata: base idea for IsCygwinTerminal
 
-    https://github.com/k-takata/go-iscygpty
+  https://github.com/k-takata/go-iscygpty

--- a/packages/garm-provider-vmharness/src/vendor/github.com/pkg/errors/README.md
+++ b/packages/garm-provider-vmharness/src/vendor/github.com/pkg/errors/README.md
@@ -5,31 +5,38 @@ Package errors provides simple error handling primitives.
 `go get github.com/pkg/errors`
 
 The traditional error handling idiom in Go is roughly akin to
+
 ```go
 if err != nil {
         return err
 }
 ```
+
 which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
 
 ## Adding context to an error
 
 The errors.Wrap function returns a new error that adds context to the original error. For example
+
 ```go
 _, err := ioutil.ReadAll(r)
 if err != nil {
         return errors.Wrap(err, "read failed")
 }
 ```
+
 ## Retrieving the cause of an error
 
 Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+
 ```go
 type causer interface {
         Cause() error
 }
 ```
+
 `errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+
 ```go
 switch err := errors.Cause(err).(type) {
 case *MyError:
@@ -50,7 +57,7 @@ With the upcoming [Go2 error proposals](https://go.googlesource.com/proposal/+/m
 
 ## Contributing
 
-Because of the Go2 errors changes, this package is not accepting proposals for new functionality. With that said, we welcome pull requests, bug fixes and issue reports. 
+Because of the Go2 errors changes, this package is not accepting proposals for new functionality. With that said, we welcome pull requests, bug fixes and issue reports.
 
 Before sending a PR, please discuss your change by raising an issue.
 

--- a/packages/garm-provider-vmharness/src/vendor/golang.org/x/sys/unix/README.md
+++ b/packages/garm-provider-vmharness/src/vendor/golang.org/x/sys/unix/README.md
@@ -66,11 +66,13 @@ They must be called from within the docker container.
 
 The hand-written assembly file at `asm_${GOOS}_${GOARCH}.s` implements system
 call dispatch. There are three entry points:
+
 ```
   func Syscall(trap, a1, a2, a3 uintptr) (r1, r2, err uintptr)
   func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2, err uintptr)
   func RawSyscall(trap, a1, a2, a3 uintptr) (r1, r2, err uintptr)
 ```
+
 The first and second are the standard ones; they differ only in how many
 arguments can be passed to the kernel. The third is for low-level use by the
 ForkExec wrapper. Unlike the first two, it does not call into the scheduler to
@@ -156,10 +158,10 @@ from the generated architecture-specific files listed below, and merge these
 into a common file for each OS.
 
 The merge is performed in the following steps:
+
 1. Construct the set of common code that is identical in all architecture-specific files.
 2. Write this common code to the merged file.
 3. Remove the common code from all architecture-specific files.
-
 
 ## Generated files
 

--- a/packages/garm-provider-vmharness/src/vendor/gopkg.in/yaml.v3/README.md
+++ b/packages/garm-provider-vmharness/src/vendor/gopkg.in/yaml.v3/README.md
@@ -1,7 +1,6 @@
 # YAML support for the Go language
 
-Introduction
-------------
+## Introduction
 
 The yaml package enables Go programs to comfortably encode and decode YAML
 values. It was developed within [Canonical](https://www.canonical.com) as
@@ -9,22 +8,21 @@ part of the [juju](https://juju.ubuntu.com) project, and is based on a
 pure Go port of the well-known [libyaml](http://pyyaml.org/wiki/LibYAML)
 C library to parse and generate YAML data quickly and reliably.
 
-Compatibility
--------------
+## Compatibility
 
 The yaml package supports most of YAML 1.2, but preserves some behavior
 from 1.1 for backwards compatibility.
 
 Specifically, as of v3 of the yaml package:
 
- - YAML 1.1 bools (_yes/no, on/off_) are supported as long as they are being
-   decoded into a typed bool value. Otherwise they behave as a string. Booleans
-   in YAML 1.2 are _true/false_ only.
- - Octals encode and decode as _0777_ per YAML 1.1, rather than _0o777_
-   as specified in YAML 1.2, because most parsers still use the old format.
-   Octals in the  _0o777_ format are supported though, so new files work.
- - Does not support base-60 floats. These are gone from YAML 1.2, and were
-   actually never supported by this package as it's clearly a poor choice.
+- YAML 1.1 bools (_yes/no, on/off_) are supported as long as they are being
+  decoded into a typed bool value. Otherwise they behave as a string. Booleans
+  in YAML 1.2 are _true/false_ only.
+- Octals encode and decode as _0777_ per YAML 1.1, rather than _0o777_
+  as specified in YAML 1.2, because most parsers still use the old format.
+  Octals in the _0o777_ format are supported though, so new files work.
+- Does not support base-60 floats. These are gone from YAML 1.2, and were
+  actually never supported by this package as it's clearly a poor choice.
 
 and offers backwards
 compatibility with YAML 1.1 in some cases.
@@ -33,37 +31,30 @@ anchors, tags, map merging, etc. Multi-document unmarshalling is not yet
 implemented, and base-60 floats from YAML 1.1 are purposefully not
 supported since they're a poor design and are gone in YAML 1.2.
 
-Installation and usage
-----------------------
+## Installation and usage
 
-The import path for the package is *gopkg.in/yaml.v3*.
+The import path for the package is _gopkg.in/yaml.v3_.
 
 To install it, run:
 
     go get gopkg.in/yaml.v3
 
-API documentation
------------------
+## API documentation
 
 If opened in a browser, the import path itself leads to the API documentation:
 
-  - [https://gopkg.in/yaml.v3](https://gopkg.in/yaml.v3)
+- [https://gopkg.in/yaml.v3](https://gopkg.in/yaml.v3)
 
-API stability
--------------
+## API stability
 
 The package API for yaml v3 will remain stable as described in [gopkg.in](https://gopkg.in).
 
-
-License
--------
+## License
 
 The yaml package is licensed under the MIT and Apache License 2.0 licenses.
 Please see the LICENSE file for details.
 
-
-Example
--------
+## Example
 
 ```Go
 package main
@@ -94,27 +85,27 @@ type T struct {
 
 func main() {
         t := T{}
-    
+
         err := yaml.Unmarshal([]byte(data), &t)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- t:\n%v\n\n", t)
-    
+
         d, err := yaml.Marshal(&t)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- t dump:\n%s\n\n", string(d))
-    
+
         m := make(map[interface{}]interface{})
-    
+
         err = yaml.Unmarshal([]byte(data), &m)
         if err != nil {
                 log.Fatalf("error: %v", err)
         }
         fmt.Printf("--- m:\n%v\n\n", m)
-    
+
         d, err = yaml.Marshal(&m)
         if err != nil {
                 log.Fatalf("error: %v", err)
@@ -147,4 +138,3 @@ b:
   - 3
   - 4
 ```
-


### PR DESCRIPTION
## Summary
- add optional Attic upload inputs to `.github/setup-nix`
- start `attic watch-store` when both `attic-token` and `attic-cache` are provided
- allow the repo CI workflow to run for PRs targeting `dev` as well as the migration-era `main`

## Why
This lets recorder CI jobs populate Attic after trusting the new substituter. The PR was retargeted to `dev`, but the repo CI workflow still only listened for PRs targeting `main`, so no fresh checks would enqueue after the retarget.

## Validation
- `git diff --check`
- pushed a rebased head on current `dev`; CI run `28720479990` queued on `acaec5f`

`yq` and `actionlint` are not installed in this workspace, so I did not rerun those local checks after the rebase.