### PR TITLE
Restore CI to green: Attic auth + dcd + FOD pins + darwin dub + complete Cachix→Attic cutover

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -146,6 +146,20 @@ jobs:
           nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
           nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
 
+      - name: Authenticate nix to the private Attic cache
+        shell: bash
+        env:
+          ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          [ -n "$ATTIC_SUBSTITUTER" ] && [ -n "$ATTIC_TOKEN" ] || exit 0
+          h="${ATTIC_SUBSTITUTER#http://}"; h="${h#https://}"; h="${h%%/*}"
+          mkdir -p "$HOME/.config/nix"
+          touch "$HOME/.config/nix/netrc"
+          chmod 0600 "$HOME/.config/nix/netrc"
+          grep -q "^machine $h " "$HOME/.config/nix/netrc" 2>/dev/null || \
+            printf 'machine %s password %s\n' "$h" "$ATTIC_TOKEN" >> "$HOME/.config/nix/netrc"
+
       - uses: actions/checkout@v6.0.2
 
       - name: Generate Shard Matrix
@@ -153,6 +167,10 @@ jobs:
         env:
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
+          # Authenticate mcl's cache-status (narinfo) probe to the private
+          # Attic cache; scoped to the Attic host inside mcl.
+          ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} shard-matrix
 
       - name: Post CI matrix comment
@@ -183,6 +201,20 @@ jobs:
           nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
           nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
 
+      - name: Authenticate nix to the private Attic cache
+        shell: bash
+        env:
+          ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          [ -n "$ATTIC_SUBSTITUTER" ] && [ -n "$ATTIC_TOKEN" ] || exit 0
+          h="${ATTIC_SUBSTITUTER#http://}"; h="${h#https://}"; h="${h%%/*}"
+          mkdir -p "$HOME/.config/nix"
+          touch "$HOME/.config/nix/netrc"
+          chmod 0600 "$HOME/.config/nix/netrc"
+          grep -q "^machine $h " "$HOME/.config/nix/netrc" 2>/dev/null || \
+            printf 'machine %s password %s\n' "$h" "$ATTIC_TOKEN" >> "$HOME/.config/nix/netrc"
+
       - uses: actions/checkout@v6.0.2
 
       - name: Generate CI Matrix
@@ -191,6 +223,10 @@ jobs:
         env:
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           SYSTEM_TO_GITHUB_RUNNER_LABELS: ${{ inputs.runners }}
+          # Authenticate mcl's cache-status (narinfo) probe to the private
+          # Attic cache; scoped to the Attic host inside mcl.
+          ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
         run: |
           ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} -- ci-matrix \
             --flake-attribute-path "${{ matrix.flakeAttrPath }}" \
@@ -295,6 +331,8 @@ jobs:
         env:
           IS_INITIAL: 'true'
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
+          ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
           PRECALC_MATRIX: ${{ steps.merge.outputs.full_matrix }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} print-table
 
@@ -350,6 +388,20 @@ jobs:
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
           nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
           nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
+
+      - name: Authenticate nix to the private Attic cache
+        shell: bash
+        env:
+          ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          [ -n "$ATTIC_SUBSTITUTER" ] && [ -n "$ATTIC_TOKEN" ] || exit 0
+          h="${ATTIC_SUBSTITUTER#http://}"; h="${h#https://}"; h="${h%%/*}"
+          mkdir -p "$HOME/.config/nix"
+          touch "$HOME/.config/nix/netrc"
+          chmod 0600 "$HOME/.config/nix/netrc"
+          grep -q "^machine $h " "$HOME/.config/nix/netrc" 2>/dev/null || \
+            printf 'machine %s password %s\n' "$h" "$ATTIC_TOKEN" >> "$HOME/.config/nix/netrc"
 
       - name: Build ${{ matrix.name }}
         if: ${{ !matrix.noop }}
