### PR TITLE
fix(ci): retry transient MCL source fetches

### DIFF
--- a/.github/workflows/reusable-flake-checks-ci-matrix.yml
+++ b/.github/workflows/reusable-flake-checks-ci-matrix.yml
@@ -125,7 +125,7 @@ jobs:
 
           {
             printf 'workflow_sha=%s\n' "$mcl_ref"
-            printf 'mcl_flake_cmd=nix run --accept-flake-config github:metacraft-labs/nixos-modules/%s#mcl\n' "$mcl_ref"
+            printf 'mcl_flake_cmd=nix --option download-attempts 5 run --accept-flake-config github:metacraft-labs/nixos-modules/%s#mcl\n' "$mcl_ref"
           } >> "$GITHUB_OUTPUT"
 
   post-initial-comment:

--- a/checks/ci-workflows.nix
+++ b/checks/ci-workflows.nix
@@ -104,7 +104,7 @@
                     )
                     assert outputs["workflow_sha"] == expected_ref, (name, outputs)
                     expected_cmd = (
-                        "nix run --accept-flake-config "
+                        "nix --option download-attempts 5 run --accept-flake-config "
                         f"github:metacraft-labs/nixos-modules/{expected_ref}#mcl"
                     )
                     assert outputs["mcl_flake_cmd"] == expected_cmd, (name, outputs)


### PR DESCRIPTION
## Summary

- give MCL flake-source commands a bounded five-attempt download budget
- keep the repository-wide Nix download retry policy unchanged
- update the reusable-workflow regression to assert the exact command

## Context

Agent Harbor AMI promotion PRs #259 and #260 both lost otherwise healthy CI jobs when GitHub returned transient HTTP 503 responses for the MCL commit and tarball endpoints. The existing setup performs only two total download attempts. This scopes the normal five-attempt budget to the shared MCL command used by shard generation, eval shards, matrix merge, and final results.

This does not remove the need for a clean workflow rerun after a prolonged outage and does not weaken any required check.

## Validation

- `nix build --accept-flake-config -L .#checks.x86_64-linux.reusable-flake-checks-mcl-ref`
- `nix develop --accept-flake-config --command actionlint .github/workflows/reusable-flake-checks-ci-matrix.yml`
- `nix develop --accept-flake-config --command prek run --files .github/workflows/reusable-flake-checks-ci-matrix.yml checks/ci-workflows.nix`
- `git diff --check`