### PR TITLE
feat(ci-token-provider): org-agnostic GitHub App token tooling

### DIFF
--- a/.github/create-app-token/action.yml
+++ b/.github/create-app-token/action.yml
@@ -1,0 +1,45 @@
+name: Create GitHub App Token
+description: >-
+  Mint a short-lived GitHub App installation token, optionally scoped to
+  specific repositories and permissions. Replaces long-lived PATs for
+  cross-repo access in CI. Company-specific values (App ID, private key,
+  target repos) are passed in by the caller; this action is org-agnostic.
+
+inputs:
+  app-id:
+    description: GitHub App ID (public). e.g. the CI_TOKEN_PROVIDER_APP_ID secret.
+    required: true
+  private-key:
+    description: GitHub App private key PEM. e.g. the CI_TOKEN_PROVIDER_PRIVATE_KEY secret.
+    required: true
+  owner:
+    description: Org/owner the token is scoped to. Defaults to the current repo's owner.
+    required: false
+    default: ${{ github.repository_owner }}
+  repositories:
+    description: >-
+      Comma- or newline-separated unqualified repo names the token may access.
+      Empty means every repo the app installation can reach in `owner`.
+    required: false
+    default: ''
+  permission-contents:
+    description: '`contents` permission for the minted token: read | write.'
+    required: false
+    default: read
+
+outputs:
+  token:
+    description: The minted installation access token (mask it; it is short-lived).
+    value: ${{ steps.mint.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - id: mint
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.repositories }}
+        permission-contents: ${{ inputs.permission-contents }}

--- a/scripts/ci-token-provider/README.md
+++ b/scripts/ci-token-provider/README.md
@@ -1,0 +1,19 @@
+# ci-token-provider
+
+Org-agnostic tooling for the "CI token provider" GitHub App pattern: a
+GitHub App whose **non-expiring** private key mints **short-lived**
+installation tokens on demand, replacing long-lived PATs.
+
+Two halves:
+
+- **Consumption** (in CI): the [`create-app-token`](../../.github/create-app-token/action.yml)
+  composite action mints a scoped token from the App ID + private key.
+- **Provisioning** (this dir): `configure-github-repo.sh` writes the
+  `CI_TOKEN_PROVIDER_APP_ID` / `CI_TOKEN_PROVIDER_PRIVATE_KEY` secrets onto
+  a repo, decrypting the key from agenix.
+
+This code carries **no company-specific values**. Each infra repo passes
+its own `CTP_APP_ID`, `CTP_KEY_AGE`, `CTP_AGE_IDENTITY`, and repo list
+(e.g. via its flake devshell / Justfile, with `nixos-modules` as a flake
+input). Terraform-managed infra repos should instead declare the two
+secrets via `github_actions_secret` sourced from the same agenix key.

--- a/scripts/ci-token-provider/configure-github-repo.sh
+++ b/scripts/ci-token-provider/configure-github-repo.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Configure one repo with the CI-token-provider App secrets.
+#
+# Usage: CTP_APP_ID=<id> CTP_KEY_AGE=<file> CTP_AGE_IDENTITY=<key> \
+#          configure-github-repo.sh <owner/repo>
+#
+# The company-specific values (App ID, key file, identity, and the repo
+# list) come from the calling infra repo. See ./lib.sh for the knobs.
+
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: CTP_APP_ID=.. CTP_KEY_AGE=.. CTP_AGE_IDENTITY=.. $0 <owner/repo>" >&2
+  exit 2
+fi
+
+pem=$(ctp_decrypt_private_key)
+printf '%s' "$pem" | ctp_apply_to_repo "$1"

