### PR TITLE
fix(ci): harden ephemeral workflows and GARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
       pull-requests: write
     secrets: inherit
     with:
+      # Foundry takes longer than vm-harness's currently deployed 600-second
+      # default. Remove this override after this PR's provider fix is deployed.
+      foundry-darwin-bootstrap-runner: '["aarch64-darwin"]'
       runners: |
         {
           "x86_64-linux": [

--- a/.github/workflows/netbird-attic-smoke.yml
+++ b/.github/workflows/netbird-attic-smoke.yml
@@ -55,8 +55,8 @@ jobs:
           # token is 401 — that is the defence-in-depth invariant.
           for attempt in $(seq 1 30); do
             if curl -fsS --connect-timeout 2 --max-time 5 \
-                 -H "Authorization: Bearer $ATTIC_TOKEN" \
-                 "$ATTIC_SUBSTITUTER/nix-cache-info" >/dev/null; then
+                -H "Authorization: Bearer $ATTIC_TOKEN" \
+                "$ATTIC_SUBSTITUTER/nix-cache-info" >/dev/null; then
               echo "authenticated read of $ATTIC_SUBSTITUTER succeeded"
               break
             fi

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -354,13 +354,6 @@ jobs:
       - name: Merge matrices
         if: needs.eval-matrix.result == 'success'
         id: merge
-        env:
-          # Authenticate mcl's cache-status (narinfo) probe to the private
-          # Attic cache; scoped to the Attic host inside mcl. Without this the
-          # per-derivation probe HEADs a token-gated cache unauthenticated and
-          # cannot identify cached derivations, scheduling redundant builds.
-          ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} merge-ci-matrices
 
       - name: Generate CI matrix comment

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -50,8 +50,11 @@ on:
         required: false
         type: string
     secrets:
+      ATTIC_PULL_TOKEN:
+        description: 'Read-only Attic token for cache substitution and status probes'
+        required: false
       ATTIC_TOKEN:
-        description: 'Attic push token for optional deployment closure mirroring'
+        description: 'Attic push token for optional deployment closure mirroring and pull-token fallback'
         required: false
       NIX_GITHUB_TOKEN:
         description: GitHub token to add as access-token in nix.conf
@@ -158,7 +161,7 @@ jobs:
         shell: bash
         env:
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: |
           [ -n "$ATTIC_SUBSTITUTER" ] && [ -n "$ATTIC_TOKEN" ] || exit 0
           h="${ATTIC_SUBSTITUTER#http://}"; h="${h#https://}"; h="${h%%/*}"
@@ -178,7 +181,7 @@ jobs:
           # Authenticate mcl's cache-status (narinfo) probe to the private
           # Attic cache; scoped to the Attic host inside mcl.
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} shard-matrix
 
       - name: Post CI matrix comment
@@ -213,7 +216,7 @@ jobs:
         shell: bash
         env:
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: |
           [ -n "$ATTIC_SUBSTITUTER" ] && [ -n "$ATTIC_TOKEN" ] || exit 0
           h="${ATTIC_SUBSTITUTER#http://}"; h="${h#https://}"; h="${h%%/*}"
@@ -234,7 +237,7 @@ jobs:
           # Authenticate mcl's cache-status (narinfo) probe to the private
           # Attic cache; scoped to the Attic host inside mcl.
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: |
           ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} -- ci-matrix \
             --flake-attribute-path "${{ matrix.flakeAttrPath }}" \
@@ -278,7 +281,7 @@ jobs:
         shell: bash
         env:
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: |
           [ -n "$ATTIC_SUBSTITUTER" ] && [ -n "$ATTIC_TOKEN" ] || exit 0
           h="${ATTIC_SUBSTITUTER#http://}"; h="${h#https://}"; h="${h%%/*}"
@@ -304,7 +307,7 @@ jobs:
           # Authenticate mcl's cache-status (narinfo) probe (same reason as the
           # Merge matrices step below).
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -355,10 +358,9 @@ jobs:
           # Authenticate mcl's cache-status (narinfo) probe to the private
           # Attic cache; scoped to the Attic host inside mcl. Without this the
           # per-derivation probe HEADs a token-gated cache unauthenticated and
-          # crashes with HTTP 401, silently skipping Publish Deployment
-          # Manifests and blocking deploys fleet-wide.
+          # cannot identify cached derivations, scheduling redundant builds.
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} merge-ci-matrices
 
       - name: Generate CI matrix comment
