### PR TITLE
deployment: correct the restartIfChanged rationale (not the wedge fix)

### DIFF
--- a/modules/deployment/pull-agent.nix
+++ b/modules/deployment/pull-agent.nix
@@ -187,12 +187,16 @@
           description = "Pull and apply signed mcl desired-state manifests for ${cfg.targetName}";
           after = [ "network-online.target" ];
           wants = [ "network-online.target" ];
-          # This service runs switch-to-configuration, and the closure it activates
-          # contains a new version of this very unit (the mcl store path changes on
-          # every publish). With the default restartIfChanged, switch-to-configuration
-          # would restart mcl-deploy-agent mid-switch, sending TERM to the process
-          # performing the switch and aborting it. Keep the running invocation alive;
-          # the new unit definition takes effect on the next timer activation.
+          # Hardening: this service runs switch-to-configuration, and the closure it
+          # activates contains a new version of this very unit (its mcl store path
+          # changes on every publish). Keep restartIfChanged false so a change to
+          # this unit can't make switch-to-configuration restart it mid-switch; the
+          # new definition takes effect on the next timer activation instead.
+          # NOTE: this is defensive, not the fix for the historical deploy wedge.
+          # That wedge was switch-to-configuration-ng blocking forever on a lost
+          # systemd JobRemoved D-Bus signal on the classic dbus-daemon, fixed in the
+          # consumer (infra) via services.dbus.implementation = "broker" plus a
+          # TimeoutStartSec bound on this service.
           restartIfChanged = false;
           serviceConfig = {
             Type = "oneshot";

--- a/modules/deployment/reconciler-timer.nix
+++ b/modules/deployment/reconciler-timer.nix
@@ -128,10 +128,12 @@
           description = "Reconcile pending mcl desired-state deployments";
           after = [ "network-online.target" ];
           wants = [ "network-online.target" ];
-          # Like mcl-deploy-agent, this runs switch-to-configuration and the
-          # activated closure contains a new version of this unit, so the default
-          # restartIfChanged would TERM the reconciler mid-switch. Keep the running
-          # invocation alive; the new definition applies on the next activation.
+          # Hardening, same rationale as mcl-deploy-agent: this runs
+          # switch-to-configuration and the activated closure contains a new version
+          # of this unit, so keep restartIfChanged false to avoid restarting it
+          # mid-switch. Defensive only -- the historical deploy wedge was a lost
+          # dbus JobRemoved signal blocking switch-to-configuration-ng, fixed in the
+          # consumer via dbus-broker plus a TimeoutStartSec bound, not here.
           restartIfChanged = false;
           serviceConfig = {
             Type = "oneshot";


### PR DESCRIPTION
Follow-up to #522. Keeps `restartIfChanged = false` on `mcl-deploy-agent` and `mcl-deployment-reconciler` as deliberate hardening, but **corrects the misleading comments**.

#522's comments claimed the change fixed the solunska deploy wedge via a switch-to-configuration self-restart loop. That diagnosis was wrong. The real root cause (metacraft-labs/infra#1168) was `switch-to-configuration-ng` blocking forever on a **lost systemd `JobRemoved` D-Bus signal** on the classic `dbus-daemon`; the fix is `services.dbus.implementation = "broker"` + a `TimeoutStartSec` bound in the consumer.

Comment-only change; `restartIfChanged = false` stays as defensive hardening for self-switching units, now honestly documented as such.