--- a/scripts/ci-token-provider/lib.sh
+++ b/scripts/ci-token-provider/lib.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Org-agnostic helpers for provisioning the CI-token-provider GitHub App
+# secrets onto repositories.
+#
+# Model
+# -----
+# A GitHub App with a non-expiring private key mints short-lived
+# installation tokens on demand (in CI via the `create-app-token`
+# composite action in this repo). Consumers store the App ID and the
+# App private key as per-repo Actions secrets:
+#
+#   * CI_TOKEN_PROVIDER_APP_ID      — numeric App ID (public)
+#   * CI_TOKEN_PROVIDER_PRIVATE_KEY — App RSA private key, PEM
+#
+# This library is deliberately company-agnostic: the App ID, the agenix
+# file holding the private key, the age identity, the target repos, and
+# (optionally) the secret names are all provided by the caller. Each
+# company's infra repo supplies those values; the logic lives here.
+#
+# Required inputs (env):
+#   CTP_APP_ID        numeric GitHub App ID
+#   CTP_KEY_AGE       path to the agenix file holding the App private key
+#   CTP_AGE_IDENTITY  path to an age identity that can decrypt CTP_KEY_AGE
+#
+# Optional inputs (env), with defaults:
+#   CTP_APP_ID_SECRET_NAME       (default: CI_TOKEN_PROVIDER_APP_ID)
+#   CTP_PRIVATE_KEY_SECRET_NAME  (default: CI_TOKEN_PROVIDER_PRIVATE_KEY)
+
+set -euo pipefail
+
+CTP_APP_ID_SECRET_NAME="${CTP_APP_ID_SECRET_NAME:-CI_TOKEN_PROVIDER_APP_ID}"
+CTP_PRIVATE_KEY_SECRET_NAME="${CTP_PRIVATE_KEY_SECRET_NAME:-CI_TOKEN_PROVIDER_PRIVATE_KEY}"
+
+ctp_require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ci-token-provider: required command '$cmd' is not on PATH" >&2
+    return 1
+  fi
+}
+
+ctp_require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "ci-token-provider: required env '$name' is not set" >&2
+    return 1
+  fi
+}
+
+# Decrypt the App private key from the age file and print the PEM to
+# stdout. Run once and reuse to avoid repeated passphrase prompts.
+ctp_decrypt_private_key() {
+  ctp_require_command age
+  ctp_require_env CTP_KEY_AGE
+  ctp_require_env CTP_AGE_IDENTITY
+  if [[ ! -f "$CTP_KEY_AGE" ]]; then
+    echo "ci-token-provider: agenix file not found at: $CTP_KEY_AGE" >&2
+    return 1
+  fi
+  if [[ ! -f "$CTP_AGE_IDENTITY" ]]; then
+    echo "ci-token-provider: age identity not found at: $CTP_AGE_IDENTITY" >&2
+    return 1
+  fi
+  age --decrypt -i "$CTP_AGE_IDENTITY" "$CTP_KEY_AGE"
+}
+
+# Set both secrets on a single repo. The PEM is piped in over stdin so it
+# never lands in `ps` output, on disk, or in shell history.
+#
+#   $1    — owner/name of the repo
+#   stdin — the App private key PEM
+ctp_apply_to_repo() {
+  local repo="$1"
+  ctp_require_command gh
+  ctp_require_env CTP_APP_ID
+
+  if [[ ! "$repo" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
+    echo "ci-token-provider: repo '$repo' must be in owner/name form" >&2
+    return 2
+  fi
+
+  local pem
+  pem=$(cat)
+  if [[ -z "$pem" ]]; then
+    echo "ci-token-provider: empty PEM piped in for $repo" >&2
+    return 1
+  fi
+
+  echo "==> $repo"
+  gh secret set "$CTP_APP_ID_SECRET_NAME" --body "$CTP_APP_ID" --repo "$repo"
+  printf '%s' "$pem" | gh secret set "$CTP_PRIVATE_KEY_SECRET_NAME" --repo "$repo"
+}


### PR DESCRIPTION
Shared home for the CI-token-provider pattern (App private key mints short-lived tokens; no expiring PATs), so company-specific config lives in each infra repo.

- `.github/create-app-token` composite action (mints a scoped installation token).
- `scripts/ci-token-provider` provisioner (writes `CI_TOKEN_PROVIDER_{APP_ID,PRIVATE_KEY}` from an agenix key) — generalized from metacraft-labs/infra, all company-specific defaults removed.

First consumer: blocksense DFCG artifacts access (migrating off the expired `DFCG_ARTIFACTS_ACCESS_TOKEN` PAT). agent-harbor to consume via a Terraform module next.