@@ -366,7 +368,7 @@ jobs:
           IS_INITIAL: 'true'
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
           PRECALC_MATRIX: ${{ steps.merge.outputs.full_matrix }}
         run: ${{ needs.compute-mcl-ref.outputs.mcl_flake_cmd }} print-table
 
@@ -427,7 +429,7 @@ jobs:
         shell: bash
         env:
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
         run: |
           [ -n "$ATTIC_SUBSTITUTER" ] && [ -n "$ATTIC_TOKEN" ] || exit 0
           h="${ATTIC_SUBSTITUTER#http://}"; h="${h#https://}"; h="${h%%/*}"
@@ -761,7 +763,7 @@ jobs:
           IS_INITIAL: 'false'
           EXTRA_CACHE_URLS: ${{ vars.SUBSTITUTERS }}
           ATTIC_SUBSTITUTER: ${{ vars.ATTIC_SUBSTITUTER }}
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}
           PRECALC_MATRIX: ${{
             needs.merge-matrices.result == 'success' &&
             needs.merge-matrices.outputs.full_matrix ||

--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -29,6 +29,11 @@ on:
         default: '["eph-linux-x64"]'
         required: false
         type: string
+      foundry-darwin-bootstrap-runner:
+        description: 'Temporary JSON-encoded runner class for Foundry on Darwin while vm-harness lifetime fixes are deployed'
+        default: ''
+        required: false
+        type: string
       push-deployment-caches:
         description: 'Push deployment target closures to configured deployment cache backends'
         default: false
@@ -395,9 +400,17 @@ jobs:
         )}}
 
     name: ${{ matrix.name }} | ${{ matrix.system }}
-    runs-on: ${{ matrix.ghRunner }}
+    # The provider fix in this PR cannot affect the runner executing this PR.
+    # Keep this narrow escape hatch until that fix is deployed, then remove it.
+    runs-on: >-
+      ${{
+        matrix.name == 'foundry' &&
+        matrix.system == 'aarch64-darwin' &&
+        inputs.foundry-darwin-bootstrap-runner != '' &&
+        fromJSON(inputs.foundry-darwin-bootstrap-runner) ||
+        matrix.ghRunner
+      }}
     continue-on-error: ${{ matrix.allowedToFail }}
-
     steps:
       - name: No builds required
         if: ${{ matrix.noop }}

--- a/.github/workflows/reusable-nix-diff.yml
+++ b/.github/workflows/reusable-nix-diff.yml
@@ -50,6 +50,15 @@ jobs:
           nix-gitlab-token: ${{ secrets.NIX_GITLAB_TOKEN }}
           nix-gitlab-domain: ${{ vars.NIX_GITLAB_DOMAIN }}
 
+      - name: Provision nix-diff workflow tools
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          jq_store_path="$(nix build --no-link --print-out-paths 'nixpkgs#jq^bin')"
+          test -x "$jq_store_path/bin/jq"
+          echo "$jq_store_path/bin" >> "$GITHUB_PATH"
+
       - name: Discover machines and generate attributes
         id: discover
         run: |

--- a/checks/ci-workflows.nix
+++ b/checks/ci-workflows.nix
@@ -159,6 +159,77 @@
             touch "$out"
           '';
 
