### PR TITLE
checks: re-fetch DCD source deterministically (drop leaveDotGit)

### DIFF
--- a/checks/packages-ci-matrix.nix
+++ b/checks/packages-ci-matrix.nix
@@ -41,12 +41,28 @@
           inherit (pkgs) terraform;
           inherit (self'.legacyPackages.inputs.terranix) terranix;
           inherit (self'.legacyPackages.inputs.dlang-nix)
-            dcd
             dscanner
             serve-d
             dmd
             ldc
             ;
+          # dlang.nix pins DCD's source with `leaveDotGit = true`, which makes the
+          # fixed-output derivation non-reproducible: the packed `.git` directory depends
+          # on GitHub's git-server behaviour, so the upstream-pinned hash silently drifted.
+          # It only stayed green while a previously-built output was available from the
+          # binary cache; once that output was gone the FOD was rebuilt and the hash
+          # mismatch surfaced. The build never needs `.git` (it stubs `git` and seds out
+          # `git describe`), so re-fetch the worktree deterministically without it.
+          # TODO: drop once the upstream fix lands in PetarKirov/dlang.nix.
+          dcd = self'.legacyPackages.inputs.dlang-nix.dcd.overrideAttrs (old: {
+            src = pkgs.fetchFromGitHub {
+              owner = "dlang-community";
+              repo = "DCD";
+              rev = "v${old.version}";
+              fetchSubmodules = true;
+              hash = "sha256-c5PAUjS2+DvY1QfI+whu0bqFQl0wDUzUUtfHjRFoieA=";
+            };
+          });
           inherit (self'.legacyPackages.inputs.ethereum-nix)
             mev-boost
             nethermind


### PR DESCRIPTION
dlang.nix pins DCD's source with `leaveDotGit = true`, making the fixed-output derivation **non-reproducible**: the packed `.git` directory depends on GitHub's git-server behaviour, so the upstream-pinned hash drifted (`sha256-3OWTnvDD…` → `sha256-9F0wHHcC…`).

### Why it broke only recently
The drift was latent. CI stayed green because a prior build of the DCD output was substitutable from the binary cache, so nix never re-fetched it. Once that cached output was no longer available (the Attic single-cache migration retired the buckets that held it), the FOD was rebuilt → re-fetched from GitHub → hash mismatch → every `flake-checks` run failed.

### Fix
The build never needs `.git` (it stubs `git` and seds out `git describe --tags`), so we override DCD's `src` to re-fetch the worktree deterministically (`fetchSubmodules = true`, no `leaveDotGit`). The new hash is content-addressed by the file tree and immune to git-server changes.

Verified: `nix build .#checks.x86_64-linux.dcd` → `dcd-0.15.2` on x86_64-linux (solunska).

`dcd` is the only dlang.nix package using `leaveDotGit`; `dscanner`/`serve-d`/`dub` are unaffected.

**TODO:** drop this override once the equivalent fix lands upstream in `PetarKirov/dlang.nix`.