### PR TITLE
fix(ci): isolate devshell loader paths from Actions Node

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -307,6 +307,8 @@ runs:
       if: ${{ fromJSON(inputs.use-direnv || 'false') || inputs.devshell != '' }}
       shell: bash
       run: |
+        set -euo pipefail
+
         direnv() { nix run --inputs-from . nixpkgs#direnv -- "$@"; }
 
         if [ "${{ inputs.devshell }}" != "" ]; then
@@ -326,5 +328,72 @@ runs:
 
         direnv allow .
         echo "::group::Exporting Nix DevShell to GITHUB_ENV"
-        direnv export gha >> "$GITHUB_ENV"
+        export_file="$(mktemp "${RUNNER_TEMP:-/tmp}/nix-devshell-env.XXXXXX")"
+        loader_file="${export_file}.ld-library-path"
+        direnv export gha > "$export_file"
+        : > "$loader_file"
+
+        # direnv's GHA format uses one multiline record per variable. Copy
+        # every record except LD_LIBRARY_PATH verbatim, and capture that value
+        # for Bash run steps below. A line-oriented grep/sed would leave the
+        # value and delimiter behind and corrupt GITHUB_ENV.
+        while IFS= read -r header; do
+          if [[ "$header" != *"<<"* ]]; then
+            echo "Invalid direnv GHA export header: $header" >&2
+            exit 1
+          fi
+          key="${header%%<<*}"
+          delimiter="${header#*<<}"
+          if [[ -z "$key" || -z "$delimiter" ]]; then
+            echo "Invalid direnv GHA export record: $header" >&2
+            exit 1
+          fi
+
+          if [[ "$key" != "LD_LIBRARY_PATH" ]]; then
+            printf '%s\n' "$header" >> "$GITHUB_ENV"
+          fi
+
+          record_complete=false
+          while IFS= read -r line; do
+            if [[ "$line" == "$delimiter" ]]; then
+              if [[ "$key" != "LD_LIBRARY_PATH" ]]; then
+                printf '%s\n' "$line" >> "$GITHUB_ENV"
+              fi
+              record_complete=true
+              break
+            fi
+            if [[ "$key" == "LD_LIBRARY_PATH" ]]; then
+              printf '%s\n' "$line" >> "$loader_file"
+            else
+              printf '%s\n' "$line" >> "$GITHUB_ENV"
+            fi
+          done
+          if [[ "$record_complete" != "true" ]]; then
+            echo "Unterminated direnv GHA export record for $key" >&2
+            exit 1
+          fi
+        done < "$export_file"
+
+        devshell_ld_library_path="$(cat "$loader_file")"
+        previous_bash_env="${BASH_ENV:-}"
+        nix_bash_env="$(mktemp "${RUNNER_TEMP:-/tmp}/nix-devshell-bash-env.XXXXXX")"
+        {
+          if [[ -n "$previous_bash_env" ]]; then
+            printf 'if [[ -f %q ]]; then source %q; fi\n' "$previous_bash_env" "$previous_bash_env"
+          fi
+          printf 'if [[ ${AH_DISABLE_DEVSHELL_LD_LIBRARY_PATH:-0} == 1 ]]; then\n'
+          printf '  unset LD_LIBRARY_PATH\n'
+          printf 'else\n'
+          printf '  export LD_LIBRARY_PATH=%q\n' "$devshell_ld_library_path"
+          printf 'fi\n'
+        } > "$nix_bash_env"
+        chmod 0600 "$nix_bash_env"
+
+        # JavaScript actions (including post actions) execute the runner's host
+        # Node binary. Keep Nix libstdc++ out of that process; GitHub's
+        # noninteractive Bash run steps source BASH_ENV and recover the
+        # devshell loader path. AH_DISABLE_DEVSHELL_LD_LIBRARY_PATH=1 gives an
+        # individual Bash step an explicit host-loader opt-out.
+        printf 'LD_LIBRARY_PATH=\n' >> "$GITHUB_ENV"
+        printf 'BASH_ENV=%s\n' "$nix_bash_env" >> "$GITHUB_ENV"
         echo "::endgroup::"

--- a/.github/setup-nix/tests/devshell-fixture/flake.nix
+++ b/.github/setup-nix/tests/devshell-fixture/flake.nix
@@ -18,6 +18,9 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          loaderFixture = pkgs.runCommand "setup-nix-loader-fixture" { } ''
+            mkdir -p "$out/lib"
+          '';
         in
         {
           # A devShell whose build always fails. Used to assert that the
@@ -36,6 +39,7 @@
           # success path still exports the environment to $GITHUB_ENV.
           default = pkgs.mkShell {
             packages = [ pkgs.hello ];
+            LD_LIBRARY_PATH = "${loaderFixture}/lib";
           };
         }
       );

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,30 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           devshell: default
 
