### PR TITLE
deploy-agent: register a system-profile generation so deploys survive reboot

### DIFF
--- a/packages/mcl/src/mcl/commands/deploy_apply.d
+++ b/packages/mcl/src/mcl/commands/deploy_apply.d
@@ -323,8 +323,22 @@ int deployApplyImpl(DeployApplyArgs args, DeployApplyDependencies deps)
     }
 
     auto previous = shell(queryRunner, args.generationCommand).stdout.strip;
+
+    // Activate the desired closure. The production default first registers it as
+    // a NixOS system-profile generation (`nix-env --set`) and only then runs
+    // switch-to-configuration -- exactly what `nixos-rebuild switch` does around
+    // switch-to-configuration. This `--set` is REQUIRED for the deployment to
+    // survive a reboot: switch-to-configuration installs the boot loader from the
+    // system-profile generations, so a bare `switch-to-configuration switch` on a
+    // store path activates at runtime but leaves the boot default on the previous
+    // generation -- the host then silently reverts to its old configuration on
+    // the next reboot. Folding the `--set` into the default command (rather than
+    // a separate step) means a test that overrides --switch-command transparently
+    // bypasses the profile mutation too.
+    auto desiredPath = manifestDesiredSystemPath(manifest);
     auto switchCommand = args.switchCommand == ""
-        ? manifestDesiredSystemPath(manifest) ~ "/bin/switch-to-configuration switch"
+        ? "nix-env -p /nix/var/nix/profiles/system --set " ~ desiredPath
+            ~ " && " ~ desiredPath ~ "/bin/switch-to-configuration switch"
         : args.switchCommand;
     auto switched = detachedSwitch(runner, switchCommand, !args.noDetachSwitch);
     auto current = shell(queryRunner, args.generationCommand).stdout.strip;
@@ -376,8 +390,13 @@ int deployApplyImpl(DeployApplyArgs args, DeployApplyDependencies deps)
     {
         if (automaticRollbackRequested(manifest) && previous != "")
         {
+            // Roll back: revert the system-profile generation to the previously-
+            // current system and reactivate it, so the boot loader default rolls
+            // back together with the runtime activation. As with the forward
+            // switch, overriding --rollback-command bypasses the profile mutation.
             auto rollbackCommand = args.rollbackCommand == ""
-                ? previous ~ "/bin/switch-to-configuration switch"
+                ? "nix-env -p /nix/var/nix/profiles/system --set " ~ previous
+                    ~ " && " ~ previous ~ "/bin/switch-to-configuration switch"
                 : args.rollbackCommand;
             auto rollback = detachedSwitch(runner, rollbackCommand, !args.noDetachSwitch);
             emit("rollback", "switch-to-configuration rollback", ["sh", "-c", rollbackCommand],


### PR DESCRIPTION
## Problem

`mcl deploy-apply` activated the desired closure with a bare
`store-path/bin/switch-to-configuration switch`, but never registered it as a
NixOS **system-profile generation** — the `nix-env -p /nix/var/nix/profiles/system --set`
step that `nixos-rebuild switch` performs around `switch-to-configuration`.

`switch-to-configuration` installs the boot loader from the system-profile
generations, so with no generation registered the boot default stayed on the
**last real generation**. Deploys were therefore applied at runtime only and
**every reboot silently reverted the host** to its previous configuration.

### Observed impact
On `gpu-server-002`, the newest system generation was stuck at **Jun 26**
despite weeks of successful deploys. After a hardware reset the machine booted
that stale closure — with a just-deployed hardware watchdog **disarmed** and a
ZFS ARC cap **absent** — so a mitigation that had been "deployed" was silently
gone. `gpu-server-001` was in the same latent state (booted closure lacked both,
agent had only switched it ephemerally).

## Fix

Fold the `nix-env --set` into the **default** switch and rollback commands, so
the production path matches `nixos-rebuild switch` and persists across reboot.
The rollback path re-sets the profile to the previous system so the boot default
reverts along with the runtime activation.

Because the `--set` lives in the *default* command string, any test that
overrides `--switch-command` / `--rollback-command` bypasses it unchanged — no
test or module wiring changes required.

## Verification

- `nix build .#mcl` — builds; embedded D unit tests: **109 passed, 0 failed**.
- The full VM check suite (`deployment-pull-agent`, `deployment-reconciler`,
  `deployment-production-cutover`) should run in CI — those stub the switch
  command and so are unaffected by the default-path change.
- Operationally verified by hand-applying the equivalent `nix-env --set` +
  `switch-to-configuration` on gpu-server-001/002: boot default now points at
  the intended generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)