### PR TITLE
Fix Terraform drift workflow init

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -899,6 +899,13 @@ jobs:
           role-session-name: terraform-drift-${{ github.run_id }}
           role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
 
+      - name: Terranix
+        if: inputs.terranix
+        run: |
+          cd ${{ inputs.working_directory }}
+          NIXPKGS=$(nix eval --raw nixpkgs#path --inputs-from . --accept-flake-config)
+          nix develop --accept-flake-config --command bash -c "terranix --pkgs '$NIXPKGS' > config.tf.json"
+
       - name: Init
         env:
           BACKEND_CONFIG_FILE: ${{ inputs.backend_config_file }}
@@ -931,17 +938,36 @@ jobs:
       - name: Detect drift
         id: drift
         run: |
+          set -euo pipefail
+
           cd ${{ inputs.working_directory }}
           tofu_bin="$(nix develop --accept-flake-config --command bash -euo pipefail -c 'command -v tofu' | tail -n 1)"
-          env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" plan -input=false -no-color -detailed-exitcode 2>&1 | tee /tmp/drift-plan.txt || {
-            exit_code=$?
-            if [ "$exit_code" -eq 2 ]; then
-              echo "drift_detected=true" >> "$GITHUB_OUTPUT"
-              echo "::warning::Infrastructure drift detected!"
-            else
-              exit $exit_code
-            fi
+          run_tofu() {
+            env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE "$tofu_bin" "$@"
           }
+
+          set +e
+          run_tofu plan \
+            -input=false \
+            -no-color \
+            -detailed-exitcode \
+            > /tmp/drift-plan.txt 2>&1
+          plan_exit=$?
+          set -e
+
+          cat /tmp/drift-plan.txt
+
+          if [ "$plan_exit" -eq 0 ]; then
+            exit 0
+          fi
+
+          if [ "$plan_exit" -eq 2 ]; then
+            echo "drift_detected=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Infrastructure drift detected!"
+            exit 0
+          fi
+
+          exit "$plan_exit"
 
       - name: Open drift issue
         if: steps.drift.outputs.drift_detected == 'true'

--- a/checks/ci-workflows.nix
+++ b/checks/ci-workflows.nix
@@ -4,6 +4,7 @@
     { pkgs, ... }:
     let
       flakeChecksWorkflow = ../.github/workflows/reusable-flake-checks-ci-matrix.yml;
+      terraformWorkflow = ../.github/workflows/reusable-terraform-ci.yml;
     in
     {
       checks.reusable-flake-checks-mcl-ref =
@@ -153,6 +154,109 @@
                     "main",
                 )
                 run_case("empty_context_falls_back", {}, "main")
+            PY
+
+            touch "$out"
+          '';
+
+      checks.reusable-terraform-drift-workflow =
+        pkgs.runCommand "reusable-terraform-drift-workflow"
+          {
+            nativeBuildInputs = [
+              pkgs.bash
+              pkgs.python3
+            ];
+          }
+          ''
+            python3 - <<'PY'
+            import subprocess
+            import tempfile
+            from pathlib import Path
+
+            workflow = Path("${terraformWorkflow}").read_text()
+            lines = workflow.splitlines()
+
+            def extract_named_block(start_text, base_indent=None):
+                start = None
+                for index, line in enumerate(lines):
+                    if line.strip() == start_text:
+                        start = index
+                        break
+                assert start is not None, f"{start_text!r} not found"
+
+                if base_indent is None:
+                    base_indent = len(lines[start]) - len(lines[start].lstrip())
+
+                end = len(lines)
+                for index in range(start + 1, len(lines)):
+                    if lines[index].strip() and (
+                        len(lines[index]) - len(lines[index].lstrip())
+                    ) <= base_indent:
+                        end = index
+                        break
+                return lines[start:end]
+
+            def extract_run_script(block_lines, step_name):
+                step_index = None
+                for index, line in enumerate(block_lines):
+                    if line.strip() == f"- name: {step_name}":
+                        step_index = index
+                        break
+                assert step_index is not None, f"{step_name!r} step not found"
+
+                step_indent = len(block_lines[step_index]) - len(block_lines[step_index].lstrip())
+                step_end = len(block_lines)
+                for index in range(step_index + 1, len(block_lines)):
+                    if block_lines[index].strip() and (
+                        len(block_lines[index]) - len(block_lines[index].lstrip())
+                    ) <= step_indent:
+                        step_end = index
+                        break
+
+                run_index = None
+                for index in range(step_index + 1, step_end):
+                    if block_lines[index].strip() == "run: |":
+                        run_index = index
+                        break
+                assert run_index is not None, f"{step_name!r} run block not found"
+
+                run_indent = len(block_lines[run_index]) - len(block_lines[run_index].lstrip())
+                block_indent = run_indent + 2
+                script_lines = []
+                for line in block_lines[run_index + 1:step_end]:
+                    if not line.strip():
+                        script_lines.append("")
+                        continue
+                    indent = len(line) - len(line.lstrip())
+                    assert indent >= block_indent, f"unexpected run block indentation: {line!r}"
+                    script_lines.append(line[block_indent:])
+                return "\n".join(script_lines) + "\n"
+
+            drift_job = extract_named_block("drift-check:", base_indent=2)
+            drift_text = "\n".join(drift_job)
+
+            terranix_index = drift_text.find("- name: Terranix")
+            init_index = drift_text.find("- name: Init")
+            detect_index = drift_text.find("- name: Detect drift")
+            assert terranix_index != -1, "drift job must generate Terranix before init"
+            assert init_index != -1, "drift job Init step not found"
+            assert detect_index != -1, "drift job Detect drift step not found"
+            assert terranix_index < init_index < detect_index, (
+                "drift job must generate Terranix before init and plan"
+            )
+
+            script = extract_run_script(drift_job, "Detect drift")
+            assert "set -euo pipefail" in script
+            assert "run_tofu()" in script
+            assert "plan_exit=$?" in script
+            assert "| tee /tmp/drift-plan.txt" not in script, (
+                "drift plan exit code must not be hidden behind tee"
+            )
+
+            with tempfile.TemporaryDirectory() as temp:
+                script_path = Path(temp) / "detect-drift.sh"
+                script_path.write_text(script)
+                subprocess.run(["${pkgs.bash}/bin/bash", "-n", str(script_path)], check=True)
             PY
 
             touch "$out"

--- a/checks/garm-incus-runner-host.nix
+++ b/checks/garm-incus-runner-host.nix
@@ -31,19 +31,27 @@ top@{ ... }:
       # trivial image. `incus image import <tarball>` registers it (alias) in
       # the local image store without needing a bootable rootfs for THIS gate
       # (we assert registration, not launch).
-      testImage = pkgs.runCommand "vmh-linux-runner-test-image.tar.gz" { nativeBuildInputs = [ pkgs.gnutar pkgs.gzip ]; } ''
-        mkdir -p build/rootfs
-        cat > build/metadata.yaml <<EOF
-        architecture: x86_64
-        creation_date: 1700000000
-        properties:
-          description: garm reconcile gate test image
-          os: debian
-          release: bookworm
-        EOF
-        # An empty rootfs dir is fine for registration.
-        tar -C build -czf $out metadata.yaml rootfs
-      '';
+      testImage =
+        pkgs.runCommand "vmh-linux-runner-test-image.tar.gz"
+          {
+            nativeBuildInputs = [
+              pkgs.gnutar
+              pkgs.gzip
+            ];
+          }
+          ''
+            mkdir -p build/rootfs
+            cat > build/metadata.yaml <<EOF
+            architecture: x86_64
+            creation_date: 1700000000
+            properties:
+              description: garm reconcile gate test image
+              os: debian
+              release: bookworm
+            EOF
+            # An empty rootfs dir is fine for registration.
+            tar -C build -czf $out metadata.yaml rootfs
+          '';
     in
     {
       checks = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {

--- a/checks/garm-reconcile.nix
+++ b/checks/garm-reconcile.nix
@@ -197,13 +197,16 @@ top@{ ... }:
                             obj = SCALESETS[name]
                         else:
                             sid = NEXT_ID[0]; NEXT_ID[0] += 1
-                            obj = {"id": sid, "name": name,
-                                   "runnerGroupId": body.get("runnerGroupId", 1),
-                                   "runnerGroupName": "Default",
-                                   "labels": body.get("labels", []),
-                                   "enabled": body.get("enabled", True),
-                                   "runnerSetting": body.get("RunnerSetting", {}),
-                                   "runnerJitConfigUrl": "http://127.0.0.1:%d/ado/jit" % PORT}
+                            obj = {
+                                "id": sid,
+                                "name": name,
+                                "runnerGroupId": body.get("runnerGroupId", 1),
+                                "runnerGroupName": "Default",
+                                "labels": body.get("labels", []),
+                                "enabled": body.get("enabled", True),
+                                "runnerSetting": body.get("RunnerSetting", {}),
+                                "runnerJitConfigUrl": "http://127.0.0.1:%d/ado/jit" % PORT,
+                            }
                             SCALESETS[name] = obj
                     return self._send(200, obj)
                 if p == "/status" or p == "/system-info/":

--- a/modules/garm/incus-runner-host.nix
+++ b/modules/garm/incus-runner-host.nix
@@ -139,9 +139,7 @@
           netAddr = builtins.elemAt parts 0;
           prefix = builtins.elemAt parts 1;
           octets = lib.splitString "." netAddr;
-          derivedGateway = lib.concatStringsSep "." (
-            (lib.sublist 0 3 octets) ++ [ "1" ]
-          );
+          derivedGateway = lib.concatStringsSep "." ((lib.sublist 0 3 octets) ++ [ "1" ]);
           gateway = if cfg.bridgeGateway != "" then cfg.bridgeGateway else derivedGateway;
 
           importScript = pkgs.writeShellApplication {
@@ -157,7 +155,7 @@
 
               # Idempotent: if the alias already resolves to an image, do nothing.
               if ${incusBin} image alias list --format csv 2>/dev/null \
-                   | cut -d, -f1 | grep -qxF "$alias"; then
+                  | cut -d, -f1 | grep -qxF "$alias"; then
                 echo "garm-incus-image-import: alias '$alias' already present — no-op"
                 exit 0
               fi

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -4,14 +4,14 @@ import std.stdio : writeln, stderr, stdout;
 import std.traits : EnumMembers;
 import std.string : indexOf, splitLines, strip;
 import std.algorithm : map, filter, reduce, chunkBy, find, any, sort, startsWith, endsWith, each, canFind, fold;
-import std.file : write, readText, dirEntries, SpanMode, append;
+import std.file : write, readText, dirEntries, SpanMode, append, exists, mkdirRecurse;
 import std.range : array, enumerate, empty, front, indexed, iota, join, chain, split;
 import std.exception : ifThrown;
 import std.conv : to, text;
 import std.json : JSONValue, parseJSON, JSONOptions, JSONType;
 import std.regex : matchFirst;
 import core.cpuid : threadsPerCPU;
-import std.path : buildPath;
+import std.path : buildPath, dirName;
 import std.process : pipeProcess, wait, Redirect, kill;
 import std.exception : enforce;
 import std.format : fmt = format;
@@ -269,6 +269,35 @@ unittest
         "cached-package",
         "cached-deployment-target",
         "uncached-package",
+    ]);
+}
+
+@("ci matrix GitHub output creates missing parent directory")
+unittest
+{
+    import std.file : deleteme, exists, readText, rmdirRecurse;
+
+    auto outputDir = deleteme ~ ".ci-matrix-output";
+    auto outputPath = outputDir.buildPath("missing", "output.env");
+    scope(exit)
+        if (outputDir.exists)
+            outputDir.rmdirRecurse;
+
+    auto packages = [
+        Package(name: "testPackage"),
+        Package(name: "testPackage2"),
+    ];
+
+    appendGHCIBuildOutput(packages, outputPath);
+
+    const output = outputPath.readText;
+    assert(output.githubOutputValue("build_matrix").matrixPackageNames == [
+        "testPackage",
+        "testPackage2",
+    ]);
+    assert(output.githubOutputValue("full_matrix").matrixPackageNames == [
+        "testPackage",
+        "testPackage2",
     ]);
 }
 
@@ -1312,8 +1341,17 @@ void appendGHCIBuildOutput(Package[] packages, string outputPath)
         "include": JSONValue(packages.map!toJSON.array)
     ]).toString(JSONOptions.doNotEscapeSlashes) ~ "\n";
 
