### PR TITLE
fix(ci): check out caller before matrix fallback

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -272,6 +272,8 @@ jobs:
     if: needs.shard-matrix.outputs.eval_matrix != '{"include":[]}' &&
       needs.eval-matrix.result == 'success'
     steps:
+      - uses: actions/checkout@v6.0.2
+
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:

--- a/checks/ci-workflows.nix
+++ b/checks/ci-workflows.nix
@@ -230,6 +230,34 @@
             touch "$out"
           '';
 
+      checks.reusable-flake-checks-artifact-fallback =
+        pkgs.runCommand "reusable-flake-checks-artifact-fallback"
+          {
+            nativeBuildInputs = [ pkgs.python3 ];
+          }
+          ''
+            python3 - <<'PY'
+            import re
+            from pathlib import Path
+
+            workflow = Path("${flakeChecksWorkflow}").read_text()
+            merge_job = workflow.split("\n  merge-matrices:\n", 1)[1]
+            next_job = re.search(r"\n  [a-z0-9-]+:\n", merge_job)
+            assert next_job is not None, "job following merge-matrices disappeared"
+            merge_job = merge_job[: next_job.start()]
+
+            checkout = "uses: actions/checkout@v6.0.2"
+            fallback = "name: Regenerate CI matrix shards when artifacts are unavailable"
+            assert checkout in merge_job, "matrix artifact fallback requires a caller-repository checkout"
+            assert fallback in merge_job, "matrix artifact fallback step disappeared"
+            assert merge_job.index(checkout) < merge_job.index(fallback), (
+                "caller-repository checkout must precede matrix artifact regeneration"
+            )
+            PY
+
+            touch "$out"
+          '';
+
       checks.reusable-terraform-drift-workflow =
         pkgs.runCommand "reusable-terraform-drift-workflow"
           {


### PR DESCRIPTION
## Summary

- check out the caller repository in the matrix merge job
- allow the existing local-regeneration fallback to evaluate the caller flake when artifact uploads are unavailable
- add a regression check enforcing checkout before regeneration

## Root cause

Metacraft infra PR #1229 hit the GitHub artifact storage quota after all matrix shards evaluated successfully. The merge job correctly attempted local regeneration, but it had no checkout and failed because the caller workspace contained no `flake.nix`.

## Validation

- `nix build --accept-flake-config .#checks.x86_64-linux.reusable-flake-checks-mcl-ref .#checks.x86_64-linux.reusable-flake-checks-attic-credentials .#checks.x86_64-linux.reusable-flake-checks-artifact-fallback --print-build-logs`
- `nix flake check --accept-flake-config --no-build`
- `nixfmt --check checks/ci-workflows.nix`
- `actionlint` passes with the pre-existing unused `setup-nix-no-push` anchor warning ignored; unfiltered output matches `main`
- `git diff --check`

## Incident evidence

- caller run: https://github.com/metacraft-labs/infra/actions/runs/29507727778
- failed merge job: https://github.com/metacraft-labs/infra/actions/runs/29507727778/job/87658595725