### PR TITLE
garm: converge nested KVM guest access

### DIFF
--- a/packages/garm-provider-vmharness/src/internal/backend/incus.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/incus.go
@@ -634,6 +634,31 @@ func (b *IncusBackend) Create(ctx context.Context, args CreateArgs) (Instance, e
 		return Instance{}, fmt.Errorf("incus start %s: %w: %s", args.Name, err, strings.TrimSpace(out))
 	}
 
+	// Incus' unix-char device is requested with mode=0666 above, but the
+	// container's device setup can still settle /dev/kvm to the host udev mode
+	// (0660 root:kvm). Cloud-init also reapplies the default runner groups and
+	// can remove the image-baked kvm membership. Converge the guest-local mode
+	// after start, before Create returns and GARM can assign a job. This affects
+	// only the dedicated NestedKvm class; the plain runner remains unchanged.
+	if b.NestedKvm {
+		ready := false
+		for i := 0; i < 30; i++ {
+			if _, err := b.run(ctx, "", "exec", args.Name, "--", "true"); err == nil {
+				ready = true
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		if !ready {
+			_ = b.forceDelete(ctx, args.Name)
+			return Instance{}, fmt.Errorf("incus container %s did not become ready for nested KVM setup", args.Name)
+		}
+		if out, err := b.run(ctx, "", "exec", args.Name, "--", "chmod", "0666", "/dev/kvm"); err != nil {
+			_ = b.forceDelete(ctx, args.Name)
+			return Instance{}, fmt.Errorf("nested KVM access setup on %s failed: %w: %s", args.Name, err, strings.TrimSpace(out))
+		}
+	}
+
 	// 6. Shared Nix client onto STANDARD paths (post-start). Mounting the host
 	//    store + daemon socket is not sufficient when the Debian runner image
 	//    has no Nix client of its own: setup-nix otherwise tries a single-user

--- a/packages/garm-provider-vmharness/src/internal/backend/incus_test.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/incus_test.go
@@ -459,6 +459,13 @@ func TestIncusNestedKvmAttachesKvmDevice(t *testing.T) {
 	if !strings.Contains(string(config), "security.nesting\ttrue") {
 		t.Fatalf("expected security.nesting=true with nested-kvm on, got config:\n%s", string(config))
 	}
+	execs, err := os.ReadFile(filepath.Join(stateDir, "garm-kvm-1", "execs"))
+	if err != nil {
+		t.Fatalf("expected post-start nested KVM access setup, but no execs file: %v", err)
+	}
+	if !strings.Contains(string(execs), "-- chmod 0666 /dev/kvm") {
+		t.Fatalf("expected guest-local /dev/kvm mode convergence before Create returns, got: %q", string(execs))
+	}
 
 	// The plain (default-OFF) backend must NOT add a kvm device or set
 	// security.nesting: the existing live runners stay byte-unchanged.


### PR DESCRIPTION
## Summary

Make the opt-in Incus nested-KVM runner class converge guest-local `/dev/kvm` permissions after container start and before GARM can assign a job.

- wait until `incus exec` is ready for a nested-KVM container;
- enforce `chmod 0666 /dev/kvm` inside that dedicated ephemeral guest;
- fail closed and remove the container if readiness or permission convergence fails;
- assert the post-start command in the backend lifecycle test;
- leave every plain Incus runner unchanged.

## Live incident evidence

The rebuilt nested image and provider successfully launched a fresh runner, and nested Docker passed (`fuse-overlayfs`, `docker run`, and `docker build`). The KVM probe then found `/dev/kvm` as `0660 root:kvm`; cloud-init had reset the runner groups to `runner,docker`, so unprivileged open returned `EACCES`. A root probe opened the same device and returned KVM API version 12, proving device passthrough and host nested virtualization are healthy.

Evidence: metacraft-labs/infra Actions runs `29778437979` and `29778636885`.

## Exact expected deployment behavior

1. Existing non-nested Incus providers execute no new commands.
2. An `incus_nested_kvm=true` provider still attaches the host `/dev/kvm` device and starts the ephemeral container.
3. Before Create returns, the provider waits up to 30 seconds for guest exec readiness and sets only that guest device to mode `0666`.
4. If readiness or chmod fails, the provider deletes the incomplete container and reports Create failure; GARM cannot assign a job to it.
5. After a consumer pins this revision and deploys the provider, a fresh `eph-linux-x64-nested` job can open KVM as the unprivileged runner and complete the existing accelerated QEMU boot proof.

No Terraform, host KVM device mode, plain-runner image, network, scale-set, or secret change is expected.

## Validation

- `git diff --check`
- `nix shell nixpkgs#go --command env CGO_ENABLED=0 go test ./internal/backend` (from the provider module)
- `nix build --accept-flake-config --no-link .#garm-provider-vmharness`