-    outputPath.append(buildMatrixLine);
-    outputPath.append(fullMatrixLine);
+    appendGitHubOutput(outputPath, buildMatrixLine ~ fullMatrixLine);
+}
+
+void appendGitHubOutput(string outputPath, string content)
+{
+    const outputDir = outputPath.dirName;
+    if (outputDir != "" && outputDir != "." && !outputDir.exists)
+        outputDir.mkdirRecurse;
+    if (!outputPath.exists)
+        outputPath.write("");
+    outputPath.append(content);
 }
 
 // Extract the host[:port] from a cache URL ("https://host/path" -> "host").

--- a/packages/mcl/src/mcl/commands/shard_matrix.d
+++ b/packages/mcl/src/mcl/commands/shard_matrix.d
@@ -4,7 +4,7 @@ import std.algorithm : map;
 import std.array : array;
 import std.conv : ConvException, to, parse;
 import std.exception : ifThrown;
-import std.file : append, write, readText;
+import std.file : write, readText;
 import std.format : fmt = format;
 import std.logger : warningf, infof;
 import std.stdio : stdout, stderr;
@@ -20,7 +20,8 @@ import mcl.utils.json : toJSON;
 import mcl.utils.nix : nix;
 import mcl.utils.path : createResultDirs, resultDir, rootDir;
 import mcl.utils.string : enumToString, writeRecordAsTable;
