### PR TITLE
feat(terraform): agnostic GitHub branch-protection ruleset library

### DIFF
--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -1,0 +1,71 @@
+# Shared GitHub Terraform library
+
+Company-agnostic Terranix helpers for managing GitHub via Terraform/OpenTofu.
+Consumers supply their own data (repositories, policy, credentials); this
+directory ships only the reusable logic. Pairs with the reusable Terraform CI
+workflow (`.github/workflows/reusable-terraform-ci.yml`) and the plan policy in
+`scripts/tofu-plan-policy.py`.
+
+## `branch-protection.nix` — branch-protection rulesets
+
+Renders `github_repository_ruleset` resources from a **branch-protection
+policy** plus per-repository configuration. It standardizes on repository
+rulesets (not classic branch protection), which is what lets a single
+wildcard rule protect _every_ branch.
+
+The policy is org-agnostic and best kept as shared data (for Metacraft this is
+`metacraft-dev-guidelines/policies/branch-protection-policy.json`, consumed as a
+`flake = false` input — no flake needed in the source repo). The policy fixes
+_which branch classes gate on CI_; the caller passes each repository's concrete
+required-check contexts.
+
+### Usage
+
+```nix
+let
+  branchProtection = import ./branch-protection.nix { inherit lib; };
+in
+branchProtection.mkRulesets {
+  policy = builtins.fromJSON (builtins.readFile
+    "${inputs.dev-guidelines}/policies/branch-protection-policy.json");
+  repositories = {
+    "my-product" = {
+      repoClass = "product";                      # product | spec | infra | product-adapted-fork
+      checks = {
+        dev = [ "ci / build" "ci / test" ];       # concrete required-check contexts
+        stable = [ "release" ];
+      };
+    };
+    "my-infra" = {
+      repoClass = "infra";
+      checks.live = [ "terraform / plan" "lint" ];
+    };
+  };
+}
+```
+
+`mkRulesets` returns `{ resource.github_repository_ruleset = { ... }; }`,
+mergeable into a Terranix root that also declares the `github` provider.
+
+### What it emits
+
+- **One baseline ruleset per repository** targeting `~ALL` branches, blocking
+  force pushes and deletions (`non_fast_forward` / `deletion`) — this is the
+  "every branch protected from force push" universal rule.
+- **One ruleset per applicable branch class** (matched by `repoClass`) that
+  gates on CI: `required_status_checks` with the repo's contexts, plus
+  `pull_request` review when the class requires it. Classes that require
+  neither (e.g. `agents`) emit no extra ruleset and rely on the baseline — so
+  `agents` is protected from force-push but does **not** gate on CI, matching
+  the branching policy.
+
+### Validate offline
+
+```bash
+nix-instantiate --eval --strict --json example/config.nix > example/config.tf.json
+cd example && tofu init -backend=false && tofu validate
+```
+
+The example is validated against the real `integrations/github` provider
+schema (`tofu validate` → `Success`). A real consumer swaps the fixture for the
+shared policy file and its own repository list.