+      checks.reusable-flake-checks-attic-credentials =
+        pkgs.runCommand "reusable-flake-checks-attic-credentials"
+          {
+            nativeBuildInputs = [ pkgs.python3 ];
+          }
+          ''
+            python3 - <<'PY'
+            from pathlib import Path
+
+            workflow = Path("${flakeChecksWorkflow}").read_text()
+            lines = workflow.splitlines()
+
+            def named_steps(name):
+                blocks = []
+                for start, line in enumerate(lines):
+                    if line.strip() != f"- name: {name}":
+                        continue
+                    step_indent = len(line) - len(line.lstrip())
+                    end = len(lines)
+                    for index in range(start + 1, len(lines)):
+                        if lines[index].strip() and (
+                            len(lines[index]) - len(lines[index].lstrip())
+                        ) <= step_indent:
+                            end = index
+                            break
+                    blocks.append("\n".join(lines[start:end]))
+                return blocks
+
+            declaration = workflow.split("\njobs:\n", 1)[0]
+            assert "      ATTIC_PULL_TOKEN:\n" in declaration
+            assert "      ATTIC_TOKEN:\n" in declaration
+
+            pull_expression = (
+                "ATTIC_TOKEN: "
+                + "$"
+                + "{{ secrets.ATTIC_PULL_TOKEN || secrets.ATTIC_TOKEN }}"
+            )
+
+            auth_steps = named_steps("Authenticate nix to the private Attic cache")
+            assert len(auth_steps) == 4, f"expected four Nix pull-auth steps, got {len(auth_steps)}"
+            for step in auth_steps:
+                assert pull_expression in step, "Nix cache auth must prefer the pull-only token"
+
+            probe_step_names = [
+                "Generate Shard Matrix",
+                "Generate CI Matrix",
+                "Regenerate CI matrix shards when artifacts are unavailable",
+                "Generate CI matrix comment",
+                "Print CI Matrix",
+            ]
+            for name in probe_step_names:
+                steps = named_steps(name)
+                assert len(steps) == 1, f"expected one {name!r} step, got {len(steps)}"
+                assert pull_expression in steps[0], f"{name} must prefer the pull-only token"
+
+            merge_steps = named_steps("Merge matrices")
+            assert len(merge_steps) == 1
+            assert "ATTIC_" not in merge_steps[0], "matrix merging does not need Attic credentials"
+
+            push_step_name = "Push deployment closure caches " + "$" + "{{ matrix.name }}"
+            push_steps = named_steps(push_step_name)
+            assert len(push_steps) == 1
+            assert "secrets.ATTIC_TOKEN" in push_steps[0]
+            assert "secrets.ATTIC_PULL_TOKEN" not in push_steps[0], (
+                "deployment cache publication must retain the push credential"
+            )
+            PY
+
+            touch "$out"
+          '';
+
       checks.reusable-terraform-drift-workflow =
         pkgs.runCommand "reusable-terraform-drift-workflow"
           {

--- a/checks/deployment-production-cutover.nix
+++ b/checks/deployment-production-cutover.nix
@@ -506,6 +506,10 @@ top@{ config, ... }:
                   workflow,
               ), "workflow must default results-runner to the ephemeral Linux class"
               assert "runs-on: ''${{ fromJSON(inputs.non-nix-runner) }}" in workflow, "non-nix helper jobs must use JSON runner labels"
+              assert "foundry-darwin-bootstrap-runner: '[\"aarch64-darwin\"]'" in repo_workflow, "only the long Foundry Darwin bootstrap build must use the persistent runner class"
+              assert "matrix.name == 'foundry'" in workflow, "Foundry bootstrap runner selection must stay package-scoped"
+              assert "matrix.system == 'aarch64-darwin'" in workflow, "Foundry bootstrap runner selection must stay Darwin-scoped"
+              assert "inputs.foundry-darwin-bootstrap-runner" in workflow, "Foundry bootstrap runner override must remain opt-in for reusable-workflow callers"
               results_job_match = re.search(
                   r"(?ms)^  results:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
                   workflow,

--- a/checks/deployment-production-cutover.nix
+++ b/checks/deployment-production-cutover.nix
@@ -492,19 +492,19 @@ top@{ config, ... }:
               assert re.search(
                   r"non-nix-runner:\s*\n"
                   r"\s+description:.*\n"
-                  r"\s+default:\s*'\[\"self-hosted\",\s*\"nixos\",\s*\"x86-64-v2\",\s*\"bare-metal\"\]'\s*\n"
+                  r"\s+default:\s*'\[\"eph-linux-x64\"\]'\s*\n"
                   r"\s+required:\s*false\s*\n"
                   r"\s+type:\s*string",
                   workflow,
-              ), "workflow must expose non-nix-runner defaulting to self-hosted labels"
+              ), "workflow must default non-nix-runner to the ephemeral Linux class"
               assert re.search(
                   r"results-runner:\s*\n"
                   r"\s+description:.*\n"
-                  r"\s+default:\s*'\[\"self-hosted\",\s*\"nixos\",\s*\"x86-64-v2\",\s*\"bare-metal\"\]'\s*\n"
+                  r"\s+default:\s*'\[\"eph-linux-x64\"\]'\s*\n"
                   r"\s+required:\s*false\s*\n"
                   r"\s+type:\s*string",
                   workflow,
-              ), "workflow must expose results-runner defaulting to self-hosted labels"
+              ), "workflow must default results-runner to the ephemeral Linux class"
               assert "runs-on: ''${{ fromJSON(inputs.non-nix-runner) }}" in workflow, "non-nix helper jobs must use JSON runner labels"
               results_job_match = re.search(
                   r"(?ms)^  results:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",

--- a/checks/garm-api-watchdog.nix
+++ b/checks/garm-api-watchdog.nix
@@ -222,9 +222,13 @@ top@{ ... }:
                 )
 
             with subtest("the failure counter reset to 0 after recovery"):