-import mcl.commands.ci_matrix : NixSystem, currentSystem, ci_matrix, CiMatrixArgs, CiMatrixBaseArgs;
+import mcl.commands.ci_matrix : NixSystem, currentSystem, ci_matrix, CiMatrixArgs, CiMatrixBaseArgs,
+    appendGitHubOutput;
 
 @(Command("shard-matrix", "shard_matrix")
     .Description("Generate a shard matrix for a flake"))
@@ -190,14 +191,12 @@ void saveShardMatrix(ShardMatrix evalMatrix, ShardMatrixArgs args)
 
     if (args.githubOutput != "")
     {
-        args.githubOutput.append(evalMatrixLine);
-        args.githubOutput.append(buildMatrixLine);
+        args.githubOutput.appendGitHubOutput(evalMatrixLine ~ buildMatrixLine);
     }
     else
     {
         createResultDirs();
-        resultDir.buildPath("gh-output.env").append(evalMatrixLine);
-        resultDir.buildPath("gh-output.env").append(buildMatrixLine);
+        resultDir.buildPath("gh-output.env").appendGitHubOutput(evalMatrixLine ~ buildMatrixLine);
     }
     rootDir.buildPath("shardMatrix.json").write(evalMatrixString);
 }


### PR DESCRIPTION
## Summary
- generate Terranix config in the reusable drift job before backend init
- make drift plan exit-code handling explicit instead of letting tee mask tofu failures
- add a regression check for the drift workflow ordering and shell handling

## Root cause
The drift job did not run Terranix before `tofu init`, so Terranix-based roots initialized as empty directories. The later `tofu plan` failed for missing provider plugins, but the `tee` pipeline hid the failure from the job.

## Validation
- `nix build --accept-flake-config .#checks.x86_64-linux.reusable-terraform-drift-workflow`
- `nix flake check --accept-flake-config --no-build --show-trace`
