### PR TITLE
fix(garm): pin scale-set listener race fix

### DIFF
--- a/checks/garm-macos-runner-install-wrapper.nix
+++ b/checks/garm-macos-runner-install-wrapper.nix
@@ -16,6 +16,7 @@ let
             context.Background(),
             commonParams.OSType("macos"),
             "http://garm.example.test/api/v1/metadata",
+            "http://garm.example.test/api/v1/callbacks/status",
             "instance-token",
         )
         if err != nil {

--- a/checks/garm-service-boot.nix
+++ b/checks/garm-service-boot.nix
@@ -86,6 +86,13 @@ top@{ ... }:
                 ).strip()
                 assert service_type == "simple", f"unexpected Type={service_type!r}"
 
+            with subtest("garm.service passes the config through the supported long flag"):
+                exec_start = server.succeed(
+                    "systemctl show -p ExecStart --value garm.service"
+                ).strip()
+                expected = " --config /var/lib/garm/config.toml"
+                assert expected in exec_start, f"garm.service ExecStart={exec_start!r}"
+
             with subtest("garm.service is active/running"):
                 server.wait_for_unit("garm.service")
                 active = server.succeed(

--- a/checks/garm-service-boot.nix
+++ b/checks/garm-service-boot.nix
@@ -7,7 +7,7 @@ top@{ ... }:
   # merely that the unit is "active"):
   #
   #   (a) garm.service is active/running (a long-running Type=simple unit);
-  #   (b) the guest `garm --version` equals the packaged pin (v0.2.1);
+  #   (b) the guest `garm --version` equals the packaged post-v0.2.1 pin;
   #   (c) the daemon SERVES its API:
   #        - the apiserver port (9997) is listening;
   #        - GET /api/v1/controller-info BEFORE first-run responds 409 with the
@@ -93,9 +93,9 @@ top@{ ... }:
                 ).strip()
                 assert active == "active", f"garm.service ActiveState={active!r}"
 
-            with subtest("the packaged garm --version matches the M0 pin (v0.2.1)"):
+            with subtest("the packaged garm --version matches the post-v0.2.1 race-fix pin"):
                 version = server.succeed("garm --version").strip()
-                assert version == "v0.2.1", f"garm --version={version!r}"
+                assert version == "v0.2.1-unstable-2026-07-08", f"garm --version={version!r}"
 
             with subtest("the daemon binds the apiserver port"):
                 server.wait_for_open_port(9997)

--- a/modules/garm/default.nix
+++ b/modules/garm/default.nix
@@ -2229,7 +2229,7 @@
               ExecStartPre = lib.getExe renderScript;
               ExecStart = lib.escapeShellArgs [
                 (lib.getExe cfg.package)
-                "-config"
+                "--config"
                 renderedConfig
               ];
               # FU9 startup bind-verify: wait for the API listener to bind and