+      - name: Assert the Actions Node runtime has the host loader environment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (process.env.LD_LIBRARY_PATH) {
+              core.setFailed(`Actions Node inherited LD_LIBRARY_PATH=${process.env.LD_LIBRARY_PATH}`)
+            }
+
       - name: Assert the working devShell was exported to PATH
         run: |
           if ! command -v hello >/dev/null; then
             echo "::error::'hello' from the devShell is not on PATH; the environment was not exported to GITHUB_ENV."
             exit 1
           fi
+          if [[ "$LD_LIBRARY_PATH" != *setup-nix-loader-fixture* ]]; then
+            echo "::error::Bash did not recover the devShell LD_LIBRARY_PATH through BASH_ENV."
+            exit 1
+          fi
+          AH_DISABLE_DEVSHELL_LD_LIBRARY_PATH=1 bash -c '
+            if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+              echo "::error::The per-step host-loader opt-out did not clear LD_LIBRARY_PATH."
+              exit 1
+            fi
+          '
           echo "OK: devShell environment exported; hello resolved to $(command -v hello)."
 
   test-mcl-secret-integration:

--- a/.github/workflows/netbird-attic-smoke.yml
+++ b/.github/workflows/netbird-attic-smoke.yml
@@ -55,8 +55,8 @@ jobs:
           # token is 401 — that is the defence-in-depth invariant.
           for attempt in $(seq 1 30); do
             if curl -fsS --connect-timeout 2 --max-time 5 \
-                 -H "Authorization: Bearer $ATTIC_TOKEN" \
-                 "$ATTIC_SUBSTITUTER/nix-cache-info" >/dev/null; then
+                -H "Authorization: Bearer $ATTIC_TOKEN" \
+                "$ATTIC_SUBSTITUTER/nix-cache-info" >/dev/null; then
               echo "authenticated read of $ATTIC_SUBSTITUTER succeeded"
               break
             fi


### PR DESCRIPTION
## Summary

- stop exporting the Nix devshell `LD_LIBRARY_PATH` job-wide to JavaScript actions
- restore that loader path only for noninteractive Bash run steps through a unique, mode-0600 `BASH_ENV` file
- preserve a pre-existing `BASH_ENV` and provide an explicit per-step host-loader opt-out
- add regression coverage for the Actions Node boundary, Bash restoration, and the opt-out
- correct two pre-existing continuation-indent errors that made the repository-wide editorconfig job fail

## Root cause

A Nix devshell can export GCC runtime libraries built against a newer glibc than the ephemeral runner host. Job-wide export makes host Node processes used by JavaScript actions load those libraries, so action and post-action steps fail with a glibc version error even after the actual build/test step succeeds.

## Validation

- the setup-action devShell regression passed in GitHub Actions on the first head, proving Node sees the host loader environment while Bash recovers the fixture path and the opt-out clears it
- focused repository hooks pass for all changed files, including the pre-existing workflow indentation repair
- `git diff --check` passes
- a fresh exact-head CI run is required after `aa90bdd`

The failed `post-initial-comment` job is an independent workflow-permission problem and is not caused by the setup action.
