### PR TITLE
fix(terraform-ci): keep policy advisories non-blocking

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -612,7 +612,9 @@ jobs:
           # Fetch policy script from nixos-modules
           WORKFLOW_REF="${{ github.action_ref || 'main' }}"
           POLICY_SCRIPT_URL="https://raw.githubusercontent.com/metacraft-labs/nixos-modules/${WORKFLOW_REF}/scripts/tofu-plan-policy.py"
+          POLICY_RUNNER_URL="https://raw.githubusercontent.com/metacraft-labs/nixos-modules/${WORKFLOW_REF}/scripts/tofu-plan-policy-ci"
           curl -fsSL "$POLICY_SCRIPT_URL" -o /tmp/tofu-plan-policy.py
+          curl -fsSL "$POLICY_RUNNER_URL" -o /tmp/tofu-plan-policy-ci
 
           PLAN_JSON="${{ steps.plan.outputs.json_plan_path }}"
           POLICY_ARGS=()
@@ -630,7 +632,7 @@ jobs:
 
           # Run policy check
           nix shell --accept-flake-config --inputs-from "$GITHUB_WORKSPACE" nixpkgs#python3 --command \
-            python3 /tmp/tofu-plan-policy.py "$PLAN_JSON" "${POLICY_ARGS[@]}"
+            bash /tmp/tofu-plan-policy-ci /tmp/tofu-plan-policy.py "$PLAN_JSON" "${POLICY_ARGS[@]}"
 
       - name: Sensitive-change gate
         if: inputs.sensitive_change_label != '' && steps.plan.outputs.changes == 'true'

--- a/checks/ci-workflows.nix
+++ b/checks/ci-workflows.nix
@@ -360,5 +360,33 @@
 
             touch "$out"
           '';
+
+      checks.reusable-terraform-policy-advisories =
+        pkgs.runCommand "reusable-terraform-policy-advisories"
+          {
+            nativeBuildInputs = [
+              pkgs.bash
+              pkgs.python3
+            ];
+          }
+          ''
+            python3 - <<'PY'
+            from pathlib import Path
+
+            workflow = Path("${terraformWorkflow}").read_text()
+            assert "POLICY_RUNNER_URL=" in workflow
+            assert "tofu-plan-policy-ci" in workflow
+            expected = (
+                'bash /tmp/tofu-plan-policy-ci /tmp/tofu-plan-policy.py "$PLAN_JSON" "'
+                + "$"
+                + '{POLICY_ARGS[@]}"'
+            )
+            assert expected in workflow
+            PY
+
+            cd ${../.}
+            python3 scripts/tests/test_policy.py
+            touch "$out"
+          '';
     };
 }

--- a/docs/Terraform-Shared-Infrastructure.status.org
+++ b/docs/Terraform-Shared-Infrastructure.status.org
@@ -519,6 +519,9 @@
           cloudflare_ruleset with same phase per zone root module" — this check is a
           hard gate requirement for blocksense/infra before imports can start)
     - [X] Integration with reusable-terraform-ci.yml (M1) as a policy gate step
+    - [X] CI adapter preserves hard failures while converting the policy
+          engine's documented advisory exit code 2 into a successful GitHub
+          warning annotation
     - [X] Policy runs on tofu show -json output (structured JSON, not text parsing)
 
 *** Verification
@@ -555,7 +558,7 @@
     - test_name: verify_moved_blocks_advisory
       description: Policy warns when plan shows create+destroy of same type without corresponding moved blocks
       status: pass
-      notes: tests/test_policy.py test 8 (moved_blocks_missing.json gives exit code 2 advisory)
+      notes: tests/test_policy.py tests 8 and 14-16 (the engine gives exit code 2; the CI adapter annotates it successfully while preserving hard failure and clean-success semantics)
 
     - test_name: verify_pluggable_static_checks
       description: Consuming repo can register a custom static check that runs as part of the policy gate