-                # After a healthy probe the persisted counter is 0 again.
+                # After a healthy probe the persisted counter is 0 again. The
+                # watchdog deliberately owns a private StateDirectory; reading
+                # garm's StateDirectory here would miss the file and regress the
+                # permission boundary that prevents the root-run oneshot from
+                # re-chowning GARM's SQLite state.
                 withwatchdog.wait_until_succeeds(
-                    "test \"$(cat /var/lib/garm/healthcheck-consecutive-failures)\" = 0",
+                    "test \"$(cat /var/lib/garm-healthcheck/healthcheck-consecutive-failures)\" = 0",
                     timeout=15,
                 )
           '';

--- a/checks/garm-reconcile.nix
+++ b/checks/garm-reconcile.nix
@@ -26,6 +26,9 @@ top@{ ... }:
   # (that is the live e2e, out of scope here) — only the management API.
   #
   # Assertions (the milestone's a–e):
+  #   (a0) STARTUP-RESTART — force GARM's first post-start check to fail;
+  #                 systemd restarts GARM while reconcile's own readiness loop
+  #                 spans the gap and still converges successfully.
   #   (a) APPLY   — after activation the reconcile ran and GARM's DB holds
   #                 EXACTLY the declared orgs/creds/scale-sets (garm-cli list).
   #   (b) IDEMPOTENT — a SECOND `systemctl start garm-reconcile` makes ZERO
@@ -252,10 +255,23 @@ top@{ ... }:
       adminPw = "correct-horse-battery-staple-9!";
       adminPwFile = pkgs.writeText "garm-reconcile-admin-pw" adminPw;
 
