### PR TITLE
feat(terraform): agnostic Terraform CI groundwork (matrix + metadata schema)

### DIFF
--- a/terraform/ci/README.md
+++ b/terraform/ci/README.md
@@ -1,0 +1,44 @@
+# Shared Terraform CI groundwork
+
+Company-agnostic tooling for the Terraform _operating layer_ every consumer
+repo needs to drive infrastructure through the reusable CI workflow
+(`.github/workflows/reusable-terraform-ci.yml`). Consumers supply their own
+roots, backends, credentials, and identifiers; this directory ships only the
+reusable discovery/validation machinery.
+
+## `terraform-ci-matrix`
+
+Discovers managed Terraform roots (any directory under `terraform/` holding a
+`metadata.json`), validates each against the shared contract, and emits the
+GitHub Actions matrix a repo's thin `terraform.yml` caller feeds into the
+reusable workflow.
+
+Unlike a company-specific generator, it hardcodes **no** provider names,
+credential paths, or per-root smoke tests — everything comes from each root's
+`metadata.json`. A root can be added before its CI keys exist: `agenix-token`
+credentials are only emitted once the referenced encrypted secrets are present.
+
+```bash
+terraform-ci-matrix --root-dir . --pretty            # local troubleshooting
+terraform-ci-matrix --github-output "$GITHUB_OUTPUT" # writes matrix=<json>
+```
+
+## `metadata.json` contract
+
+Each managed root carries a `metadata.json` validated against
+[`metadata.schema.json`](./metadata.schema.json). Required: `state_key`,
+`state_sensitivity` (`standard` | `sensitive`), `backend_config_file`,
+`credential_mode` (`aws-oidc` | `agenix-token` | `none`), `enable_checkov`,
+`provider_allowlist`. `agenix-token` roots also require `credentials_env_name`
+and `agenix_{plan,apply}_secret_path`. Optional: `smoke_test_command`,
+`split_boundary` (prose; see the root-layering runbook).
+
+The one fixed rule: the state key must match its sensitivity —
+`terraform/<config>.tfstate` for `standard`, `terraform-sensitive/<config>.tfstate`
+for `sensitive`, where `<config>` is the root path minus the leading
+`terraform/`. This keeps sensitive state on an auditable key prefix.
+
+## Tests
+
+`tests/test-matrix.sh` covers discovery and negative validation offline (no
+credentials, no network).

--- a/terraform/ci/metadata.schema.json
+++ b/terraform/ci/metadata.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Terraform root metadata",
+  "description": "Per-root contract consumed by terraform-ci-matrix. Company-agnostic; identifiers are supplied by the consuming repo.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["state_key", "state_sensitivity", "backend_config_file", "credential_mode", "enable_checkov", "provider_allowlist"],
+  "properties": {
+    "state_key": { "type": "string", "description": "Backend state key. Must be terraform/<config>.tfstate (standard) or terraform-sensitive/<config>.tfstate (sensitive), where <config> is the root path minus the leading terraform/." },
+    "state_sensitivity": { "enum": ["standard", "sensitive"] },
+    "backend_config_file": { "type": "string", "description": "Path to the root's backends/*.hcl (state key only; never secrets)." },
+    "credential_mode": { "enum": ["aws-oidc", "agenix-token", "none"] },
+    "credentials_env_name": { "type": "string", "description": "Required for agenix-token: env var the decrypted token is exported as (e.g. GITHUB_TOKEN, CLOUDFLARE_API_TOKEN)." },
+    "agenix_plan_secret_path": { "type": "string", "description": "Required for agenix-token: repo-relative path to the read-only (plan) agenix secret." },
+    "agenix_apply_secret_path": { "type": "string", "description": "Required for agenix-token: repo-relative path to the read-write (apply) agenix secret." },
+    "enable_checkov": { "type": "boolean" },
+    "provider_allowlist": { "type": "array", "minItems": 1, "items": { "type": "string" }, "description": "Exact terraform.required_providers source values permitted in this root." },
+    "smoke_test_command": { "type": "string", "description": "Optional post-apply smoke test command." },
+    "split_boundary": { "type": "object", "description": "Optional prose documenting why this root is a separate state boundary (see the root-layering runbook)." }
+  }
+}