--- a/terraform/github/branch-protection.nix
+++ b/terraform/github/branch-protection.nix
@@ -1,0 +1,151 @@
+# Agnostic branch-protection rulesets for GitHub repositories.
+#
+# Renders `github_repository_ruleset` resources from the shared branch-protection
+# policy (the machine-readable `branch-protection-policy.json` maintained in
+# metacraft-dev-guidelines) plus per-repository configuration. This library is
+# company- and repository-agnostic: the caller supplies the parsed policy, the
+# list of repositories, each repository's class, and its concrete required-check
+# contexts. The policy fixes *which* branch classes gate on CI; the caller
+# provides the *check names*.
+#
+# Usage (from a Terranix root):
+#
+#   let bp = import ./branch-protection.nix { inherit lib; };
+#   in bp.mkRulesets {
+#     policy = builtins.fromJSON (builtins.readFile "${inputs.dev-guidelines}/policies/branch-protection-policy.json");
+#     repositories = {
+#       "my-product" = {
+#         repoClass = "product";
+#         checks = { dev = [ "ci / build" "ci / test" ]; stable = [ "release" ]; };
+#       };
+#       "my-infra" = {
+#         repoClass = "infra";
+#         checks.live = [ "terraform / plan" "lint" ];
+#       };
+#     };
+#   }
+{ lib }:
+let
+  inherit (lib)
+    filterAttrs
+    concatMapAttrs
+    foldlAttrs
+    optionalAttrs
+    replaceStrings
+    ;
+
+  # Sanitize a repo/branch identifier into a Terraform resource key.
+  key =
+    replaceStrings
+      [
+        "/"
+        "."
+        "*"
+        "<"
+        ">"
+        "-"
+        " "
+      ]
+      [
+        "_"
+        "_"
+        "star"
+        ""
+        ""
+        "_"
+        "_"
+      ];
+in
+{
+  # policy: the parsed branch-protection-policy.json (baseline + branchClasses).
+  # repositories: attrset keyed by repo name; each value is
+  #   { repoClass;                         # "product" | "spec" | "infra" | "product-adapted-fork"
+  #     checks ? { };                       # { <branchClassKey> = [ "context" ... ]; }
+  #     reviewCount ? 1; }
+  mkRulesets =
+    { policy, repositories }:
+    let
+      inherit (policy) baseline branchClasses;
+
+      # Baseline ruleset: every branch, no force push / no deletion.
+      baselineRuleset = repoName: {
+        name = "baseline-protect-all-branches";
+        repository = repoName;
+        target = "branch";
+        enforcement = "active";
+        conditions.ref_name = {
+          include = [ "~ALL" ];
+          exclude = [ ];
+        };
+        rules = {
+          # A `true` rule blocks the operation.
+          deletion = !(baseline.allowDeletion or false);
+          non_fast_forward = !(baseline.allowForcePush or false);
+        };
+      };
+
+      # Per-class rulesets for one repo: only classes whose repoClass matches.
+      classRulesets =
+        repoName: repoCfg:
+        let
+          applicable = filterAttrs (_: c: c.repoClass == repoCfg.repoClass) branchClasses;
+        in
+        concatMapAttrs (
+          branchKey: cls:
+          let
+            # Which branch(es) this class targets.
+            refInclude =
+              if cls ? pattern then
+                (
+                  if cls.pattern == "<product-name>" then
+                    [ "refs/heads/${repoName}" ]
+                  else
+                    [ "refs/heads/${cls.pattern}" ]
+                )
+              else
+                [ "refs/heads/${branchKey}" ];
+            contexts = repoCfg.checks.${branchKey} or [ ];
+            rules =
+              optionalAttrs (cls.requireStatusChecks or false) {
+                required_status_checks = {
+                  strict_required_status_checks_policy = true;
+                  required_check = map (ctx: { context = ctx; }) contexts;
+                };
+              }
+              // optionalAttrs (cls.requirePullRequestReview or false) {
+                pull_request = {
+                  required_approving_review_count = repoCfg.reviewCount or 1;
+                  dismiss_stale_reviews_on_push = true;
+                  require_code_owner_review = false;
+                };
+              };
+          in
+          # Emit only when this class adds something beyond the baseline.
+          optionalAttrs (rules != { }) {
+            "ruleset_${key repoName}_${key branchKey}" = {
+              name = "${branchKey}-policy";
+              repository = repoName;
+              target = "branch";
+              enforcement = "active";
+              conditions.ref_name = {
+                include = refInclude;
+                exclude = [ ];
+              };
+              inherit rules;
+            };
+          }
+        ) applicable;
+
+      allRulesets = foldlAttrs (
+        acc: repoName: repoCfg:
+        acc
+        // {
+          "ruleset_${key repoName}_baseline" = baselineRuleset repoName;
+        }
+        // classRulesets repoName repoCfg
+      ) { } repositories;
+    in
+    {
+      resource.github_repository_ruleset = allRulesets;
+    };
+}