+      # Deterministically exercise the production startup recovery contract on
+      # one node. The first ExecStartPost fails after the GARM process launches;
+      # Restart=always then starts it again and this check succeeds thereafter.
+      failInitialGarmStartOnce = pkgs.writeShellScript "garm-test-fail-initial-start-once" ''
+        marker=/var/lib/garm/test-failed-initial-start
+        if [ ! -e "$marker" ]; then
+          : > "$marker"
+          echo "garm-test: deliberately failing first post-start check"
+          exit 1
+        fi
+      '';
+
       # Common node config: garm + reconcile pointed at the mock endpoint.
       mkNode =
         {
           pruneUnmanaged,
+          failInitialGarmStart ? false,
           # When true the reconcile oneshot is NOT wanted by multi-user.target
           # (it does not auto-run at boot) and a KNOWN admin password is staged,
           # so the test can pre-populate GARM's DB by hand and then start the
@@ -289,6 +305,13 @@ top@{ ... }:
           # a no-op (mirrors the live high-mem-server case: EXP2/3/4 state was
           # created outside the reconcile).
           systemd.services.garm-reconcile.wantedBy = lib.mkIf adoptExisting (lib.mkForce [ ]);
+
+          # The reconcile must survive GARM's supported Restart=always path. Put
+          # the fail-once hook before the real API bind verification so the
+          # second start still proves the production post-start check.
+          systemd.services.garm.serviceConfig.ExecStartPost = lib.mkIf failInitialGarmStart (
+            lib.mkBefore [ failInitialGarmStartOnce ]
+          );
 
           services.garm = {
             enable = true;
@@ -366,7 +389,10 @@ top@{ ... }:
           name = "t_garm_reconcile";
 
           nodes.pruneoff = mkNode { pruneUnmanaged = false; };
-          nodes.pruneon = mkNode { pruneUnmanaged = true; };
+          nodes.pruneon = mkNode {
+            pruneUnmanaged = true;
+            failInitialGarmStart = true;
+          };
           nodes.adopt = mkNode {
             pruneUnmanaged = false;
             adoptExisting = true;
@@ -402,8 +428,59 @@ top@{ ... }:
                 node.wait_for_unit("garm.service")
                 node.wait_for_open_port(${toString mockPort})
                 node.wait_for_open_port(9997)
+                # A failed initial GARM bind verification is recovered by
+                # Restart=always. Reconcile must wait through that recovery,
+                # rather than inherit a permanent dependency failure.
+                wants = node.succeed(
+                    "systemctl show garm-reconcile.service -p Wants --value"
+                ).split()
+                requires = node.succeed(
+                    "systemctl show garm-reconcile.service -p Requires --value"
+                ).split()
+                assert "garm.service" in wants, f"reconcile does not want GARM: {wants}"
+                assert "garm.service" not in requires, \
+                    f"reconcile still hard-requires GARM and cannot span a startup restart: {requires}"
                 # The reconcile oneshot is wanted by multi-user.target.
                 node.wait_for_unit("garm-reconcile.service")
+
+            with subtest("(a0) STARTUP-RESTART: reconcile spans GARM's recovered first start"):
+                pruneon.succeed("test -e /var/lib/garm/test-failed-initial-start")
+                injected_failures = int(pruneon.succeed(
+                    "journalctl -u garm.service --no-pager "
+                    "| grep -c 'garm-test: deliberately failing first post-start check'"
+                ).strip())
+                assert injected_failures == 1, \
+                    f"expected exactly one injected GARM start failure, got {injected_failures}"
+                restarts = int(pruneon.succeed(
+                    "systemctl show garm.service -p NRestarts --value"
+                ).strip())
+                assert restarts >= 1, f"GARM did not take Restart=always path: {restarts}"
+                assert pruneon.succeed("systemctl is-active garm.service").strip() == "active"
+                assert pruneon.succeed(
+                    "systemctl show garm.service -p Result --value"
+                ).strip() == "success"
+                assert pruneon.succeed(
+                    "systemctl is-active garm-reconcile.service"
+                ).strip() == "active"
+                assert pruneon.succeed(
+                    "systemctl show garm-reconcile.service -p Result --value"
+                ).strip() == "success"
+
+                reconcile_started = int(pruneon.succeed(
+                    "systemctl show garm-reconcile.service "
+                    "-p ExecMainStartTimestampMonotonic --value"
+                ).strip())
+                garm_active = int(pruneon.succeed(
+                    "systemctl show garm.service -p ActiveEnterTimestampMonotonic --value"
+                ).strip())
+                assert 0 < reconcile_started < garm_active, \
+                    f"reconcile did not span GARM restart: reconcile={reconcile_started}, garm={garm_active}"
+
+                startup_journal = pruneon.succeed(
+                    "journalctl -u garm-reconcile.service --no-pager"
+                )
+                assert "controller API ready" in startup_journal, startup_journal
+                assert "reconcile complete" in startup_journal, startup_journal
 
             with subtest("(a) APPLY: reconcile created the declared cred/org/scale-set"):
                 for node in (pruneoff, pruneon):

--- a/checks/garm-reconcile.nix
+++ b/checks/garm-reconcile.nix
@@ -595,8 +595,19 @@ top@{ ... }:
                 before_ids = {n: s["id"] for n, s in before_ss.items()}
 
                 # NOW run the reconcile for the first time — it must ADOPT.
+                # Isolate its readiness request from the periodic watchdog so we
+                # can prove an initialized controller does not incur 60 retries.
+                node.systemctl("stop garm-healthcheck.timer garm-healthcheck.service")
+                probe_count_cmd = (
+                    "journalctl -u garm.service -o cat --no-pager "
+                    "| grep -c 'access_log method=GET uri=/api/v1/controller-info user_agent=curl/' || true"
+                )
+                probes_before = int(node.succeed(probe_count_cmd).strip())
                 node.systemctl("start garm-reconcile.service")
                 node.wait_for_unit("garm-reconcile.service")
+                probes_after = int(node.succeed(probe_count_cmd).strip())
+                assert probes_after - probes_before == 1, \
+                    f"adopt readiness issued {probes_after - probes_before} HTTP probes instead of one"
                 assert "success" in node.succeed(
                     "systemctl show -p Result --value garm-reconcile.service"
                 ), "adopt reconcile did not succeed"
@@ -616,6 +627,8 @@ top@{ ... }:
                 # The reconcile log should show 'already converged', never 'created'.
                 # NB: don't shadow the driver's built-in `log` (AbstractLogger).
                 journal = node.succeed("journalctl -u garm-reconcile.service --no-pager")
+                assert "controller API ready (HTTP 401)" in journal, \
+                    f"adopt reconcile did not accept the initialized controller's 401 readiness response:\n{journal}"
                 assert "already converged" in journal, f"adopt did not report convergence:\n{journal}"
                 assert "created in org" not in journal, f"adopt CREATED a scale set:\n{journal}"
           '';

--- a/modules/garm/default.nix
+++ b/modules/garm/default.nix
@@ -504,13 +504,25 @@
           gcli() { garm-cli --format json "$@"; }
 
           # ---- (0) Wait for the API + ensure first-run admin exists -----------
+          # This endpoint requires authentication after first-run, so an existing
+          # controller correctly returns 401. Any HTTP response proves the local
+          # API is accepting requests; only curl's 000/no-response result means
+          # it is not ready yet. Keep each probe bounded so a broken listener
+          # cannot wedge the oneshot indefinitely.
+          api_code=""
           for _ in $(seq 1 60); do
-            if curl -fsS -o /dev/null "$api_url/api/v1/controller-info" 2>/dev/null; then break; fi
-            # 409 (init/urls required) also means the server is UP.
-            code="$(curl -s -o /dev/null -w '%{http_code}' "$api_url/api/v1/controller-info" || true)"
-            [ "$code" = "409" ] && break
+            api_code="$(curl --connect-timeout 1 --max-time 2 -sS -o /dev/null \
+              -w '%{http_code}' "$api_url/api/v1/controller-info" 2>/dev/null || true)"
+            if [ -n "$api_code" ] && [ "$api_code" != "000" ]; then
+              log "controller API ready (HTTP $api_code)"
+              break
+            fi
             sleep 1
           done
+          if [ -z "$api_code" ] || [ "$api_code" = "000" ]; then
+            log "ERROR: controller API did not respond after 60 attempts"
+            exit 1
+          fi
 
           # first-run is idempotent enough: 200 on fresh, 409 if already done.
           fr_code="$(curl -s -o /tmp/garm-fr.json -w '%{http_code}' \

--- a/modules/garm/default.nix
+++ b/modules/garm/default.nix
@@ -2295,18 +2295,24 @@
           };
 
           # ---- The declarative reconcile oneshot ----------------------------
-          # Runs AFTER garm.service is up, converges GARM's DB onto the declared
-          # github creds + orgs + scale sets, then exits (RemainAfterExit so a
-          # re-switch re-runs it). Idempotent: a second run with unchanged config
-          # makes no changes. It runs as the SAME user as garm (so it reads the
-          # module-staged PEM copies under stateDir + shares the garm-cli HOME)
-          # and, like garm, may stage an operator admin password via
-          # LoadCredential. Enabling it is OPT-IN (`reconcile.enable`).
+          # Ordered after garm.service's first start attempt, converges GARM's DB
+          # onto the declared github creds + orgs + scale sets, then exits
+          # (RemainAfterExit so a re-switch re-runs it). The dependency is a Want,
+          # not a Require: a startup bind-verification failure intentionally makes
+          # systemd restart GARM, and a hard Require would leave this oneshot in a
+          # permanent dependency-failed state even after that restart succeeds.
+          # The script's bounded API-readiness loop spans the restart and its own
+          # Restart=on-failure policy handles a genuinely unavailable controller.
+          # Idempotent: a second run with unchanged config makes no changes. It
+          # runs as the SAME user as garm (so it reads the module-staged PEM copies
+          # under stateDir + shares the garm-cli HOME) and, like garm, may stage an
+          # operator admin password via LoadCredential. Enabling it is OPT-IN
+          # (`reconcile.enable`).
           systemd.services.garm-reconcile = mkIf rcfg.enable {
             description = "Reconcile GARM DB state (orgs/credentials/scale sets) to the declared config";
             documentation = [ "https://github.com/cloudbase/garm" ];
             after = [ "garm.service" ];
-            requires = [ "garm.service" ];
+            wants = [ "garm.service" ];
             wantedBy = [ "multi-user.target" ];
 
             serviceConfig = {

--- a/packages/garm-provider-vmharness/src/internal/backend/vmharness.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/vmharness.go
@@ -27,7 +27,12 @@ import (
 	garmErrors "github.com/cloudbase/garm-provider-common/errors"
 )
 
-const windowsRunnerTimeoutSec = "43200"
+// GitHub Actions jobs may run for up to six hours by default. Keep every
+// one-shot guest alive beyond that boundary so boot, package installation, and
+// runner cleanup do not consume part of the job's usable window. vm-harness'
+// default is only 600 seconds, which deterministically terminates long Linux
+// and macOS jobs while the foreground ephemeral runner is still busy.
+const runnerTimeoutSec = "43200"
 
 // VMHarnessRunBackend drives vm-harness backends whose lifecycle is already
 // one-shot and self-cleaning. It starts `vm-harness run` in the background and
@@ -212,7 +217,11 @@ func (b *VMHarnessRunBackend) Create(ctx context.Context, args CreateArgs) (Inst
 
 	guestPath := "/tmp/garm-bootstrap.sh"
 	bootstrapPath := filepath.Join(dir, "garm-bootstrap.sh")
-	argv := []string{"run", "--backend", b.BackendID, "--guest", b.GuestOS, "--baseline", args.SourceImage, "--output-dir", outDir}
+	argv := []string{
+		"run", "--backend", b.BackendID, "--guest", b.GuestOS,
+		"--baseline", args.SourceImage, "--output-dir", outDir,
+		"--timeout-sec", runnerTimeoutSec,
+	}
 	ephemeralPrefix := b.tartEphemeralPrefix(args.Name)
 	if ephemeralPrefix != "" {
 		argv = append(argv, "--ephemeral-prefix", ephemeralPrefix)
@@ -220,10 +229,7 @@ func (b *VMHarnessRunBackend) Create(ctx context.Context, args CreateArgs) (Inst
 	if strings.EqualFold(args.OSName, "windows") || b.GuestOS == "windows" {
 		guestPath = `C:\garm-bootstrap.ps1`
 		bootstrapPath = filepath.Join(dir, "garm-bootstrap.ps1")
-		// A GitHub Actions job may run for up to six hours by default. Keep the
-		// guest alive beyond that boundary so boot and runner cleanup time do not
-		// consume part of the job's usable window.
-		argv = append(argv, "--timeout-sec", windowsRunnerTimeoutSec, "--copy-to", bootstrapPath+":"+guestPath, "--")
+		argv = append(argv, "--copy-to", bootstrapPath+":"+guestPath, "--")
 		argv = append(argv, windowsBootstrapCommand(guestPath)...)
 	} else {
 		argv = append(argv, "--copy-to", bootstrapPath+":"+guestPath, "--", "/bin/sh", "-c", "chmod +x "+guestPath+" && exec "+guestPath)

--- a/packages/garm-provider-vmharness/src/internal/backend/vmharness_test.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/vmharness_test.go
@@ -232,6 +232,8 @@ func TestVMHarnessRunBackendDarwinAsUserWrapper(t *testing.T) {
 		"/nix/store/test-vm-harness/bin/vm-harness\n",
 		"run\n",
 		"tart-macos\n",
+		"--timeout-sec\n",
+		runnerTimeoutSec + "\n",
 	} {
 		if !strings.Contains(argv, want) {
 			t.Fatalf("launchctl argv missing %q:\n%s", want, argv)
@@ -294,7 +296,7 @@ func TestVMHarnessRunBackendWindowsCreateCommandWaitsAfterBootstrap(t *testing.T
 		"--guest\n",
 		"windows\n",
 		"--timeout-sec\n",
-		windowsRunnerTimeoutSec + "\n",
+		runnerTimeoutSec + "\n",
 		"--copy-to\n",
 		"garm-bootstrap.ps1:C:\\garm-bootstrap.ps1\n",
 		"--\n",

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -1414,7 +1414,7 @@ bool isCached(in Package pkg, string binaryCacheHttpEndpoint, in string[string] 
     }
     catch (HTTPStatusException e)
     {
-        if (e.status == 404)
+        if (cacheProbeHttpStatusIsMiss(e.status))
             return false;
         else
             throw e;
@@ -1423,6 +1423,25 @@ bool isCached(in Package pkg, string binaryCacheHttpEndpoint, in string[string] 
     {
         return false;
     }
+}
+
+bool cacheProbeHttpStatusIsMiss(long status) pure nothrow @safe
+{
+    // Cache lookup is an optimisation: if a cache rejects, rate-limits, or
+    // otherwise cannot answer a narinfo request, the safe result is "not
+    // proven cached" so CI builds the output.  An HTTP cache failure must not
+    // abort matrix generation and skip the build entirely.
+    return status >= 400 && status < 600;
+}
+
+@("cache probe HTTP failures are cache misses")
+unittest
+{
+    foreach (status; [401L, 403L, 404L, 429L, 500L, 503L])
+        assert(cacheProbeHttpStatusIsMiss(status));
+
+    assert(!cacheProbeHttpStatusIsMiss(200));
+    assert(!cacheProbeHttpStatusIsMiss(302));
 }
 
 @("isCached")


### PR DESCRIPTION
## Summary

- make reusable nix-diff self-contained by realizing `nixpkgs#jq^bin`, checking `bin/jq`, and exporting it through `GITHUB_PATH`
- classify binary-cache transport errors and HTTP 4xx/5xx as misses so CI schedules builds instead of aborting or assuming false hits
- prefer optional pull-only `ATTIC_PULL_TOKEN` for reads and probes, retain `ATTIC_TOKEN` as a rollout fallback, and exclude the pull token from publication; structural checks enforce the boundary
- give every vm-harness backend a 43,200-second runner lifetime and temporarily route only `foundry | aarch64-darwin` to the stable Darwin class until the fixed provider is deployed
- accept any bounded HTTP response—including an initialized controller's expected `401`—as GARM reconcile readiness, with explicit failure after no-response exhaustion
- let reconcile span GARM's supported startup restart (`Wants+After`, not `Requires+After`) and prove it with a deterministic fail-once post-start regression
- update the affected workflow/GARM checks, including the watchdog's isolated `/var/lib/garm-healthcheck` path, accepted ephemeral runner defaults, and the NetBird continuation-only lint correction

## Root causes

The minimal `eph-linux-x64` image exposed an undeclared `jq` dependency: infra PR #1229 completed machine discovery and then exited 127 before nix-diff ran.

Private-cache HTTP failures could abort MCL matrix generation because only `404` was treated as a miss, while reads reused the deployment credential. A rejected or unavailable cache is not proof that an output exists; the safe result is to build it.

vm-harness defaults non-Windows guests to 600 seconds. A live Darwin runner registered and began Foundry, then was terminated at that exact limit. The provider fix cannot affect the runner executing this PR, so the Foundry-only stable-runner override is deliberately temporary.

The reconcile readiness loop used `curl -f` and a second status request, rejecting an initialized controller's valid `401` and issuing up to 120 probes. Under a CPU-starved KVM run this prevented adopt reconciliation from reaching `/first-run` before the one-hour harness deadline.

A subsequent exact-head run exposed the companion startup-recovery bug: GARM's first bind verification failed and `Restart=always` recovered the daemon, but reconcile's hard `Requires` job had already failed with result `dependency` and was never requeued. A soft `Wants` edge is correct because reconcile has its own bounded readiness and restart policy; the active-exited convergence result does not need daemon stop propagation.

The watchdog failure was a stale assertion still reading GARM's SQLite directory after its counter moved to a private systemd `StateDirectory`.

## Validation

- focused MCL cache-probe tests: 2 passed
- Attic credential-boundary and Foundry routing assertions: passed
- `go test ./internal/backend` with vendored dependencies and the repository-pinned Go toolchain: passed
- predecessor-scope repository hooks, jq realization/executable checks, representative JSON conversion, and `git diff --check`: passed; actionlint found no new syntax/type errors beyond known custom-runner/action-metadata advisories
- reconcile changes: focused Nix evaluation passed; rendered Bash passed `bash -n` and ShellCheck 0.11.0; rendered test driver passed Python AST parsing
- rendered units prove fail-once post-start hook → real bind verifier, GARM `Restart=always`, and reconcile `After+Wants` without `Requires`
- the deterministic VM regression requires one injected startup failure, a GARM restart, successful reconcile across the gap, one adopt readiness probe, explicit `HTTP 401` readiness, and no-op adoption

Local NixOS VM execution is unavailable because Nix rejects this agent container's world-writable filesystem root. That local limitation was not used as a waiver: exact-head run [`29488125028`](https://github.com/metacraft-labs/nixos-modules/actions/runs/29488125028) completed successfully on `983300ddda8de25ef5ed2811ba73aa0d94036fbe` with 137 successful jobs, 2 intentional skips, 0 failures, and 0 pending jobs. Both `t_garm_reconcile` and `Final Results` passed.

## Review and rollout boundary

Reviewed base: `523f1b57240220536ed612be59cad208d36c3875`  
Reviewed head: `983300ddda8de25ef5ed2811ba73aa0d94036fbe`

An authorized human must review and merge only after the exact head is fully green and base/head remain unchanged. The agent will not approve, merge, deploy, or bypass checks.

This PR does not deploy runner infrastructure. After merge, the separate GARM listener-race pin remains a follow-up; infra PR #1229 must then be rebased and validated independently through the normal signed deployment path. Remove the temporary Foundry/Darwin override only after the fixed provider is deployed and a greater-than-10-minute job succeeds on `eph-macos-arm64`.