--- a/scripts/tests/test_policy.py
+++ b/scripts/tests/test_policy.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "tofu-plan-policy.py")
+CI_RUNNER = os.path.join(os.path.dirname(__file__), "..", "tofu-plan-policy-ci")
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
 
 
@@ -13,6 +14,15 @@ def run_policy(fixture: str, *args) -> subprocess.CompletedProcess:
     """Run the policy script with a fixture and extra args."""
     return subprocess.run(
         [sys.executable, SCRIPT, os.path.join(FIXTURES, fixture)] + list(args),
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_policy_ci(fixture: str, *args) -> subprocess.CompletedProcess:
+    """Run the CI adapter around the policy script."""
+    return subprocess.run(
+        ["bash", CI_RUNNER, SCRIPT, os.path.join(FIXTURES, fixture)] + list(args),
         capture_output=True,
         text=True,
     )
@@ -90,6 +100,18 @@ def main():
     # Test 13: Blast radius — expected resource types
     r = run_policy("scope_wrong_type.json", "--expected-resource-types", "cloudflare_r2_bucket")
     all_passed &= test("Blast radius unexpected type detected", r, 1, "unexpected resource types")
+
+    # Test 14: CI treats documented advisory exit 2 as a successful annotation.
+    r = run_policy_ci("moved_blocks_missing.json")
+    all_passed &= test("CI adapter annotates advisory warnings without failing", r, 0, "::warning::")
+
+    # Test 15: CI preserves hard policy failures.
+    r = run_policy_ci("import_with_update.json", "--mode", "import-only")
+    all_passed &= test("CI adapter preserves hard policy failure", r, 1, "POLICY VIOLATIONS")
+
+    # Test 16: CI preserves clean success.
+    r = run_policy_ci("no_changes.json", "--mode", "import-only")
+    all_passed &= test("CI adapter preserves clean success", r, 0, "Policy check PASSED")
 
     print()
     if all_passed:

--- a/scripts/tofu-plan-policy-ci
+++ b/scripts/tofu-plan-policy-ci
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+if (($# < 2)); then
+  echo "usage: tofu-plan-policy-ci POLICY_SCRIPT PLAN_JSON [POLICY_ARGS...]" >&2
+  exit 64
+fi
+
+policy_script="$1"
+shift
+
+if python3 "$policy_script" "$@"; then
+  exit 0
+else
+  policy_status=$?
+fi
+
+case "$policy_status" in
+  2)
+    echo "::warning::OpenTofu plan policy reported advisory warnings; see the policy output above."
+    exit 0
+    ;;
+  *)
+    exit "$policy_status"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- add a small CI adapter for `tofu-plan-policy.py` that converts documented advisory exit code 2 into a GitHub warning annotation
- preserve exit 1 and every other hard failure unchanged
- wire the reusable Terraform workflow to the adapter and add engine/adapter/wiring regression coverage
- retain current `main`'s Reprobuild pin (`1cf4d0f9`), which contains PR #28's shared RBCA v2 extractor fix, so the required cross-host cache check verifies current archives

## Trigger

Agent Harbor infra PR #265 produced its exact expected AWS plan (24 create, 7 update, 2 delete, 0 replace). The policy engine printed `Policy check PASSED with 2 warning(s).` for the legitimate create/delete security-rule transition, then returned its documented advisory status 2. The reusable workflow treated that advisory as a failed shell step.

The first CI run also exposed an independent regression on current `main`: `t_cross_host_publish_substitute` used a private RBCA v1-only decoder after the shared publisher advanced to RBCA v2. Reprobuild PR #28 replaced that duplicate decoder with the version-compatible shared extractor. Current `main` now pins `1cf4d0f9`, a descendant containing that fix; this branch intentionally retains that newer pin after rebase.

## Validation

- `python3 scripts/tests/test_policy.py` — 16/16 pass
- `nix build --accept-flake-config --no-link .#checks.x86_64-linux.reusable-terraform-policy-advisories`
- `actionlint .github/workflows/reusable-terraform-ci.yml`
- `bash -n scripts/tofu-plan-policy-ci`
- `git diff --check`
- `nix build --accept-flake-config -L .#checks.x86_64-linux.t_cross_host_publish_substitute` — real two-node TCP publish/substitute passed with 5 RBCA v2 members and byte-identical extraction