--- a/packages/garm/default.nix
+++ b/packages/garm/default.nix
@@ -16,17 +16,19 @@
 # vendors. The daemon (`garm`) and admin CLI (`garm-cli`) are both produced.
 buildGo126Module rec {
   pname = "garm";
-  version = "0.2.1";
+  version = "0.2.1-unstable-2026-07-08";
 
-  # Pin the exact upstream commit for v0.2.1 (do NOT depend on the local
-  # references/garm overlay — CI builds nixos-modules without it).
-  rev = "154638445c3949c1958b01812f69d9a1e4d82684";
+  # v0.2.1 can wedge a scale-set listener forever when a delayed job message
+  # races an already-terminal runner transition. Pin the upstream fix merged
+  # by cloudbase/garm#817 until the next tagged release includes it. Do not
+  # depend on the local references/garm overlay: CI builds this flake alone.
+  rev = "0a9a939c10f1e253947b63b0708acaa0c9d5e0bc";
 
   src = fetchFromGitHub {
     owner = "cloudbase";
     repo = "garm";
     inherit rev;
-    hash = "sha256-Eqa0gnPm/puaxVqODJ+nwphYgt0crN6D/OmRijzmZ/M=";
+    hash = "sha256-lv15Q8gzg+SeRxlBXA70W26W+chIOqtgvuMahsMHb6s=";
   };
 
   # Deps are vendored in-tree → build offline against `vendor/`.

--- a/packages/garm/patches/allow-macos-runner-install-templates.patch
+++ b/packages/garm/patches/allow-macos-runner-install-templates.patch
@@ -1,30 +1,26 @@
 diff --git a/cmd/garm-cli/cmd/templates.go b/cmd/garm-cli/cmd/templates.go
-index 32f6e4a..3e8c4d1 100644
 --- a/cmd/garm-cli/cmd/templates.go
 +++ b/cmd/garm-cli/cmd/templates.go
-@@ -77 +77 @@ var templateCreateCmd = &cobra.Command{
+@@ -83 +83 @@ var templateCreateCmd = &cobra.Command{
 -		case commonParams.Linux, commonParams.Windows:
 +		case commonParams.Linux, commonParams.Windows, commonParams.MacOS:
-@@ -79 +79 @@ var templateCreateCmd = &cobra.Command{
+@@ -85 +85 @@ var templateCreateCmd = &cobra.Command{
 -			return fmt.Errorf("invalid OS type: %q (supported: %s)", osType, strings.Join([]string{string(params.GithubEndpointType), string(params.GiteaEndpointType)}, ", "))
 +			return fmt.Errorf("invalid OS type: %q (supported: %s)", osType, strings.Join([]string{string(commonParams.Linux), string(commonParams.Windows), string(commonParams.MacOS)}, ", "))
 diff --git a/params/requests.go b/params/requests.go
-index 80e88ee..e25cc2d 100644
 --- a/params/requests.go
 +++ b/params/requests.go
-@@ -896 +896 @@ func (c *CreateTemplateParams) Validate() error {
+@@ -952 +952 @@ func (c *CreateTemplateParams) Validate() error {
 -	case commonParams.Linux, commonParams.Windows:
 +	case commonParams.Linux, commonParams.Windows, commonParams.MacOS:
 diff --git a/internal/templates/templates.go b/internal/templates/templates.go
-index 01d0f07..84f5d59 100644
 --- a/internal/templates/templates.go
 +++ b/internal/templates/templates.go
-@@ -40 +40 @@ func GetTemplateContent(osType commonParams.OSType, forge params.EndpointType) (
+@@ -54 +54 @@ func GetTemplateContent(osType commonParams.OSType, forge params.EndpointType) (
 -		case commonParams.Linux, commonParams.Windows:
 +		case commonParams.Linux, commonParams.Windows, commonParams.MacOS:
 diff --git a/internal/templates/userdata/macos_wrapper.tmpl b/internal/templates/userdata/macos_wrapper.tmpl
 new file mode 100644
-index 0000000..3f81d1d
 --- /dev/null
 +++ b/internal/templates/userdata/macos_wrapper.tmpl
 @@ -0,0 +1,12 @@
@@ -41,20 +37,11 @@ index 0000000..3f81d1d
 +/tmp/real-install.sh
 +rm -f /tmp/real-install.sh
 diff --git a/internal/templates/templates_test.go b/internal/templates/templates_test.go
-new file mode 100644
-index 0000000..28866e5
---- /dev/null
+--- a/internal/templates/templates_test.go
 +++ b/internal/templates/templates_test.go
-@@ -0,0 +1,39 @@
-+package templates
-+
-+import (
+@@ -17,0 +18 @@ import (
 +	"context"
-+	"strings"
-+	"testing"
-+
-+	commonParams "github.com/cloudbase/garm-provider-common/params"
-+)
+@@ -69,0 +71,31 @@ func TestInstallTemplatesRenderForceInsecure(t *testing.T) {
 +
 +func TestRenderMacOSRunnerInstallWrapper(t *testing.T) {
 +	t.Parallel()
@@ -63,6 +50,7 @@ index 0000000..28866e5
 +		context.Background(),
 +		commonParams.MacOS,
 +		"http://garm.example.test/api/v1/metadata",
++		"http://garm.example.test/api/v1/callbacks/status",
 +		"instance-token",
 +	)
 +	if err != nil {
@@ -86,8 +74,7 @@ index 0000000..28866e5
 +	}
 +}
 diff --git a/vendor/github.com/cloudbase/garm-provider-common/params/params.go b/vendor/github.com/cloudbase/garm-provider-common/params/params.go
-index e8bc7eb..0ea1721 100644
 --- a/vendor/github.com/cloudbase/garm-provider-common/params/params.go
 +++ b/vendor/github.com/cloudbase/garm-provider-common/params/params.go
-@@ -30,0 +31 @@ const (
+@@ -32,0 +33 @@ const (
 +	MacOS   OSType = "macos"


### PR DESCRIPTION
## Summary

- pin GARM to upstream commit `0a9a939c10f1e253947b63b0708acaa0c9d5e0bc`, which contains the scale-set listener race fix from cloudbase/garm#817
- rebase the downstream macOS runner-install template patch onto the updated listener callback API
- update the wrapper regression test to exercise the required callback URL argument
- switch the NixOS service to the post-v0.2.1 Cobra `--config` flag and assert the rendered `ExecStart` contract

## Why

The released GARM 0.2.1 can wedge a scale-set listener during concurrent instance creation and state transitions. The selected exact post-release commit contains the bounded instance creation, listener timeout, race-tolerant transition, reaper, and locking changes associated with the upstream fix while avoiding unrelated later `main` changes.

## Validation

- `nixfmt --check` on all changed Nix files
- `git diff --check upstream/main...HEAD`
- x86_64-linux and aarch64-darwin package version evaluations return `0.2.1-unstable-2026-07-08`
- all changed GARM checks evaluate on x86_64-linux and aarch64-linux during `nix flake check --all-systems --no-build`
- the NixOS service and watchdog VM checks evaluate with the corrected long config flag
- the patched exact upstream source passes `go test -mod=vendor ./internal/templates ./params ./cmd/garm-cli/cmd` with Go 1.26

The repository-wide all-systems evaluation subsequently reaches an unrelated pre-existing `aarch64-linux` failure because the Ethereum input does not expose `foundry`. A local targeted Nix build cannot start in this agent container because Nix rejects its world-writable `/` path. Exact-head GitHub CI is therefore required before merge.

No infrastructure is deployed by this PR. After merge, the private infrastructure runner-fleet PR must pin this exact `main` revision before deployment.