--- a/terraform/github/example/config.nix
+++ b/terraform/github/example/config.nix
@@ -1,0 +1,61 @@
+# Example Terranix root exercising the branch-protection ruleset library.
+#
+# Render and validate offline:
+#   terranix --quiet example/config.nix > config.tf.json
+#   tofu init -backend=false && tofu validate
+#
+# A real consumer passes the policy from the shared data file instead of the
+# fixture, e.g.
+#   policy = builtins.fromJSON (builtins.readFile
+#     "${inputs.dev-guidelines}/policies/branch-protection-policy.json");
+let
+  pkgs = import <nixpkgs> { };
+  inherit (pkgs) lib;
+  branchProtection = import ../branch-protection.nix { inherit lib; };
+
+  policy = builtins.fromJSON (builtins.readFile ./policy.fixture.json);
+
+  rulesets = branchProtection.mkRulesets {
+    inherit policy;
+    repositories = {
+      # A product repo: dev/stable gate on CI, agents does not.
+      "my-product" = {
+        repoClass = "product";
+        checks = {
+          dev = [
+            "ci / build"
+            "ci / test"
+          ];
+          stable = [
+            "release"
+            "package"
+          ];
+        };
+      };
+      # A spec repo: latest gates on the docs checks.
+      "my-specs" = {
+        repoClass = "spec";
+        checks.latest = [
+          "markdown lint"
+          "link check"
+        ];
+      };
+      # An infra repo: live gates on plan + lint.
+      "my-infra" = {
+        repoClass = "infra";
+        checks.live = [
+          "terraform / plan"
+          "lint"
+        ];
+      };
+    };
+  };
+in
+{
+  terraform.required_providers.github = {
+    source = "integrations/github";
+    version = ">= 6.0";
+  };
+  provider.github.owner = "example-org";
+}
+// rulesets

--- a/terraform/github/example/policy.fixture.json
+++ b/terraform/github/example/policy.fixture.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Representative fixture of the shared branch-protection policy for the example/tests. The real policy is maintained in metacraft-dev-guidelines/policies/branch-protection-policy.json and passed in by consumers.",
+  "version": 1,
+  "baseline": { "allowForcePush": false, "allowDeletion": false },
+  "branchClasses": {
+    "stable": { "repoClass": "product", "requireStatusChecks": true, "requirePullRequestReview": true },
+    "dev": { "repoClass": "product", "requireStatusChecks": true, "requirePullRequestReview": true },
+    "agents": { "repoClass": "product", "requireStatusChecks": false, "requirePullRequestReview": false },
+    "latest": { "repoClass": "spec", "requireStatusChecks": true },
+    "live": { "repoClass": "infra", "requireStatusChecks": true }
+  }
+}


### PR DESCRIPTION
First shared Terraform/Terranix library in `nixos-modules` — Phase 1 of the infra→Terraform campaign (design doc lives in the private `metacraft-specs`). Establishes `terraform/` as the home for reusable, company-agnostic TF/Terranix libraries.

## `terraform/github/branch-protection.nix`
`mkRulesets { policy, repositories }` → `github_repository_ruleset` resources:

- **One baseline ruleset per repo** targeting `~ALL` branches, blocking force pushes and deletions — the universal "every branch protected from force push".
- **One ruleset per applicable branch class** (matched by `repoClass`) that gates on CI: `required_status_checks` + optional `pull_request` review. Classes that gate on neither (e.g. `agents`) emit nothing and rely on the baseline — protected from force-push, but not CI-gated.

### Design choices (per the campaign decisions)
- **Repository rulesets, not classic branch protection** — required for a single wildcard "all branches" rule.
- The policy fixes *which branch classes gate on CI*; the caller passes concrete **check contexts**, so the library stays org- and repo-agnostic.
- The policy is external shared data — for Metacraft, `metacraft-dev-guidelines/policies/branch-protection-policy.json`, consumed as a `flake = false` input (no flake needed in the source repo).

### Validation
The example (`terraform/github/example/`) renders and **`tofu validate` passes against the real `integrations/github` provider** — the resource shape is verified, not guessed. Nix formatted with `nixfmt`, docs with `prettier`.

Follow-ups (tracked in the campaign doc): wire a `tofu test` mock harness for the reusable-terraform-ci offline job, and the larger governance/secrets-as-code engine extraction.