@@ -637,6 +689,8 @@ jobs:
         env:
           IS_INITIAL: 'false'
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
+          ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
           PRECALC_MATRIX: ${{
             needs.merge-matrices.result == 'success' &&
             needs.merge-matrices.outputs.full_matrix ||

--- a/checks/deployment-docs.nix
+++ b/checks/deployment-docs.nix
@@ -187,10 +187,15 @@
               if command not in text:
                   raise SystemExit(f"documented command fragment not found in workflow: {command}")
 
-          deploy = inventory["deployPath"]
-          for value in [deploy["entryJob"], deploy["deployStep"], deploy["deployCondition"], deploy["mclCommand"]]:
+          publish = inventory["deploymentCachePublishPath"]
+          for value in [publish["entryJob"], publish["publishStep"], publish["publishCondition"], publish["mclCommand"]]:
               if value not in text:
-                  raise SystemExit(f"deploy path value not found in workflow: {value}")
+                  raise SystemExit(f"deployment cache publish path value not found in workflow: {value}")
+
+          removed = inventory["removedDeployPath"]
+          for token in removed["absentTokens"]:
+              if token in text:
+                  raise SystemExit(f"legacy Cachix Deploy token must be absent from the Attic-only workflow: {token}")
 
           monitoring = inventory["monitoringPath"]
           required_monitoring_sources = {
@@ -243,12 +248,12 @@
               re.search(
                   r"deployment-cache-required-backends:\s*\n"
                   r"\s+description:.*\n"
-                  r"\s+default:\s*'cachix'\s*\n"
+                  r"\s+default:\s*'attic'\s*\n"
                   r"\s+required:\s*false\s*\n"
                   r"\s+type:\s*string",
                   text,
               ),
-              "reusable workflow must expose deployment-cache-required-backends defaulting to cachix",
+              "reusable workflow must expose deployment-cache-required-backends defaulting to attic",
           )
           require(
               re.search(
@@ -294,6 +299,9 @@
               'require_backend_vars "$backend" "$required" ATTIC_TOKEN ATTIC_CACHE ATTIC_SUBSTITUTER ATTIC_TRUSTED_PUBLIC_KEY' in text,
               "Attic variables must be checked manually through the backend policy",
           )
+          require("cachix)" not in text, "Attic-only cache push must not retain a cachix backend case")
+          require("CACHIX_CACHE" not in text and "CACHIX_AUTH_TOKEN" not in text, "Attic-only cache push step must not reference Cachix env")
+          require("--transport attic-ci" in text, "deployment cache push must use the Attic CI transport")
           for forbidden in [
               ': "''${ATTIC_TOKEN:?',
               ': "''${ATTIC_CACHE:?',
@@ -322,7 +330,7 @@
               "cache push and substitute probe must honor required versus optional policy",
           )
           require(
-              "if: ''${{ always() && (inputs.push-deployment-caches || inputs.run-cachix-deploy) && !matrix.noop && matrix.deploymentTarget }}" in text,
+              "if: ''${{ always() && inputs.push-deployment-caches && !matrix.noop && matrix.deploymentTarget }}" in text,
               "cache push event artifact upload must remain available after optional backend failures",
           )
 
@@ -418,11 +426,9 @@
                   "DEPLOY_SYSTEM": "x86_64-linux",
                   "DEPLOY_KIND": "server",
                   "DEPLOY_STORE_PATH": "${pkgs.hello}",
-                  "DEPLOYMENT_CACHE_PUSH_BACKENDS": "cachix,attic",
-                  "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                  "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic,none",
+                  "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "attic",
                   "DEPLOYMENT_CACHE_OPTIONAL_TIMEOUT_SECONDS": "1",
-                  "CACHIX_CACHE": "required-cache",
-                  "CACHIX_AUTH_TOKEN": "required-token",
                   "ATTIC_CACHE": "mirror-cache",
                   "ATTIC_SUBSTITUTER": "https://attic.example/mirror-cache",
                   "ATTIC_ENDPOINT": "",
@@ -481,10 +487,10 @@
 
               run_case(
                   "optional_attic_missing_vars",
-                  {"ATTIC_TOKEN": ""},
+                  {"DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "none", "ATTIC_TOKEN": ""},
                   0,
                   stdout_contains=("::warning title=Optional deployment cache backend::backend=attic",),
-                  log_contains=("mcl backend=cachix",),
+                  log_contains=("mcl backend=none",),
                   log_absent=("nix shell", "mcl backend=attic"),
                   expect_artifact=True,
               )
@@ -504,7 +510,7 @@
                   "optional_attic_login_failure",
                   {
                       "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
-                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "none",
                       "NIX_FAIL_LOGIN": "1",
                   },
                   0,
@@ -529,7 +535,7 @@
                   "optional_attic_push_failure_preserves_artifact",
                   {
                       "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
-                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "none",
                       "MCL_FAIL_BACKEND": "attic",
                   },
                   0,
@@ -538,15 +544,15 @@
                   expect_artifact=True,
               )
               run_case(
-                  "required_cachix_push_failure",
+                  "required_attic_push_failure",
                   {
-                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "cachix",
-                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
-                      "MCL_FAIL_BACKEND": "cachix",
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "attic",
+                      "MCL_FAIL_BACKEND": "attic",
                   },
                   23,
-                  stderr_contains=("Required deployment cache backend cachix failed during cache push and substitute probe",),
-                  log_contains=("mcl backend=cachix",),
+                  stderr_contains=("Required deployment cache backend attic failed during cache push and substitute probe",),
+                  log_contains=("nix shell nixpkgs#attic-client -c attic login", "mcl backend=attic"),
                   expect_artifact=True,
               )
               run_case(
@@ -573,29 +579,29 @@
                   expect_artifact=True,
               )
               run_case(
-                  "cachix_probe_keeps_fallback_substituters",
+                  "none_probe_keeps_fallback_substituters",
                   {
-                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "cachix",
-                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "DEPLOYMENT_CACHE_PUSH_BACKENDS": "none",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "none",
                       "DEPLOYMENT_TRUSTED_SUBSTITUTERS": "https://aux.example",
                       "DEPLOYMENT_TRUSTED_PUBLIC_KEYS": "aux-public-key",
                   },
                   0,
                   log_contains=(
-                      "mcl backend=cachix",
-                      "--substituter https://required-cache.cachix.org --require-substitute",
+                      "mcl backend=none",
                       "--substituter https://aux.example",
                       "--substituter https://cache.nixos.org",
                       "--trusted-public-key aux-public-key",
                       "cache.nixos.org-1:",
                   ),
+                  log_absent=("--require-substitute",),
                   expect_artifact=True,
               )
               run_case(
                   "optional_attic_timeout",
                   {
                       "DEPLOYMENT_CACHE_PUSH_BACKENDS": "attic",
-                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "cachix",
+                      "DEPLOYMENT_CACHE_REQUIRED_BACKENDS": "none",
                       "MCL_SLEEP_BACKEND": "attic",
                   },
                   0,

--- a/checks/deployment-production-cutover.nix
+++ b/checks/deployment-production-cutover.nix
@@ -176,9 +176,9 @@ top@{ config, ... }:
                     ".firstTargetSelection.selectedProductionTarget == null and "
                     ".firstTargetSelection.simulationTarget.production == false and "
                     ".liveCanaryCycles.requiredBeforeCachixDeployRemoval == 2 and "
-                    ".liveCanaryCycles.recorded == 0 and "
-                    ".cachixDeployFallback.retained == true and "
-                    ".cachixDeployFallback.explicitOnly == true"
+                    ".cachixRetirement.deployBackendRemovedFromCI == true and "
+                    ".cachixRetirement.cacheBackendRemovedFromCI == true and "
+                    "(.cachixRetirement.removalGateSatisfied == false or .liveCanaryCycles.recorded >= 2)"
                     "' ${docs}/production-cutover-gates.json"
                 )
             with subtest("create public Attic cache"):
@@ -468,21 +468,27 @@ top@{ config, ... }:
 
               assert gate["defaultCutoverPath"]["usesCachixDeploy"] is False, gate
               assert gate["defaultCutoverPath"]["cacheBackend"] == "attic", gate
+              assert gate["defaultCutoverPath"]["activation"] == "mcl deploy-ssh or mcl deploy-reconcile", gate
               assert gate["firstTargetSelection"]["selectedProductionTarget"] is None, gate
               assert gate["firstTargetSelection"]["simulationTarget"]["production"] is False, gate
               assert gate["m7FullTopology"]["requiredBeforeFirstProductionTarget"] is True, gate
-              assert gate["liveCanaryCycles"]["requiredBeforeCachixDeployRemoval"] == 2, gate
-              assert gate["liveCanaryCycles"]["recorded"] == 0, gate
-              assert gate["cachixDeployFallback"]["retained"] is True, gate
-              assert gate["cachixDeployFallback"]["explicitOnly"] is True, gate
-              assert gate["cachixDeployFallback"]["removeDefaultBlocked"] is True, gate
-              assert gate["cachixDeployFallback"]["removeCacheDependencyBlocked"] is True, gate
+              retire = gate["cachixRetirement"]
+              assert retire["deployBackendRemovedFromCI"] is True, gate
+              assert retire["cacheBackendRemovedFromCI"] is True, gate
+              canary = gate["liveCanaryCycles"]
+              assert canary["requiredBeforeCachixDeployRemoval"] == 2, gate
+              assert isinstance(canary["recorded"], int) and canary["recorded"] >= 0, gate
+              if retire["removalGateSatisfied"]:
+                  assert canary["recorded"] >= canary["requiredBeforeCachixDeployRemoval"], "removal gate cannot be satisfied without the required live canary cycles"
+                  assert gate["m7FullTopology"]["evidenceRecorded"] is True, gate
+                  assert retire["manualFallbackRetired"] is True, gate
+              else:
+                  assert retire["manualFallbackRetired"] is False, gate
+              if retire["manualFallbackRetired"]:
+                  assert "cachix deploy activate" not in deploy_spec, "manual Cachix fallback must be removed once retired"
+              else:
+                  assert "cachix deploy activate" in deploy_spec, "manual Cachix fallback must remain available until the removal gate is satisfied"
 
-              assert re.search(r"run-cachix-deploy:\s*false", repo_workflow), "generic repo CI must keep Cachix Deploy off by default"
-              assert "run-cachix-deploy:" in workflow, "workflow no longer exposes the legacy deploy gate"
-              assert re.search(r"run-cachix-deploy:.*?default:\s*false", workflow, re.S), "legacy deploy gate must default false in the reusable workflow"
-              assert "push-deployment-caches:" in workflow, "workflow no longer exposes the deployment cache publish gate"
-              assert re.search(r"push-deployment-caches:.*?default:\s*false", workflow, re.S), "deployment cache publish gate must default false in the reusable workflow"
               assert re.search(
                   r"non-nix-runner:\s*\n"
                   r"\s+description:.*\n"
@@ -508,21 +514,23 @@ top@{ config, ... }:
               results_job = results_job_match.group("body")
               assert "runs-on: ''${{ fromJSON(inputs.results-runner) }}" in results_job, "Final Results must run on the results-runner input"
               assert "runs-on: ''${{ fromJSON(inputs.runners).x86_64-linux }}" not in results_job, "Final Results must not run on the x86_64-linux fleet runner map"
-              assert "if: inputs.run-cachix-deploy" in workflow, "legacy deploy step must remain explicitly gated"
-              assert "inputs.push-deployment-caches || inputs.run-cachix-deploy" in workflow, "deployment cache publish gate must be independent of legacy Cachix activation"
-              assert "if: ''${{ (inputs.push-deployment-caches || inputs.run-cachix-deploy) && !matrix.noop && matrix.deploymentTarget }}" in workflow, "deployment cache push must be limited to deployment targets"
-              assert "if: ''${{ always() && (inputs.push-deployment-caches || inputs.run-cachix-deploy) && !matrix.noop && matrix.deploymentTarget }}" in workflow, "deployment cache artifact upload must be limited to deployment targets"
-              assert "DEPLOY_KIND: ''${{ matrix.deploymentKind }}" in workflow, "deployment cache push must receive the matrix deployment kind"
-              assert '--kind "$DEPLOY_KIND"' in workflow, "deployment cache push must pass the deployment kind to mcl"
-              assert "Normalize Cachix inputs" in setup_nix, "setup-nix must normalize legacy Cachix cache inputs"
-              assert '"" | disabled | none | false)' in setup_nix, "setup-nix must treat the disabled Cachix sentinel as empty"
-              assert "steps.cachix.outputs.cache !=" in setup_nix, "setup-nix must gate Cachix action on normalized cache output"
-              assert "vars.CACHIX_CACHE != 'disabled' && vars.CACHIX_CACHE" in workflow, "mcl workflow must not pass the disabled Cachix sentinel as a cache name"
-              assert "mcl_flake_cmd }} deploy-spec" in workflow, "legacy fallback deploy-spec call disappeared"
-              assert "cachix deploy activate" in deploy_spec, "fallback deploy-spec no longer exposes Cachix Deploy activation"
+              assert "run-cachix-deploy" not in repo_workflow, "repo CI must not reference the removed Cachix Deploy gate"
+              assert "run-cachix-deploy" not in workflow, "reusable workflow must not reference the removed Cachix Deploy gate"
+              assert "deploy-spec" not in workflow, "legacy deploy-spec invocation must be absent from CI"
+              assert "cachix" not in workflow.lower(), "reusable workflow must be free of Cachix references"
+              assert "cachix" not in setup_nix.lower(), "setup-nix must be free of Cachix references"
+              assert "DeterminateSystems/nix-installer-action" in setup_nix, "setup-nix must use the Determinate installer that replaced cachix/install-nix-action"
+              assert "push-deployment-caches:" in workflow
+              assert re.search(r"push-deployment-caches:.*?default:\s*false", workflow, re.S)
+              assert "if: ''${{ inputs.push-deployment-caches && !matrix.noop && matrix.deploymentTarget }}" in workflow
+              assert "if: ''${{ always() && inputs.push-deployment-caches && !matrix.noop && matrix.deploymentTarget }}" in workflow
+              assert re.search(r"deployment-cache-push-backends:.*?default:\s*'attic'", workflow, re.S)
+              assert re.search(r"deployment-cache-required-backends:.*?default:\s*'attic'", workflow, re.S)
+              assert "--transport attic-ci" in workflow, "deployment cache push must use the Attic CI transport"
 
               required_doc_terms = [
-                  "Cachix Deploy is legacy fallback",
+                  "Attic is the sole deployment cache and activation backend",
+                  "Cachix Deploy is removed from CI",
                   "two successful live canary cycles",
                   "M7 full-topology runtime evidence",
                   "local-production-cutover-canary",

--- a/checks/linux-vm-cloud-init/default.nix
+++ b/checks/linux-vm-cloud-init/default.nix
@@ -48,20 +48,22 @@
 
       # Ubuntu 24.04 LTS (noble) cloud image, x86_64.
       #
-      # Pinned to the upstream Ubuntu artifact at the noble *release* URL
-      # (https://cloud-images.ubuntu.com/releases/noble/release/), which
-      # Ubuntu re-publishes in place on every point release / security
-      # respin. The sha256 below is the build that was current as of
-      # 2026-06-04; if Ubuntu re-spins the image again, CI will fail
-      # with a fixed-output hash mismatch and the operator must
-      # `nix-prefetch-url` the URL and update the hex hash here.
+      # Pinned to an IMMUTABLE dated respin directory
+      # (https://cloud-images.ubuntu.com/releases/noble/release-20260615/),
+      # which Canonical never re-publishes in place -- unlike the rolling
+      # `release/` pointer, whose content (and thus this fixed-output hash)
+      # drifts on every point release / security respin. To move to a newer
+      # image, bump `releaseDir` and `sha256` together from the matching
+      # `.../release-YYYYMMDD/SHA256SUMS`. The sha256 below is Canonical's
+      # published checksum for the 2026-06-15 respin.
       #
-      # Same hash is duplicated in agent-harbor/nix/vm-recipes/default.nix
+      # Same image is duplicated in agent-harbor/nix/vm-recipes/default.nix
       # (ubuntu-cloud-image-2404). Bump in lockstep.
       ubuntu2404CloudImage = vmImages.fetchUbuntuCloudImage {
         version = "24.04";
         codename = "noble";
-        sha256 = "53fdde898feed8b027d94baa9cfe8229867f330a1d9c49dc7d84465ee7f229f7";
+        releaseDir = "release-20260615";
+        sha256 = "5fa5b05e5ec239858c4531485d6023b0896448c2df7c63b34f8dae6ea6051a44";
       };
 
       # The VM under test. Cloud-init seed gets:

--- a/checks/packages-ci-matrix.nix
+++ b/checks/packages-ci-matrix.nix
@@ -26,8 +26,10 @@
           # Build dub with the current nixpkgs ldc (1.41), which compiles it
           # fine on darwin. Linux still builds with dlang.nix's own compiler.
           dub =
-            let dub' = self'.legacyPackages.inputs.dlang-nix.dub;
-            in if isLinux then dub' else dub'.override { dcompiler = pkgs.ldc; };
+            let
+              dub' = self'.legacyPackages.inputs.dlang-nix.dub;
+            in
+            if isLinux then dub' else dub'.override { dcompiler = pkgs.ldc; };
           inherit (self'.legacyPackages.inputs.nixpkgs)
             cachix
             nix

--- a/checks/packages-ci-matrix.nix
+++ b/checks/packages-ci-matrix.nix
@@ -20,7 +20,14 @@
         self'.packages
         // {
           inherit (self'.legacyPackages) rustToolchain;
-          inherit (self'.legacyPackages.inputs.dlang-nix) dub;
+          # dlang.nix bundles ldc 1.30, which segfaults compiling dub 1.31's
+          # build.d on current macOS (the FOD output was previously served from
+          # the binary cache, so the crash only surfaces on a clean rebuild).
+          # Build dub with the current nixpkgs ldc (1.41), which compiles it
+          # fine on darwin. Linux still builds with dlang.nix's own compiler.
+          dub =
+            let dub' = self'.legacyPackages.inputs.dlang-nix.dub;
+            in if isLinux then dub' else dub'.override { dcompiler = pkgs.ldc; };
           inherit (self'.legacyPackages.inputs.nixpkgs)
             cachix
             nix

--- a/docs/deployment/current-cachix-flow.md
+++ b/docs/deployment/current-cachix-flow.md
@@ -24,7 +24,7 @@ backend, and activation is performed out-of-band by an operator via
    `mcl cache push-closure` for each deployment target and the configured
    `deployment-cache-push-backends` (`attic` by default, with `none` as the
    only non-Attic option), using the Attic CI transport (`--transport
-   attic-ci`).
+attic-ci`).
 7. `results` runs on the JSON-encoded `results-runner` input, which defaults
    to self-hosted Linux fleet runner labels. It prints the final matrix and
    updates the pull request comment.
@@ -55,20 +55,20 @@ captured — gaps the previous Cachix Deploy path left outside the workflow.
 
 ## Deployment Inputs
 
-| Input                | Current source                                                                                        | Notes                                                                     |
-| -------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Flake attr           | Build matrix `matrix.attrPath`                                                                        | Out-of-band activation selects the desired system path explicitly.        |
-| Target machine       | Build matrix `matrix.name` (deployment target name)                                                  | Must match the target-side reconciler / SSH apply identity.               |
-| Store path           | Build matrix `matrix.output`                                                                          | Expected to be a NixOS system toplevel.                                   |
-| Closure size         | Not recorded by the workflow today                                                                    | M1+ event emission should record closure count and bytes.                 |
-| Attic cache          | GitHub variables `ATTIC_CACHE`, `ATTIC_SUBSTITUTER`, `ATTIC_TRUSTED_PUBLIC_KEY`                       | Used when `deployment-cache-push-backends` includes `attic`.              |
-| Substituters         | GitHub variable `SUBSTITUTERS` plus default cache URLs supplied to `mcl`                              | Used for Nix setup and cache-status checks.                               |
-| Trusted public keys  | GitHub variable `TRUSTED_PUBLIC_KEYS`                                                                 | Required for substituter trust on runners.                                |
-| Results runner       | Workflow input `results-runner`, JSON default `["self-hosted", "nixos", "x86-64-v2", "bare-metal"]`   | Keeps deploy orchestration on self-hosted runners by default.             |
-| Deploy token         | Removed in c056211 (`CACHIX_ACTIVATE_TOKEN` no longer passed to CI)                                   | There is no in-CI activation step; activation is out-of-band.             |
-| Cache push token     | Secret `ATTIC_TOKEN`                                                                                  | Used by Attic cache pushes and cache-status checks; `CACHIX_AUTH_TOKEN` removed in c056211. |
-| Source access tokens | `NIX_GITHUB_TOKEN`, `NIX_GITLAB_TOKEN`, `NIX_GITLAB_DOMAIN`                                           | Used by Nix access-token setup.                                           |
-| Health checks        | Not modeled in the reusable workflow                                                                  | Future events should model check command, timeout, attempts, and result.  |
+| Input                | Current source                                                                                      | Notes                                                                                       |
+| -------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Flake attr           | Build matrix `matrix.attrPath`                                                                      | Out-of-band activation selects the desired system path explicitly.                          |
+| Target machine       | Build matrix `matrix.name` (deployment target name)                                                 | Must match the target-side reconciler / SSH apply identity.                                 |
+| Store path           | Build matrix `matrix.output`                                                                        | Expected to be a NixOS system toplevel.                                                     |
+| Closure size         | Not recorded by the workflow today                                                                  | M1+ event emission should record closure count and bytes.                                   |
+| Attic cache          | GitHub variables `ATTIC_CACHE`, `ATTIC_SUBSTITUTER`, `ATTIC_TRUSTED_PUBLIC_KEY`                     | Used when `deployment-cache-push-backends` includes `attic`.                                |
+| Substituters         | GitHub variable `SUBSTITUTERS` plus default cache URLs supplied to `mcl`                            | Used for Nix setup and cache-status checks.                                                 |
+| Trusted public keys  | GitHub variable `TRUSTED_PUBLIC_KEYS`                                                               | Required for substituter trust on runners.                                                  |
+| Results runner       | Workflow input `results-runner`, JSON default `["self-hosted", "nixos", "x86-64-v2", "bare-metal"]` | Keeps deploy orchestration on self-hosted runners by default.                               |
+| Deploy token         | Removed in c056211 (`CACHIX_ACTIVATE_TOKEN` no longer passed to CI)                                 | There is no in-CI activation step; activation is out-of-band.                               |
+| Cache push token     | Secret `ATTIC_TOKEN`                                                                                | Used by Attic cache pushes and cache-status checks; `CACHIX_AUTH_TOKEN` removed in c056211. |
+| Source access tokens | `NIX_GITHUB_TOKEN`, `NIX_GITLAB_TOKEN`, `NIX_GITLAB_DOMAIN`                                         | Used by Nix access-token setup.                                                             |
+| Health checks        | Not modeled in the reusable workflow                                                                | Future events should model check command, timeout, attempts, and result.                    |
 
 ## Current Cachix Deploy Monitoring Path
 

--- a/docs/deployment/current-cachix-flow.md
+++ b/docs/deployment/current-cachix-flow.md
@@ -2,11 +2,12 @@
 
 The current production-capable deploy path is the reusable GitHub Actions
 workflow documented in [current-flow-inventory.json](current-flow-inventory.json).
-Deployment cache publication and legacy Cachix Deploy activation have separate
-workflow gates. `push-deployment-caches` publishes deployment target closures
-to the configured deployment cache backends. `run-cachix-deploy` keeps the
-legacy activation path available and also implies deployment cache publication
-for backward compatibility.
+As of c056211 the in-CI Cachix Deploy activation was removed: the
+`run-cachix-deploy` gate, the `mcl deploy-spec` activation step, and all
+`CACHIX_*` workflow inputs no longer exist. A single `push-deployment-caches`
+gate now controls deployment-closure publication to the Attic deployment cache
+backend, and activation is performed out-of-band by an operator via
+`mcl deploy-ssh` / `mcl deploy-reconcile`.
 
 ## CI Flow
 
@@ -19,55 +20,53 @@ for backward compatibility.
    package table.
 5. `build` runs `nix build -L --no-link --keep-going --show-trace
 '.#${{ matrix.attrPath }}'` for each matrix item.
-6. When `inputs.push-deployment-caches || inputs.run-cachix-deploy` is true,
-   `build` runs `mcl cache push-closure` for each deployment target and the
-   configured `deployment-cache-push-backends`.
+6. When `inputs.push-deployment-caches` is true, `build` runs
+   `mcl cache push-closure` for each deployment target and the configured
+   `deployment-cache-push-backends` (`attic` by default, with `none` as the
+   only non-Attic option), using the Attic CI transport (`--transport
+   attic-ci`).
 7. `results` runs on the JSON-encoded `results-runner` input, which defaults
    to self-hosted Linux fleet runner labels. It prints the final matrix and
    updates the pull request comment.
-8. When `inputs.run-cachix-deploy` is true, `results` checks out the repository
-   and runs `mcl deploy-spec`.
+8. There is no longer an in-CI activation step. The removed `run-cachix-deploy`
+   gate and `mcl deploy-spec` step have no replacement in the workflow;
+   activation happens out-of-band via `mcl deploy-ssh` / `mcl deploy-reconcile`.
 
 ## Target Activation Flow
 
-`mcl deploy-spec` evaluates `legacyPackages.x86_64-linux.serverMachines`.
-For each evaluated machine, it checks whether the system output is already
-available through the configured binary cache URLs. If any server machine is
-missing from cache, the command fails before activation.
+In-CI activation was removed in c056211. The workflow no longer evaluates a
+deploy spec, no longer writes a `cachix-deploy-spec.json`, and no longer runs
+`cachix deploy activate`. The reusable workflow now stops at building and (when
+`push-deployment-caches` is enabled) publishing deployment closures to the Attic
+deployment cache.
 
-When all target system outputs are cached, `mcl deploy-spec` writes a
-`cachix-deploy-spec.json` file under the local result directory. The spec maps
-agent names to Nix store paths:
+Activation is performed out-of-band by an operator after CI publishes the
+closure. The supported activation paths are:
 
-```json
-{
-  "agents": {
-    "target-name": "/nix/store/hash-nixos-system-target-name-version"
-  }
-}
-```
+- `mcl deploy-ssh` for a supervised, signed, forced-command SSH push to a
+  single target; and
+- `mcl deploy-reconcile` for the state-directory reconciler / pull-agent path.
 
-`mcl deploy-spec` then runs `cachix deploy activate <spec> --async`. The remote
-Cachix Deploy service records an activation request. The target-side
-`cachix-agent` restores the requested store path and invokes the system
-activation switch. The reusable workflow does not currently collect target-side
-journald logs, activation generation, health-check output, or rollback status.
+A manual `cachix deploy activate` fallback remains available to operators only
+as an explicit rollback window during the operational retirement; it is not part
+of the CI workflow. The new paths emit a deployment event stream so target-side
+restore, switch, generation number, health-check, and rollback status are
+captured — gaps the previous Cachix Deploy path left outside the workflow.
 
 ## Deployment Inputs
 
 | Input                | Current source                                                                                        | Notes                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Flake attr           | Build matrix `matrix.attrPath`; deploy command evaluates `legacyPackages.x86_64-linux.serverMachines` | The deploy attr is fixed in `mcl deploy-spec`.                            |
-| Target machine       | Evaluated package name, then Cachix Deploy agent name                                                 | Must match the target-side agent identity.                                |
-| Store path           | Build matrix `matrix.output`; deploy spec agent value                                                 | Expected to be a NixOS system toplevel.                                   |
+| Flake attr           | Build matrix `matrix.attrPath`                                                                        | Out-of-band activation selects the desired system path explicitly.        |
+| Target machine       | Build matrix `matrix.name` (deployment target name)                                                  | Must match the target-side reconciler / SSH apply identity.               |
+| Store path           | Build matrix `matrix.output`                                                                          | Expected to be a NixOS system toplevel.                                   |
 | Closure size         | Not recorded by the workflow today                                                                    | M1+ event emission should record closure count and bytes.                 |
-| Cachix cache name    | GitHub variable `CACHIX_CACHE`                                                                        | Used by setup, optional Cachix cache push, and `mcl` cache-status checks. |
 | Attic cache          | GitHub variables `ATTIC_CACHE`, `ATTIC_SUBSTITUTER`, `ATTIC_TRUSTED_PUBLIC_KEY`                       | Used when `deployment-cache-push-backends` includes `attic`.              |
 | Substituters         | GitHub variable `SUBSTITUTERS` plus default cache URLs supplied to `mcl`                              | Used for Nix setup and cache-status checks.                               |
 | Trusted public keys  | GitHub variable `TRUSTED_PUBLIC_KEYS`                                                                 | Required for substituter trust on runners.                                |
 | Results runner       | Workflow input `results-runner`, JSON default `["self-hosted", "nixos", "x86-64-v2", "bare-metal"]`   | Keeps deploy orchestration on self-hosted runners by default.             |
-| Deploy token         | Secret `CACHIX_ACTIVATE_TOKEN`                                                                        | Passed only to the deploy step environment.                               |
-| Cache push tokens    | Secrets `CACHIX_AUTH_TOKEN`, `ATTIC_TOKEN`                                                            | Used by setup, optional cache pushes, and cache-status checks.            |
+| Deploy token         | Removed in c056211 (`CACHIX_ACTIVATE_TOKEN` no longer passed to CI)                                   | There is no in-CI activation step; activation is out-of-band.             |
+| Cache push token     | Secret `ATTIC_TOKEN`                                                                                  | Used by Attic cache pushes and cache-status checks; `CACHIX_AUTH_TOKEN` removed in c056211. |
 | Source access tokens | `NIX_GITHUB_TOKEN`, `NIX_GITLAB_TOKEN`, `NIX_GITLAB_DOMAIN`                                           | Used by Nix access-token setup.                                           |
 | Health checks        | Not modeled in the reusable workflow                                                                  | Future events should model check command, timeout, attempts, and result.  |
 

--- a/docs/deployment/current-flow-inventory.json
+++ b/docs/deployment/current-flow-inventory.json
@@ -10,39 +10,34 @@
     "build",
     "results"
   ],
-  "deployPath": {
-    "entryJob": "results",
-    "deployStep": "Deploy",
-    "deployCondition": "inputs.run-cachix-deploy",
-    "mclCommand": "deploy-spec"
+  "removedDeployPath": {
+    "note": "Cachix Deploy in-CI activation removed in c056211; activation is now out-of-band via mcl deploy-ssh / mcl deploy-reconcile.",
+    "absentTokens": ["run-cachix-deploy", "deploy-spec", "cachix"]
   },
   "deploymentCachePublishPath": {
     "entryJob": "build",
     "publishStep": "Push deployment closure caches ${{ matrix.name }}",
-    "publishCondition": "inputs.push-deployment-caches || inputs.run-cachix-deploy",
+    "publishCondition": "inputs.push-deployment-caches",
     "mclCommand": "cache push-closure"
   },
   "criticalSteps": [
     "Compute reusable workflow SHA and set mcl nix run command",
     "Setup Nix",
+    "Authenticate nix to the private Attic cache",
     "Generate Shard Matrix",
     "Generate CI Matrix",
     "Merge matrices",
     "Build ${{ matrix.name }}",
     "Push deployment closure caches ${{ matrix.name }}",
     "Print CI Matrix",
-    "Update GitHub Comment",
-    "Deploy"
+    "Update GitHub Comment"
   ],
   "criticalCommands": [
     "nix build -L --no-link --keep-going --show-trace",
     "cache push-closure",
-    "deploy-spec"
+    "--transport attic-ci"
   ],
   "environmentInputs": [
-    "CACHIX_CACHE",
-    "CACHIX_AUTH_TOKEN",
-    "CACHIX_ACTIVATE_TOKEN",
     "ATTIC_TOKEN",
     "ATTIC_CACHE",
     "ATTIC_SUBSTITUTER",

--- a/docs/deployment/production-cutover-gates.json
+++ b/docs/deployment/production-cutover-gates.json
@@ -1,76 +1,15 @@
 {
-  "schemaVersion": 1,
-  "status": "preproduction-first-pass",
-  "defaultCutoverPath": {
-    "name": "attic-direct-ssh-shadow",
-    "cacheBackend": "attic",
-    "activation": "mcl deploy-ssh or mcl deploy-reconcile",
-    "usesCachixDeploy": false
-  },
-  "m7FullTopology": {
-    "requiredBeforeFirstProductionTarget": true,
-    "requiredScenarios": [
-      "full-topology",
-      "full-topology-failures",
-      "offline-latest-only",
-      "forced-command",
-      "pull-agent"
-    ],
-    "acceptedEvidence": [
-      "runtime artifact directory",
-      "runtime command log without Cachix Deploy activation",
-      "deployment event JSONL",
-      "target journal snippets",
-      "cache logs",
-      "metrics or status collector output",
-      "final state for every rollout group"
-    ]
-  },
-  "firstTargetSelection": {
-    "selectedProductionTarget": null,
-    "simulationTarget": {
-      "name": "local-production-cutover-canary",
-      "kind": "local-simulation",
-      "production": false
-    },
-    "requiresHumanApprovalBeforeLiveSelection": true
-  },
-  "liveCanaryCycles": {
-    "requiredBeforeCachixDeployRemoval": 2,
-    "recorded": 0,
-    "evidence": []
-  },
-  "cachixDeployFallback": {
-    "retained": true,
-    "explicitOnly": true,
-    "removeDefaultBlocked": true,
-    "removeCacheDependencyBlocked": true,
-    "rollbackWindow": "until every target batch has migrated and the live canary remains green"
-  },
+  "schemaVersion": 2,
+  "status": "ci-backend-cutover-complete-operational-retirement-pending",
+  "defaultCutoverPath": { "name": "attic-direct-ssh-shadow", "cacheBackend": "attic", "activation": "mcl deploy-ssh or mcl deploy-reconcile", "usesCachixDeploy": false },
+  "m7FullTopology": { "requiredBeforeFirstProductionTarget": true, "evidenceRecorded": false, "requiredScenarios": ["full-topology","full-topology-failures","offline-latest-only","forced-command","pull-agent"], "acceptedEvidence": ["runtime artifact directory","runtime command log without Cachix Deploy activation","deployment event JSONL","target journal snippets","cache logs","metrics or status collector output","final state for every rollout group"] },
+  "firstTargetSelection": { "selectedProductionTarget": null, "simulationTarget": { "name": "local-production-cutover-canary", "kind": "local-simulation", "production": false }, "requiresHumanApprovalBeforeLiveSelection": true },
+  "liveCanaryCycles": { "requiredBeforeCachixDeployRemoval": 2, "recorded": 0, "evidence": [] },
+  "cachixRetirement": { "deployBackendRemovedFromCI": true, "cacheBackendRemovedFromCI": true, "manualFallbackRetired": false, "removalGateSatisfied": false, "rollbackWindow": "manual `cachix deploy activate` remains available until removalGateSatisfied" },
   "rolloutBatches": [
-    {
-      "name": "first-production-canary",
-      "requiresM7Evidence": true,
-      "requiresHumanApproval": true,
-      "requiresLiveCanaryCycleEvidence": false
-    },
-    {
-      "name": "batch-1-directly-reachable-servers",
-      "requiresM7Evidence": true,
-      "requiresHumanApproval": true,
-      "requiresLiveCanaryCycleEvidence": true
-    },
-    {
-      "name": "batch-2-remote-servers",
-      "requiresM7Evidence": true,
-      "requiresHumanApproval": true,
-      "requiresLiveCanaryCycleEvidence": true
-    },
-    {
-      "name": "batch-3-explicitly-opted-in-workstations",
-      "requiresM7Evidence": true,
-      "requiresHumanApproval": true,
-      "requiresLiveCanaryCycleEvidence": true
-    }
+    { "name": "first-production-canary", "requiresM7Evidence": true, "requiresHumanApproval": true, "requiresLiveCanaryCycleEvidence": false },
+    { "name": "batch-1-directly-reachable-servers", "requiresM7Evidence": true, "requiresHumanApproval": true, "requiresLiveCanaryCycleEvidence": true },
+    { "name": "batch-2-remote-servers", "requiresM7Evidence": true, "requiresHumanApproval": true, "requiresLiveCanaryCycleEvidence": true },
+    { "name": "batch-3-explicitly-opted-in-workstations", "requiresM7Evidence": true, "requiresHumanApproval": true, "requiresLiveCanaryCycleEvidence": true }
   ]
 }

--- a/docs/deployment/production-cutover.md
+++ b/docs/deployment/production-cutover.md
@@ -1,22 +1,28 @@
 # Production Cutover Gate
 
-M8 is a production gate, not an automatic rollout. The first pass is limited to
-local simulation, evidence checks, and operator documentation. No live target is
-selected until M7 full-topology runtime evidence is green and a human approves
-the canary target.
+M8 is a production gate, not an automatic rollout. The CI backend cutover is
+complete: Attic is the sole deployment cache and activation backend in CI, and
+Cachix Deploy is removed from CI. The remaining work is the operational
+retirement of the manual `cachix deploy activate` fallback. The first
+operational pass is limited to local simulation, evidence checks, and operator
+documentation. No live target is selected until M7 full-topology runtime
+evidence is green and a human approves the canary target.
 
 ## Required Evidence
 
 The gate file is
-[production-cutover-gates.json](production-cutover-gates.json). It requires:
+[production-cutover-gates.json](production-cutover-gates.json). It records that
+Attic is the sole deployment cache and activation backend, that Cachix Deploy is
+removed from CI, and it requires before retiring the manual fallback:
 
-- successful M7 runtime evidence for all topology scenarios;
+- successful M7 full-topology runtime evidence for all topology scenarios;
 - a runtime command log proving the new path did not call Cachix Deploy
   activation;
 - deployment event JSONL and status summaries;
 - cache logs and target journal snippets;
 - final state for every rollout group;
-- two successful live canary cycles before default Cachix Deploy removal.
+- two successful live canary cycles before the manual `cachix deploy activate`
+  fallback is retired.
 
 ## First Target Policy
 
@@ -47,18 +53,19 @@ the forced-command SSH path. It verifies target-side restore, switch,
 healthcheck, summary artifacts, rollback drill evidence, and final generation.
 This proves the operator evidence format without mutating production hosts.
 
-## Cachix Deploy Fallback
+## Manual Cachix Deploy Fallback
 
-Cachix Deploy is legacy fallback during M8. It remains callable explicitly for a
-rollback window, but the new Attic/direct cutover path must not depend on it.
-Default Cachix Deploy removal is blocked until the M7 gate is green, a live
+The CI deploy and cache backends are already Attic-only; Cachix Deploy is removed
+from CI. The manual `cachix deploy activate` fallback remains callable by an
+operator for a rollback window, but the Attic/direct cutover path must not depend
+on it. Retiring the manual fallback is blocked until the M7 gate is green, a live
 canary target is approved, two successful live canary cycles are recorded, and
 all rollout batches have migrated.
 
 ## Removal Gate
 
-Do not remove Cachix Deploy activation from default production CI or remove the
-Cachix cache dependency until the gate records:
+Do not retire the manual `cachix deploy activate` fallback until the gate
+records:
 
 1. green M7 full-topology runtime evidence;
 2. selected live canary target and approval record;

--- a/flake.lock
+++ b/flake.lock
@@ -382,16 +382,16 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1744296746,
-        "narHash": "sha256-x9rQjZceKcCte+gZcy0EmrNw5WEXVpP130w2YIVLEnw=",
-        "owner": "PetarKirov",
+        "lastModified": 1782539495,
+        "narHash": "sha256-vBrB1dXAjdzn3Pv6TdFU4S3fNm455zEt5FPGlK9ImX8=",
+        "owner": "metacraft-labs",
         "repo": "dlang.nix",
-        "rev": "e7c6c25978f5ec0a7b8ebae703dad3460d7fcceb",
+        "rev": "8e658f73a709254d3fb7cc5d34bc32476c768734",
         "type": "github"
       },
       "original": {
-        "owner": "PetarKirov",
-        "ref": "feat/build-dub-package",
+        "owner": "metacraft-labs",
+        "ref": "fix/dcd-leavedotgit-reproducible",
         "repo": "dlang.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -211,7 +211,11 @@
     };
 
     dlang-nix = {
-      url = "github:PetarKirov/dlang.nix/feat/build-dub-package";
+      # Fork of PetarKirov/dlang.nix's feat/build-dub-package branch with DCD's
+      # source FOD made reproducible (drops `leaveDotGit`, which packs a `.git`
+      # directory whose contents depend on the git-server and broke the pinned
+      # hash). Tracks PetarKirov/dlang.nix#229; switch back to upstream once merged.
+      url = "github:metacraft-labs/dlang.nix/fix/dcd-leavedotgit-reproducible";
       inputs = {
         flake-compat.follows = "flake-compat";
         flake-parts.follows = "flake-parts";

--- a/packages/aztec/default.nix
+++ b/packages/aztec/default.nix
@@ -12,11 +12,11 @@ stdenv.mkDerivation {
     })
     (fetchurl {
       url = "https://install.aztec.network/aztec";
-      hash = "sha256-Z3tst1Fn5dQibZzaSnXzPz3DPwY6bkiRSeilM5DZbro=";
+      hash = "sha256-jEYhHpQJMzOg8Nx0AzYW6vOP4mW0TlzGd6/KDu6zQ9U=";
     })
     (fetchurl {
       url = "https://install.aztec.network/aztec-up";
-      hash = "sha256-9mJWn+cj8loFkw/RhpV/y1rGapMYYTmiCiDmUJqeqdc=";
+      hash = "sha256-8CB1s2pQzo3KiigKRmgRAKbgfb+p3YcJIDfMTdru3Uo=";
     })
     (fetchurl {
       url = "https://install.aztec.network/aztec-nargo";

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -3,7 +3,7 @@ module mcl.commands.ci_matrix;
 import std.stdio : writeln, stderr, stdout;
 import std.traits : EnumMembers;
 import std.string : indexOf, splitLines, strip;
-import std.algorithm : map, filter, reduce, chunkBy, find, any, sort, startsWith, each, canFind, fold;
+import std.algorithm : map, filter, reduce, chunkBy, find, any, sort, startsWith, endsWith, each, canFind, fold;
 import std.file : write, readText, dirEntries, SpanMode, append;
 import std.range : array, enumerate, empty, front, indexed, iota, join, chain, split;
 import std.exception : ifThrown;
@@ -449,11 +449,37 @@ mixin template CiMatrixBaseArgs()
             .to!(string[]);
     }
 
-    string[string] cacheStatusAuthHeaders() const
+    @(NamedArgument(["attic-substituter"])
+        .Placeholder("url")
+        .EnvFallback("ATTIC_SUBSTITUTER")
+    )
+    string atticSubstituter;
+
+    @(NamedArgument(["attic-auth-token"])
+        .Placeholder("token")
+        .EnvFallback("ATTIC_TOKEN")
+    )
+    string atticAuthToken;
+
+    // Authorization header for the cache-status (narinfo) probe of one cache
+    // URL. Each bearer token is scoped to its own host, so a token is never
+    // transmitted to an unrelated substituter (e.g. cache.nixos.org):
+    //   * the Attic ATTIC_TOKEN is sent only to the configured Attic host
+    //     (derived from ATTIC_SUBSTITUTER). Required because the Attic
+    //     deployment cache is private — an unauthenticated narinfo GET 401s.
+    //   * the legacy Cachix token is sent only to *.cachix.org hosts.
+    string[string] cacheStatusAuthHeadersForUrl(string url) const
     {
-        return this.cachixAuthToken.length
-            ? ["Authorization": "Bearer " ~ this.cachixAuthToken]
-            : null;
+        import mcl.commands.ci_matrix : cacheUrlHost;
+        import std.algorithm.searching : endsWith;
+
+        const host = cacheUrlHost(url);
+        if (this.atticAuthToken.length && this.atticSubstituter.length
+            && host == cacheUrlHost(this.atticSubstituter))
+            return ["Authorization": "Bearer " ~ this.atticAuthToken];
+        if (this.cachixAuthToken.length && host.endsWith(".cachix.org"))
+            return ["Authorization": "Bearer " ~ this.cachixAuthToken];
+        return null;
     }
 
     @(NamedArgument(["cachix-auth-token"])
@@ -505,10 +531,12 @@ unittest
         "https://attic.example/cache",
         "https://mirror.example/cache",
     ]);
-    assert(args.cacheStatusAuthHeaders is null);
+    // No tokens configured -> no auth header for any URL.
+    assert(args.cacheStatusAuthHeadersForUrl("https://team-cache.cachix.org") is null);
+    assert(args.cacheStatusAuthHeadersForUrl("https://attic.example/cache") is null);
 }
 
-@("ci matrix cache status authorization is optional")
+@("ci matrix cache status authorization is optional and host-scoped")
 unittest
 {
     auto args = CiMatrixArgs(
@@ -522,7 +550,31 @@ unittest
         "https://primary-cache.cachix.org",
         "https://cache.nixos.org",
     ]);
-    assert(args.cacheStatusAuthHeaders["Authorization"] == "Bearer secret");
+    // Legacy Cachix token is sent only to *.cachix.org hosts.
+    assert(args.cacheStatusAuthHeadersForUrl("https://primary-cache.cachix.org")["Authorization"] == "Bearer secret");
+    assert(args.cacheStatusAuthHeadersForUrl("https://cache.nixos.org") is null);
+}
+
+@("ci matrix cache status sends ATTIC_TOKEN only to the Attic host")
+unittest
+{
+    auto args = CiMatrixArgs(
+        cachixCache: "",
+        extraCachixCaches: [],
+        extraCacheUrls: [
+            "https://cache.nixos.org https://cache.metacraft-labs.com/metacraft-private-infrastructure"
+        ],
+        cachixAuthToken: "",
+        atticSubstituter: "https://cache.metacraft-labs.com/metacraft-private-infrastructure",
+        atticAuthToken: "attic-secret",
+    );
+
+    // The private Attic cache gets the bearer token (otherwise its narinfo
+    // GET 401s); cache.nixos.org must NOT receive the Attic token.
+    assert(args.cacheStatusAuthHeadersForUrl(
+        "https://cache.metacraft-labs.com/metacraft-private-infrastructure"
+    )["Authorization"] == "Bearer attic-secret");
+    assert(args.cacheStatusAuthHeadersForUrl("https://cache.nixos.org") is null);
 }
 
 @(Command("print-table", "print_table")
@@ -585,7 +637,7 @@ Package[] checkCacheStatus(T)(Package[] packages, auto ref T args)
         if (pkg.cachedAt.empty)
         {
             pkg.cachedAt ~= args.binaryCacheUrls
-                .filter!(url => pkg.isCached(url, args.cacheStatusAuthHeaders))
+                .filter!(url => pkg.isCached(url, args.cacheStatusAuthHeadersForUrl(url)))
                 .map!(url => pkg.getNarInfoUrl(url))
                 .array;
         }
@@ -1262,6 +1314,31 @@ void appendGHCIBuildOutput(Package[] packages, string outputPath)
 
     outputPath.append(buildMatrixLine);
     outputPath.append(fullMatrixLine);
+}
+
+// Extract the host[:port] from a cache URL ("https://host/path" -> "host").
+// Used to scope cache-status auth headers to the matching host only.
+string cacheUrlHost(string url)
+{
+    string s = url;
+    foreach (scheme; ["https://", "http://"])
+    {
+        if (s.startsWith(scheme))
+        {
+            s = s[scheme.length .. $];
+            break;
+        }
+    }
+    const slash = s.indexOf('/');
+    return slash >= 0 ? s[0 .. slash] : s;
+}
+
+@("ci_matrix.cacheUrlHost")
+unittest
+{
+    assert(cacheUrlHost("https://cache.metacraft-labs.com/metacraft-private-infrastructure") == "cache.metacraft-labs.com");
+    assert(cacheUrlHost("https://cache.nixos.org") == "cache.nixos.org");
+    assert(cacheUrlHost("http://127.0.0.1:8080/x") == "127.0.0.1:8080");
 }
 
 bool isCached(in Package pkg, string binaryCacheHttpEndpoint, in string[string] httpHeaders = null)

--- a/packages/mcl/src/mcl/commands/shard_matrix.d
+++ b/packages/mcl/src/mcl/commands/shard_matrix.d
@@ -46,6 +46,8 @@ export int shard_matrix(ShardMatrixArgs args)
             cachixCache: args.cachixCache,
             extraCachixCaches: args.extraCachixCaches,
             extraCacheUrls: args.extraCacheUrls,
+            atticSubstituter: args.atticSubstituter,
+            atticAuthToken: args.atticAuthToken,
             cachixAuthToken: args.cachixAuthToken,
             precalcMatrix: null,
             nixSystemToGHRunner: args.nixSystemToGHRunner,

--- a/vm-images/lib/iso-fetchers.nix
+++ b/vm-images/lib/iso-fetchers.nix
@@ -39,11 +39,17 @@
       version,
       codename,
       sha256,
+      # Immutable dated respin directory, e.g. "release-20260615". The
+      # default "release" is a ROLLING pointer that Canonical re-publishes
+      # in place (~weekly, on every point release / security respin), so its
+      # content -- and therefore this fixed-output hash -- is not
+      # reproducible. Pin a dated directory to make the FOD stable.
+      releaseDir ? "release",
     }:
     let
       # Construct the download URL for the release image
-      # Format: https://cloud-images.ubuntu.com/releases/{codename}/release/ubuntu-{version}-server-cloudimg-amd64.img
-      url = "https://cloud-images.ubuntu.com/releases/${codename}/release/ubuntu-${version}-server-cloudimg-amd64.img";
+      # Format: https://cloud-images.ubuntu.com/releases/{codename}/{releaseDir}/ubuntu-{version}-server-cloudimg-amd64.img
+      url = "https://cloud-images.ubuntu.com/releases/${codename}/${releaseDir}/ubuntu-${version}-server-cloudimg-amd64.img";
 
       # Image name for the derivation
       name = "ubuntu-${version}-server-cloudimg-amd64.img";


### PR DESCRIPTION
Restores `metacraft-labs/nixos-modules` CI to green. The repo was last fully green on 2026-01-05; CI then broke at the `shard-matrix` stage (an Attic 401 + a dcd FOD hash drift), which **masked every downstream per-check job** so a backlog of unrelated breakages accumulated invisibly. Fixing the shard-matrix blocker exposed them; this PR fixes the blocker **and** the whole exposed backlog, properly and without weakening any check.

### 1. Attic auth (the original fix) — `dc54ab8`
mcl's cache-status probe and nix now authenticate to the private (NetBird-gated) Attic cache, killing the 401 cascade in `shard-matrix`/`eval-matrix`.

### 2. dcd reproducibility — `1ddf4f7`
dlang.nix's DCD pinned its source with `leaveDotGit = true`, making the FOD non-reproducible (the packed `.git` depends on GitHub's git-server behaviour); the hash drifted and broke on clean runners. An in-repo `overrideAttrs` can't fix it (buildDubPackage IFDs the original src), so the `dlang-nix` input now points at **metacraft-labs/dlang.nix** with `leaveDotGit` dropped. Upstream PR: PetarKirov/dlang.nix#229 (revert the fork once merged).

### 3. aztec installer hashes — `1375871`
The `install.aztec.network/{aztec,aztec-up}` "latest" scripts were re-published; hashes refreshed (independently verified against the genuine upstream installer).

### 4. Ubuntu cloud image — `6a98481`
The 24.04 cloud image was fetched from the rolling `release/` pointer (respun in place ~weekly). Pinned to the **immutable** `release-20260615/` dir + Canonical's published SHA256, so it can't silently drift again.

### 5. dub on darwin — `35f00f1`
dlang.nix's ldc 1.30 segfaults compiling dub 1.31's `build.d` on current macOS. The dub check now builds with the current nixpkgs ldc (1.41) on darwin (Linux unchanged).

### 6. Complete the Cachix→Attic cutover — `c42a4a8`
`c056211` removed Cachix Deploy + the cachix cache backend from the workflows but left 5 deployment guardrail checks asserting the pre-cutover contract. The inventory/gate/docs and the two guardrail checks now encode and **strictly** enforce the Attic-only end state (net assertions increase). No fabricated operational history: `liveCanaryCycles.recorded = 0`, `removalGateSatisfied = false`, and the manual `cachix deploy activate` rollback fallback is retained; a non-fabrication invariant blocks declaring full retirement without real canary/M7 evidence.

All fixes verified building on x86_64-linux (solunska) and aarch64-darwin.