--- a/terraform/ci/terraform-ci-matrix
+++ b/terraform/ci/terraform-ci-matrix
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Company-agnostic Terraform CI matrix generator.
+#
+# Discovers managed Terraform roots (any directory under `terraform/` holding a
+# `metadata.json`), validates each metadata against the shared contract, and
+# emits the GitHub Actions matrix consumed by a repo's thin `terraform.yml`
+# caller (which invokes the reusable-terraform-ci workflow). Unlike a
+# company-specific version, this script hardcodes no provider names, credential
+# paths, or per-root smoke tests: everything comes from each root's
+# `metadata.json`. See `metadata.schema.json` for the contract.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: terraform-ci-matrix [--pretty] [--github-output FILE] [--root-dir DIR]
+
+Options:
+  --pretty              Pretty-print the matrix for local troubleshooting.
+  --github-output FILE  Also write matrix=<json> to a GitHub Actions output file.
+  --root-dir DIR        Repository root. Defaults to $PWD.
+  -h, --help            Show this help text.
+USAGE
+}
+
+format="compact"
+github_output=""
+root_dir="$PWD"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pretty) format="pretty"; shift ;;
+    --github-output)
+      [[ $# -ge 2 ]] || { echo "--github-output requires a file path." >&2; exit 2; }
+      github_output="$2"; shift 2 ;;
+    --root-dir)
+      [[ $# -ge 2 ]] || { echo "--root-dir requires a directory." >&2; exit 2; }
+      root_dir="$(cd -- "$2" && pwd)"; shift 2 ;;
+    -h | --help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# A root is `terraform/<segment>/.../<name>` — at least one level under terraform/.
+is_safe_terraform_root() {
+  [[ "$1" =~ ^terraform/[A-Za-z0-9._/-]+$ && "$1" != *".."* ]]
+}
+
+rows=()
+failures=0
+
+while IFS= read -r root; do
+  [[ -z "$root" ]] && continue
+  config="${root#terraform/}"
+  metadata_file="${root_dir}/${root}/metadata.json"
+
+  if ! is_safe_terraform_root "$root"; then
+    echo "Discovered unsafe Terraform root '${root}'." >&2
+    failures=$((failures + 1)); continue
+  fi
+
+  # Structural validation of the metadata contract. Company-agnostic: the only
+  # fixed rule is the state-key <-> sensitivity naming convention.
+  if ! jq -e --arg config "$config" '
+    def nonempty_string: type == "string" and length > 0;
+    def string_array: type == "array" and all(.[]; type == "string" and length > 0);
+    (.state_key | nonempty_string)
+    and (.backend_config_file | nonempty_string)
+    and (.state_sensitivity | IN("standard", "sensitive"))
+    and (.credential_mode | IN("aws-oidc", "agenix-token", "none"))
+    and (.enable_checkov | type == "boolean")
+    and (.provider_allowlist | string_array and length > 0)
+    # agenix-token roots must declare their env name and plan/apply secret paths.
+    and (
+      .credential_mode != "agenix-token"
+      or (
+        (.credentials_env_name | nonempty_string)
+        and (.agenix_plan_secret_path | nonempty_string)
+        and (.agenix_apply_secret_path | nonempty_string)
+      )
+    )
+    and (
+      (.state_sensitivity == "standard"  and .state_key == ("terraform/" + $config + ".tfstate"))
+      or
+      (.state_sensitivity == "sensitive" and .state_key == ("terraform-sensitive/" + $config + ".tfstate"))
+    )
+  ' "$metadata_file" >/dev/null 2>&1; then
+    echo "Terraform root '${root}' is missing or has invalid metadata.json." >&2
+    failures=$((failures + 1)); continue
+  fi
+
+  credential_mode="$(jq -r '.credential_mode' "$metadata_file")"
+  uses_aws_oidc=false
+  credentials_env_name=""
+  agenix_plan_secret_path=""
+  agenix_apply_secret_path=""
+  smoke_test_command="$(jq -r '.smoke_test_command // ""' "$metadata_file")"
+
+  case "$credential_mode" in
+    aws-oidc)
+      uses_aws_oidc=true ;;
+    agenix-token)
+      credentials_env_name="$(jq -r '.credentials_env_name' "$metadata_file")"
+      agenix_plan_secret_path="$(jq -r '.agenix_plan_secret_path' "$metadata_file")"
+      agenix_apply_secret_path="$(jq -r '.agenix_apply_secret_path' "$metadata_file")"
+      # Only emit credentials when the encrypted secrets are actually present,
+      # so a root can be added before its CI keys are provisioned.
+      if [[ ! -f "${root_dir}/${agenix_plan_secret_path}" || ! -f "${root_dir}/${agenix_apply_secret_path}" ]]; then
+        credentials_env_name=""; agenix_plan_secret_path=""; agenix_apply_secret_path=""
+      fi ;;
+    none) : ;;
+  esac
+
+  row="$(jq -c -n \
+    --arg root "$root" \
+    --arg config "$config" \
+    --argjson metadata "$(jq -c . "$metadata_file")" \
+    --argjson uses_aws_oidc "$uses_aws_oidc" \
+    --arg credentials_env_name "$credentials_env_name" \
+    --arg agenix_plan_secret_path "$agenix_plan_secret_path" \
+    --arg agenix_apply_secret_path "$agenix_apply_secret_path" \
+    --arg smoke_test_command "$smoke_test_command" \
+    '{
+      root: $root,
+      config: $config,
+      state_key: $metadata.state_key,
+      backend_config_file: $metadata.backend_config_file,
+      provider_allowlist: ($metadata.provider_allowlist | join(",")),
+      enable_checkov: $metadata.enable_checkov,
+      state_sensitivity: $metadata.state_sensitivity,
+      credential_mode: $metadata.credential_mode,
+      uses_aws_oidc: $uses_aws_oidc,
+      credentials_env_name: $credentials_env_name,
+      agenix_plan_secret_path: $agenix_plan_secret_path,
+      agenix_apply_secret_path: $agenix_apply_secret_path,
+      smoke_test_command: $smoke_test_command
+    }')"
+  rows+=("$row")
+done < <(cd "$root_dir" && find terraform -name metadata.json -exec dirname {} \; 2>/dev/null | sort)
+
+if ((failures > 0)); then
+  echo "Terraform CI matrix metadata check failed with ${failures} issue(s)." >&2
+  exit 1
+fi
+
+if ((${#rows[@]} == 0)); then
+  matrix='{"include":[]}'
+else
+  matrix="$(printf '%s\n' "${rows[@]}" | jq -s -c '{include: .}')"
+fi
+
+if [[ -n "$github_output" ]]; then
+  printf 'matrix=%s\n' "$matrix" >> "$github_output"
+fi
+
+if [[ "$format" == "pretty" ]]; then
+  jq . <<<"$matrix"
+else
+  printf '%s\n' "$matrix"
+fi

--- a/terraform/ci/tests/test-matrix.sh
+++ b/terraform/ci/tests/test-matrix.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Self-contained tests for terraform-ci-matrix (positive discovery + negative
+# validation). No credentials or network required.
+set -euo pipefail
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+matrix="${here}/../terraform-ci-matrix"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fail=0
+
+mkroot() { mkdir -p "$tmp/$1"; cat > "$tmp/$1/metadata.json"; }
+
+# Two valid roots.
+mkroot terraform/github/governance <<'J'
+{ "state_key":"terraform/github/governance.tfstate","state_sensitivity":"standard",
+  "backend_config_file":"backends/gh.hcl","credential_mode":"agenix-token",
+  "credentials_env_name":"GITHUB_TOKEN","agenix_plan_secret_path":"a.age","agenix_apply_secret_path":"b.age",
+  "enable_checkov":false,"provider_allowlist":["integrations/github"] }
+J
+mkroot terraform/aws/prod <<'J'
+{ "state_key":"terraform/aws/prod.tfstate","state_sensitivity":"standard","backend_config_file":"backends/aws.hcl",
+  "credential_mode":"aws-oidc","enable_checkov":true,"provider_allowlist":["hashicorp/aws"] }
+J
+out="$("$matrix" --root-dir "$tmp")"
+n="$(jq '.include | length' <<<"$out")"
+[[ "$n" == "2" ]] || { echo "FAIL: expected 2 roots, got $n"; fail=1; }
+jq -e '.include[] | select(.root=="terraform/aws/prod") | .uses_aws_oidc == true' <<<"$out" >/dev/null \
+  || { echo "FAIL: aws root should set uses_aws_oidc"; fail=1; }
+
+# Invalid: state_key does not match sensitivity naming rule.
+badtmp="$(mktemp -d)"; mkdir -p "$badtmp/terraform/x/y"
+cat > "$badtmp/terraform/x/y/metadata.json" <<'J'
+{ "state_key":"wrong.tfstate","state_sensitivity":"standard","backend_config_file":"b.hcl",
+  "credential_mode":"none","enable_checkov":false,"provider_allowlist":["hashicorp/aws"] }
+J
+if "$matrix" --root-dir "$badtmp" >/dev/null 2>&1; then echo "FAIL: bad state_key should exit non-zero"; fail=1; fi
+rm -rf "$badtmp"
+
+[[ "$fail" == "0" ]] && echo "OK: terraform-ci-matrix tests passed" || exit 1


### PR DESCRIPTION
**Phase 0** of the infra→Terraform campaign (design in private `metacraft-specs`): extract the company-agnostic Terraform *operating-layer* tooling into `nixos-modules` so metacraft and blocksense consume it instead of reinventing agent-harbor's version.

## What's here
- **`terraform/ci/terraform-ci-matrix`** — discovers managed roots (any dir under `terraform/` with a `metadata.json`), validates each against the shared contract, and emits the GitHub Actions matrix a repo's thin `terraform.yml` caller feeds into `reusable-terraform-ci.yml`.
  - **Fully metadata-driven**: no hardcoded provider names, credential paths, or per-root smoke tests — generalized from agent-harbor's version (which hardcoded cloudflare/stripe age paths and an AH-specific smoke test).
  - A root can be added before its CI keys exist: `agenix-token` credentials are only emitted once the referenced secrets are present.
- **`terraform/ci/metadata.schema.json`** — the per-root contract (JSON Schema). Fixed rule: state key must match sensitivity (`terraform/…` vs `terraform-sensitive/…`).
- **`terraform/ci/tests/test-matrix.sh`** — offline discovery + negative-validation tests.

## Validation
Test passes; `shellcheck` clean; editorconfig / EOF / prettier clean.

## Not in this PR (needs your decisions)
The per-repo **Layer-0 bootstrap** — state backend choice (blocksense has none; S3 vs GCS + account), OIDC vs agenix-token credential identity — is human-applied infra I'll scaffold once those are decided. This PR is the reusable machinery that sits above it.