### PR TITLE
desktop-vms: drop removed virtualisation.libvirtd.qemu.ovmf (NixOS 26.05)

### DIFF
--- a/modules/virtualisation/desktop-vms.nix
+++ b/modules/virtualisation/desktop-vms.nix
@@ -828,10 +828,12 @@
               package = mkDefault pkgs.qemu_kvm;
               runAsRoot = mkDefault true;
               swtpm.enable = mkDefault true;
-              ovmf = {
-                enable = mkDefault true;
-                packages = mkDefault [ ovmfPackage ];
-              };
+              # virtualisation.libvirtd.qemu.ovmf was removed in NixOS 26.05 —
+              # all OVMF images distributed with QEMU are now available by
+              # default. The VMs here don't rely on libvirt's firmware auto-
+              # selection anyway: each domain references the Secure-Boot/TPM
+              # OVMF explicitly via ovmfCodePath/ovmfVarsPath (see above), which
+              # still come from the ovmfPackage override.
               # VirtIO-FS requires memory backing access
               verbatimConfig = ''
                 memory_backing_dir = "/dev/shm"


### PR DESCRIPTION
NixOS 26.05 removed the `virtualisation.libvirtd.qemu.ovmf` submodule (now a `mkRemovedOptionModule` stub): all OVMF images shipped with QEMU are available by default, and any config setting the option fails evaluation, so `desktop-vms` no longer evaluates on 26.05.

Drops the `ovmf = { enable; packages = [ ovmfPackage ]; }` block from the libvirtd QEMU settings. No firmware behaviour change: VMs reference the Secure-Boot/TPM OVMF explicitly via `ovmfCodePath`/`ovmfVarsPath` (still from the `ovmfPackage` override), not libvirt firmware auto-selection.

Verified by evaluating a downstream 26.05 host (`home-pc`, GPU passthrough + Windows VM) to a derivation. Not runtime-tested.