### PR TITLE
deployment: stop pull-agent/reconciler TERMing themselves mid-switch

### DIFF
--- a/modules/deployment/pull-agent.nix
+++ b/modules/deployment/pull-agent.nix
@@ -187,6 +187,13 @@
           description = "Pull and apply signed mcl desired-state manifests for ${cfg.targetName}";
           after = [ "network-online.target" ];
           wants = [ "network-online.target" ];
+          # This service runs switch-to-configuration, and the closure it activates
+          # contains a new version of this very unit (the mcl store path changes on
+          # every publish). With the default restartIfChanged, switch-to-configuration
+          # would restart mcl-deploy-agent mid-switch, sending TERM to the process
+          # performing the switch and aborting it. Keep the running invocation alive;
+          # the new unit definition takes effect on the next timer activation.
+          restartIfChanged = false;
           serviceConfig = {
             Type = "oneshot";
             ExecStart = "${pkgs.util-linux}/bin/flock -n ${escapeShellArg cfg.lockFile} ${agentCommand}";

--- a/modules/deployment/reconciler-timer.nix
+++ b/modules/deployment/reconciler-timer.nix
@@ -128,6 +128,11 @@
           description = "Reconcile pending mcl desired-state deployments";
           after = [ "network-online.target" ];
           wants = [ "network-online.target" ];
+          # Like mcl-deploy-agent, this runs switch-to-configuration and the
+          # activated closure contains a new version of this unit, so the default
+          # restartIfChanged would TERM the reconciler mid-switch. Keep the running
+          # invocation alive; the new definition applies on the next activation.
+          restartIfChanged = false;
           serviceConfig = {
             Type = "oneshot";
             ExecStart = "${pkgs.util-linux}/bin/flock -n ${escapeShellArg cfg.lockFile} ${reconcileCommand}";


### PR DESCRIPTION
The visibility added by the Attic migration surfaced a real, fleet-wide deployment bug.

## Symptom
On solunska-server: `mcl-deploy-agent` in `failed` state, **26 `switch failed` vs 20 `complete`** events, the agent repeatedly killed by `signal=TERM` mid-`switch`, and elevated host load from constant re-switching. Deployments land *unreliably* (flapping, not frozen).

## Root cause
`mcl-deploy-agent` and `mcl-deployment-reconciler` are `oneshot`, timer-driven services that run `switch-to-configuration`. The closure they activate contains a **new version of their own unit** (the `mcl` store path changes on every publish), so with the default `restartIfChanged`, `switch-to-configuration` restarts the unit **mid-switch** — sending `TERM` to the process performing the switch and aborting it. (`Restart=no`, yet the journal shows an instant `Stopped`→`Starting` right after `switching to system configuration` = the switch restarting it.) Classic NixOS self-deployment footgun.

## Fix
`restartIfChanged = false` on both self-switching units, so the running invocation completes; the new unit definition takes effect on the **next** timer activation. The `mcl-deployment-ssh-apply` path is an SSH forced-command (not a self-restarting systemd service) and is unaffected.

## Rollout
Fleet-wide (every pull-agent host). After merge + infra pin bump, roll out via direct `mcl deploy-ssh` (bypassing the pull-agent so it does not TERM itself while applying its own fix), solunska-first as canary, then the rest. Self-healing for every switch thereafter.

Verified: both deployment VM checks still evaluate.