### PR TITLE
flake: point dlang-nix back at upstream now that the DCD fix is merged

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,16 +382,16 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1782539495,
+        "lastModified": 1782557549,
         "narHash": "sha256-vBrB1dXAjdzn3Pv6TdFU4S3fNm455zEt5FPGlK9ImX8=",
-        "owner": "metacraft-labs",
+        "owner": "PetarKirov",
         "repo": "dlang.nix",
-        "rev": "8e658f73a709254d3fb7cc5d34bc32476c768734",
+        "rev": "24fb2dc3c7fc8bcabbdf1a96035a5d9acfaef31e",
         "type": "github"
       },
       "original": {
-        "owner": "metacraft-labs",
-        "ref": "fix/dcd-leavedotgit-reproducible",
+        "owner": "PetarKirov",
+        "ref": "feat/build-dub-package",
         "repo": "dlang.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -211,11 +211,7 @@
     };
 
     dlang-nix = {
-      # Fork of PetarKirov/dlang.nix's feat/build-dub-package branch with DCD's
-      # source FOD made reproducible (drops `leaveDotGit`, which packs a `.git`
-      # directory whose contents depend on the git-server and broke the pinned
-      # hash). Tracks PetarKirov/dlang.nix#229; switch back to upstream once merged.
-      url = "github:metacraft-labs/dlang.nix/fix/dcd-leavedotgit-reproducible";
+      url = "github:PetarKirov/dlang.nix/feat/build-dub-package";
       inputs = {
         flake-compat.follows = "flake-compat";
         flake-parts.follows = "flake-parts";


### PR DESCRIPTION
PetarKirov/dlang.nix#229 (drop `leaveDotGit` from DCD's source FOD) has merged into `feat/build-dub-package`, so the temporary `metacraft-labs/dlang.nix` fork is no longer needed.

Repoints the `dlang-nix` input back at upstream. The resolved tree is byte-identical to the fork (same `narHash`), and `dcd-0.15.2` still builds reproducibly on x86_64-linux (verified on solunska). Removes the fork dependency / TODO introduced in #516.