### PR TITLE
feat(terraform/github): shared GitHub governance engine

### DIFF
--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -70,6 +70,44 @@ The example is validated against the real `integrations/github` provider
 schema (`tofu validate` → `Success`). A real consumer swaps the fixture for the
 shared policy file and its own repository list.
 
+## `governance.nix` — GitHub governance engine
+
+Maps a declarative **governance model** (repositories, memberships, teams,
+branch protection, Environments, Actions permissions/variables, issue labels)
+plus a **secret manifest** and the GitHub-encrypted **payloads** rendered by
+`github-governance-secrets-render` into `github_*` Terraform resources, and
+exposes the rich `output` block the bootstrap helper reads. It is the engine
+behind each org's `bootstrap/github/<name>-governance-prod` root.
+
+Everything company-specific is a parameter; the machinery (name sanitizers,
+list→resource mappers, the secret-manifest validation that throws on unknown or
+missing managed/payload ids) is org-agnostic. A consumer's `root.nix` becomes a
+thin caller that resolves its local generated documents and passes its own data:
+
+```nix
+{ managedFile ? ./secrets/managed.generated.nix, payloadFile ? ./secrets/payloads.generated.nix, ... }:
+{ ... }:
+import "${inputs.nixos-modules}/terraform/github/governance.nix" {
+  awsAccountId = "…";
+  awsRegion = "us-east-1";
+  githubOwner = "…";                                   # githubAccessCheckRepository defaults to <owner>/infra
+  githubBootstrapStateKey = "bootstrap/github/…-governance-prod.tfstate";
+  governance = import ./governance.nix;                 # the org inventory model (per-company data)
+  manifest = import ./secrets/manifest.nix;             # the secret registry (per-company data)
+  managedDoc = if builtins.pathExists managedFile then import managedFile else { providerIds = [ ]; };
+  payloadDoc = if builtins.pathExists payloadFile then import payloadFile else { payloads = { }; };
+}
+```
+
+The `governance` and `manifest` documents stay in each infra repo — they are the
+org's inventory and secret facts. Only the mapper is shared. See
+[`governance.example.nix`](./governance.example.nix) for a minimal renderable
+model and [`tests/test-render.sh`](./tests/test-render.sh) for the offline check.
+
+Verifying an extraction is a no-op is the same as for the AWS module: render the
+original `root.nix` and the thin caller with identical data and `diff` the
+`nix eval --json | jq -S` output — empty diff == zero plan diff == safe.
+
 ## `github-bootstrap` — GitHub Layer-0 driver
 
 Org-admin driver for the GitHub side of Layer 0: the CI-enabling repo settings

--- a/terraform/github/governance.example.nix
+++ b/terraform/github/governance.example.nix
@@ -1,0 +1,120 @@
+# Example caller for governance.nix. A real consumer's governance root
+# (bootstrap/github/<name>-governance-prod/root.nix) imports this engine and
+# passes its own `governance` inventory model and secret `manifest`, plus the
+# resolved managed/payload documents rendered by github-governance-secrets-render.
+# This fixture supplies a tiny, org-agnostic model so the engine can be rendered
+# offline (Nix eval only) with no credentials and no company literals.
+import ./governance.nix {
+  awsAccountId = "000000000000";
+  awsRegion = "us-east-1";
+  githubOwner = "example-org";
+  githubBootstrapStateKey = "bootstrap/github/example-governance-prod.tfstate";
+
+  governance = {
+    snapshot.source = "example-inventory-snapshot";
+    organization.actionsPermissions = {
+      enabledRepositories = "all";
+      allowedActions = "selected";
+      shaPinningRequired = true;
+    };
+    repositories = [
+      {
+        name = "infra";
+        visibility = "private";
+        hasIssues = true;
+        hasProjects = false;
+        hasWiki = false;
+        hasDiscussions = false;
+        allowForking = false;
+        archived = false;
+        isTemplate = false;
+        webCommitSignoffRequired = false;
+        defaultBranch = "live";
+        description = "Infrastructure as code.";
+        topics = [ "terraform" ];
+      }
+    ];
+    memberships = [
+      {
+        username = "example-admin";
+        role = "admin";
+      }
+    ];
+    outsideCollaborators = [ ];
+    teamRepositories = [
+      {
+        teamSlug = "infra";
+        repository = "infra";
+        permission = "admin";
+      }
+    ];
+    branchProtections = [
+      {
+        repository = "infra";
+        pattern = "live";
+        enforceAdmins = true;
+        allowsDeletions = false;
+        allowsForcePushes = false;
+        requiredLinearHistory = false;
+        requireConversationResolution = true;
+        requireSignedCommits = false;
+        lockBranch = false;
+        requiredStatusChecks = {
+          strict = true;
+          contexts = [ "ci / build" ];
+        };
+      }
+    ];
+    repositoryEnvironments = [
+      {
+        repository = "infra";
+        environment = "production";
+        canAdminsBypass = true;
+        waitTimer = 0;
+      }
+    ];
+    actionsRepositoryPermissions = [
+      {
+        repository = "infra";
+        enabled = true;
+        allowedActions = "selected";
+        shaPinningRequired = true;
+      }
+    ];
+    actionsVariables = [
+      {
+        repository = "infra";
+        name = "BACKEND_CONFIG_FILE";
+        value = "backends/aws-example-prod.hcl";
+      }
+    ];
+    issueLabels = [
+      {
+        repository = "infra";
+        name = "sensitive-change";
+        color = "b60205";
+        description = "Touches Layer-0 or secrets.";
+      }
+    ];
+    deferredResources = [ ];
+  };
+
+  # One org secret declared but not yet promoted to Terraform management (absent
+  # from managedDoc), so the engine renders manifest counts without needing any
+  # GitHub-encrypted payloads.
+  manifest = {
+    version = 1;
+    owner = "example-org";
+    secrets = [
+      {
+        providerResource = "github_actions_organization_secret";
+        scope = "organization";
+        name = "GH_GOVERNANCE_APP_ID";
+        providerId = "example-org/GH_GOVERNANCE_APP_ID";
+        visibility = "all";
+        ageFile = "secrets/actions/org/GH_GOVERNANCE_APP_ID.age";
+        manageWithTerraform = true;
+      }
+    ];
+  };
+}

--- a/terraform/github/governance.nix
+++ b/terraform/github/governance.nix
@@ -1,0 +1,571 @@
+# Company-agnostic GitHub governance engine.
+#
+# Maps a declarative governance model (repositories, teams, memberships, branch
+# protection, Actions variables, issue labels) plus a secret manifest and the
+# GitHub-encrypted payloads rendered by `github-governance-secrets-render` into
+# `github_*` Terraform resources, and exposes the same rich `output` block the
+# bootstrap helper reads. Nothing company-specific is hardcoded: the consumer
+# supplies its own `governance` / `manifest` data and the resolved managed and
+# payload documents. See `terraform/github/README.md` for the thin-caller shape.
+{
+  awsAccountId,
+  awsRegion,
+  githubOwner,
+  githubAccessCheckRepository ? "${githubOwner}/infra",
+  githubBootstrapStateKey,
+  governance,
+  manifest,
+  managedDoc ? {
+    version = 1;
+    providerIds = [ ];
+  },
+  payloadDoc ? {
+    version = 1;
+    payloads = { };
+  },
+}:
+let
+  inherit (builtins)
+    attrNames
+    concatStringsSep
+    elem
+    filter
+    foldl'
+    hasAttr
+    length
+    listToAttrs
+    map
+    replaceStrings
+    sort
+    throw
+    ;
+
+  optionalAttrs = cond: attrs: if cond then attrs else { };
+  optionalField = attrs: name: if hasAttr name attrs then { ${name} = attrs.${name}; } else { };
+  resourceKey = value: "secret_${replaceStrings [ "/" ":" "." ] [ "_" "_" "_" ] value}";
+  governanceResourceKey =
+    value:
+    replaceStrings
+      [
+        "/"
+        ":"
+        "."
+        "-"
+        " "
+        "|"
+        "("
+        ")"
+        ","
+      ]
+      [
+        "_"
+        "_"
+        "_"
+        "_"
+        "_"
+        "_"
+        "_"
+        "_"
+        "_"
+      ]
+      value;
+  repositoryResourceName = repository: governanceResourceKey "repo:${repository}";
+  teamDataName = teamSlug: governanceResourceKey "team:${teamSlug}";
+  terraformRef = ref: "\${${ref}}";
+  listToResourceAttrs =
+    values: keyFn: valueFn:
+    listToAttrs (
+      map (value: {
+        name = governanceResourceKey (keyFn value);
+        value = valueFn value;
+      }) values
+    );
+
+  requestedPayloads = payloadDoc.payloads or { };
+
+  eligibleSecrets = filter (secret: secret.manageWithTerraform or false) manifest.secrets;
+  manifestProviderIds = map (secret: secret.providerId) eligibleSecrets;
+  managedProviderIds = managedDoc.providerIds or [ ];
+  unknownManagedIds = filter (providerId: !(elem providerId manifestProviderIds)) managedProviderIds;
+  unknownPayloadIds = filter (providerId: !(elem providerId manifestProviderIds)) (
+    attrNames requestedPayloads
+  );
+  missingPayloadIds = filter (providerId: !(hasAttr providerId requestedPayloads)) managedProviderIds;
+  manifestOrganizationSecrets = filter (secret: secret.scope == "organization") eligibleSecrets;
+  manifestRepositorySecrets = filter (secret: secret.scope == "repository") eligibleSecrets;
+  manifestEnvironmentSecrets = filter (secret: secret.scope == "environment") eligibleSecrets;
+  managedSecrets =
+    if unknownManagedIds != [ ] then
+      throw "unknown managed GitHub secret ids: ${concatStringsSep ", " unknownManagedIds}"
+    else
+      filter (secret: elem secret.providerId managedProviderIds) eligibleSecrets;
+  secretPayloads =
+    if unknownPayloadIds != [ ] then
+      throw "unknown GitHub secret payload ids: ${concatStringsSep ", " unknownPayloadIds}"
+    else if missingPayloadIds != [ ] then
+      throw "missing GitHub secret payload ids: ${concatStringsSep ", " missingPayloadIds}"
+    else
+      requestedPayloads;
+
+  organizationSecrets = filter (secret: secret.scope == "organization") managedSecrets;
+  repositorySecrets = filter (secret: secret.scope == "repository") managedSecrets;
+  environmentSecrets = filter (secret: secret.scope == "environment") managedSecrets;
+
+  withPayload =
+    secret: attrs:
+    let
+      payload = secretPayloads.${secret.providerId};
+    in
+    attrs
+    // {
+      key_id = payload.keyId;
+      value_encrypted = payload.valueEncrypted;
+    };
+
+  organizationSecretResources = listToAttrs (
+    map (secret: {
+      name = resourceKey secret.providerId;
+      value = withPayload secret (
+        {
+          secret_name = secret.name;
+          visibility = secret.visibility;
+        }
+        // optionalAttrs (secret ? selectedRepositoryIds) {
+          selected_repository_ids = secret.selectedRepositoryIds;
+        }
+      );
+    }) organizationSecrets
+  );
+
+  repositorySecretResources = listToAttrs (
+    map (secret: {
+      name = resourceKey secret.providerId;
+      value = withPayload secret {
+        repository = secret.repository;
+        secret_name = secret.name;
+      };
+    }) repositorySecrets
+  );
+
+  environmentSecretResources = listToAttrs (
+    map (secret: {
+      name = resourceKey secret.providerId;
+      value = withPayload secret {
+        repository = secret.repository;
+        environment = secret.environment;
+        secret_name = secret.name;
+      };
+    }) environmentSecrets
+  );
+
+  sortedRepoNames = sort (a: b: a < b) (map (repo: repo.name) governance.repositories);
+
+  repositoryResources = listToResourceAttrs governance.repositories (repo: "repo:${repo.name}") (
+    repo:
+    {
+      name = repo.name;
+      visibility = repo.visibility;
+      has_issues = repo.hasIssues;
+      has_projects = repo.hasProjects;
+      has_wiki = repo.hasWiki;
+      has_discussions = repo.hasDiscussions;
+      allow_forking = repo.allowForking;
+      archived = repo.archived;
+      is_template = repo.isTemplate;
+      web_commit_signoff_required = repo.webCommitSignoffRequired;
+      lifecycle = {
+        ignore_changes = [
+          # GitHub no longer uses this provider field, but imported state can
+          # still contain the historical value.
+          "has_downloads"
+        ];
+      };
+    }
+    // optionalField repo "description"
+    // optionalField repo "topics"
+    // optionalAttrs (repo ? homepageUrl) { homepage_url = repo.homepageUrl; }
+    // optionalAttrs (repo ? allowAutoMerge) { allow_auto_merge = repo.allowAutoMerge; }
+    // optionalAttrs (repo ? allowMergeCommit) { allow_merge_commit = repo.allowMergeCommit; }
+    // optionalAttrs (repo ? allowSquashMerge) { allow_squash_merge = repo.allowSquashMerge; }
+    // optionalAttrs (repo ? allowUpdateBranch) { allow_update_branch = repo.allowUpdateBranch; }
+    // optionalAttrs (repo ? deleteBranchOnMerge) { delete_branch_on_merge = repo.deleteBranchOnMerge; }
+  );
+
+  branchDefaultResources =
+    listToResourceAttrs governance.repositories (repo: "branch-default:${repo.name}")
+      (repo: {
+        repository = repo.name;
+        branch = repo.defaultBranch;
+      });
+
+  teamSlugs = attrNames (
+    listToAttrs (
+      map (grant: {
+        name = grant.teamSlug;
+        value = true;
+      }) governance.teamRepositories
+    )
+  );
+
+  teamDataSources = listToAttrs (
+    map (teamSlug: {
+      name = teamDataName teamSlug;
+      value = {
+        slug = teamSlug;
+      };
+    }) teamSlugs
+  );
+
+  membershipResources =
+    listToResourceAttrs governance.memberships (member: "member:${member.username}")
+      (member: {
+        username = member.username;
+        role = member.role;
+      });
+
+  repositoryCollaboratorResources =
+    listToResourceAttrs governance.outsideCollaborators
+      (collaborator: "repo-collaborator:${collaborator.repository}:${collaborator.username}")
+      (collaborator: {
+        repository = collaborator.repository;
+        username = collaborator.username;
+        permission = collaborator.permission;
+      });
+
+  teamRepositoryResources =
+    listToResourceAttrs governance.teamRepositories
+      (grant: "team-repository:${grant.teamSlug}:${grant.repository}")
+      (grant: {
+        team_id = terraformRef "data.github_team.${teamDataName grant.teamSlug}.id";
+        repository = grant.repository;
+        permission = grant.permission;
+      });
+
+  branchProtectionResources =
+    listToResourceAttrs governance.branchProtections
+      (branch: "branch-protection:${branch.repository}:${branch.pattern}")
+      (
+        branch:
+        {
+          repository_id = terraformRef "github_repository.${repositoryResourceName branch.repository}.node_id";
+          pattern = branch.pattern;
+          enforce_admins = branch.enforceAdmins;
+          allows_deletions = branch.allowsDeletions;
+          allows_force_pushes = branch.allowsForcePushes;
+          required_linear_history = branch.requiredLinearHistory;
+          require_conversation_resolution = branch.requireConversationResolution;
+          require_signed_commits = branch.requireSignedCommits;
+          lock_branch = branch.lockBranch;
+        }
+        // optionalAttrs (branch ? requiredStatusChecks) {
+          required_status_checks = [
+            {
+              strict = branch.requiredStatusChecks.strict;
+              contexts = branch.requiredStatusChecks.contexts;
+            }
+          ];
+        }
+        // optionalAttrs (branch ? requiredPullRequestReviews) {
+          required_pull_request_reviews = [
+            {
+              dismiss_stale_reviews = branch.requiredPullRequestReviews.dismissStaleReviews;
+              require_code_owner_reviews = branch.requiredPullRequestReviews.requireCodeOwnerReviews;
+              require_last_push_approval = branch.requiredPullRequestReviews.requireLastPushApproval;
+              required_approving_review_count = branch.requiredPullRequestReviews.requiredApprovingReviewCount;
+            }
+          ];
+        }
+      );
+
+  repositoryEnvironmentResources =
+    listToResourceAttrs governance.repositoryEnvironments
+      (environment: "environment:${environment.repository}:${environment.environment}")
+      (
+        environment:
+        {
+          repository = environment.repository;
+          environment = environment.environment;
+          can_admins_bypass = environment.canAdminsBypass;
+          wait_timer = environment.waitTimer;
+        }
+        // optionalAttrs (environment ? deploymentBranchPolicy) {
+          deployment_branch_policy = [
+            {
+              protected_branches = environment.deploymentBranchPolicy.protectedBranches;
+              custom_branch_policies = environment.deploymentBranchPolicy.customBranchPolicies;
+            }
+          ];
+        }
+      );
+
+  actionsRepositoryPermissionResources =
+    listToResourceAttrs governance.actionsRepositoryPermissions
+      (permissions: "actions-repository-permissions:${permissions.repository}")
+      (permissions: {
+        repository = permissions.repository;
+        enabled = permissions.enabled;
+        allowed_actions = permissions.allowedActions;
+        sha_pinning_required = permissions.shaPinningRequired;
+      });
+
+  actionsVariableResources =
+    listToResourceAttrs governance.actionsVariables
+      (variable: "actions-variable:${variable.repository}:${variable.name}")
+      (variable: {
+        repository = variable.repository;
+        variable_name = variable.name;
+        value = variable.value;
+      });
+
+  issueLabelResources =
+    listToResourceAttrs governance.issueLabels (label: "label:${label.repository}:${label.name}")
+      (
+        label:
+        {
+          repository = label.repository;
+          name = label.name;
+          color = label.color;
+        }
+        // optionalField label "description"
+      );
+
+  organizationResources = {
+    github_actions_organization_permissions.default = {
+      enabled_repositories = governance.organization.actionsPermissions.enabledRepositories;
+      allowed_actions = governance.organization.actionsPermissions.allowedActions;
+      sha_pinning_required = governance.organization.actionsPermissions.shaPinningRequired;
+    };
+  };
+
+  governanceResources =
+    organizationResources
+    // optionalAttrs (membershipResources != { }) { github_membership = membershipResources; }
+    // optionalAttrs (repositoryResources != { }) { github_repository = repositoryResources; }
+    // optionalAttrs (branchDefaultResources != { }) { github_branch_default = branchDefaultResources; }
+    // optionalAttrs (repositoryCollaboratorResources != { }) {
+      github_repository_collaborator = repositoryCollaboratorResources;
+    }
+    // optionalAttrs (teamRepositoryResources != { }) {
+      github_team_repository = teamRepositoryResources;
+    }
+    // optionalAttrs (branchProtectionResources != { }) {
+      github_branch_protection = branchProtectionResources;
+    }
+    // optionalAttrs (repositoryEnvironmentResources != { }) {
+      github_repository_environment = repositoryEnvironmentResources;
+    }
+    // optionalAttrs (actionsRepositoryPermissionResources != { }) {
+      github_actions_repository_permissions = actionsRepositoryPermissionResources;
+    }
+    // optionalAttrs (actionsVariableResources != { }) {
+      github_actions_variable = actionsVariableResources;
+    }
+    // optionalAttrs (issueLabelResources != { }) { github_issue_label = issueLabelResources; };
+
+  countAttrs = attrs: length (attrNames attrs);
+  countTopics = foldl' (sum: repo: sum + length (repo.topics or [ ])) 0 governance.repositories;
+
+  resources =
+    governanceResources
+    // optionalAttrs (organizationSecretResources != { }) {
+      github_actions_organization_secret = organizationSecretResources;
+    }
+    // optionalAttrs (repositorySecretResources != { }) {
+      github_actions_secret = repositorySecretResources;
+    }
+    // optionalAttrs (environmentSecretResources != { }) {
+      github_actions_environment_secret = environmentSecretResources;
+    };
+in
+{
+  terraform = {
+    required_version = ">= 1.8.0";
+    backend.s3 = { };
+    required_providers.github = {
+      source = "integrations/github";
+      version = "~> 6.0";
+    };
+  };
+
+  provider.github = {
+    owner = githubOwner;
+  };
+
+  data = optionalAttrs (teamDataSources != { }) {
+    github_team = teamDataSources;
+  };
+
+  resource = resources;
+
+  output = {
+    expected_aws_account_id = {
+      value = awsAccountId;
+      description = "Expected AWS account ID for the S3 backend used by this bootstrap layer.";
+    };
+
+    aws_region = {
+      value = awsRegion;
+      description = "AWS region for the S3 backend used by this bootstrap layer.";
+    };
+
+    github_owner = {
+      value = githubOwner;
+      description = "GitHub organization governed by this bootstrap layer.";
+    };
+
+    github_access_check_repository = {
+      value = githubAccessCheckRepository;
+      description = "Repository used by the bootstrap helper to validate GitHub token access.";
+    };
+
+    github_bootstrap_state_key = {
+      value = githubBootstrapStateKey;
+      description = "S3 key for the manually applied GitHub governance Terraform state file.";
+    };
+
+    governance_inventory_source = {
+      value = governance.snapshot.source;
+      description = "Reviewed inventory snapshot used to seed the non-secret GitHub governance model.";
+    };
+
+    github_governance_repository_count = {
+      value = length governance.repositories;
+      description = "GitHub repositories emitted by the governance model.";
+    };
+
+    github_governance_repository_names = {
+      value = sortedRepoNames;
+      description = "GitHub repositories emitted by the governance model.";
+    };
+
+    github_governance_membership_count = {
+      value = countAttrs membershipResources;
+      description = "Organization membership resources emitted by the governance model.";
+    };
+
+    github_governance_branch_default_count = {
+      value = countAttrs branchDefaultResources;
+      description = "Default branch resources emitted by the governance model.";
+    };
+
+    github_governance_outside_collaborator_count = {
+      value = countAttrs repositoryCollaboratorResources;
+      description = "Direct outside collaborator resources emitted by the governance model.";
+    };
+
+    github_governance_team_repository_count = {
+      value = countAttrs teamRepositoryResources;
+      description = "Team repository grant resources emitted by the governance model.";
+    };
+
+    github_governance_branch_protection_count = {
+      value = countAttrs branchProtectionResources;
+      description = "Branch protection resources emitted by the governance model.";
+    };
+
+    github_governance_environment_count = {
+      value = countAttrs repositoryEnvironmentResources;
+      description = "Repository Environment resources emitted by the governance model.";
+    };
+
+    github_governance_actions_repository_permissions_count = {
+      value = countAttrs actionsRepositoryPermissionResources;
+      description = "Repository Actions permission resources emitted by the governance model.";
+    };
+
+    github_governance_actions_variable_count = {
+      value = countAttrs actionsVariableResources;
+      description = "Repository Actions variable resources emitted by the governance model.";
+    };
+
+    github_governance_issue_label_count = {
+      value = countAttrs issueLabelResources;
+      description = "Issue label resources emitted by the governance model.";
+    };
+
+    github_governance_repository_topic_count = {
+      value = countTopics;
+      description = "Repository topics modeled through github_repository.topics.";
+    };
+
+    github_governance_deferred_resource_count = {
+      value = length governance.deferredResources;
+      description = "Inventory rows intentionally not emitted by this root yet.";
+    };
+
+    github_governance_deferred_resource_names = {
+      value = map (resource: "${resource.type}:${resource.name}") governance.deferredResources;
+      description = "Deferred inventory rows that need explicit follow-up before Terraform management.";
+    };
+
+    secret_manifest_count = {
+      value = length eligibleSecrets;
+      description = "Total GitHub Actions secrets declared in the governance manifest.";
+    };
+
+    secret_manifest_organization_secret_count = {
+      value = length manifestOrganizationSecrets;
+      description = "Organization-scoped GitHub Actions secrets declared in the governance manifest.";
+    };
+
+    secret_manifest_repository_secret_count = {
+      value = length manifestRepositorySecrets;
+      description = "Repository-scoped GitHub Actions secrets declared in the governance manifest.";
+    };
+
+    secret_manifest_environment_secret_count = {
+      value = length manifestEnvironmentSecrets;
+      description = "Environment-scoped GitHub Actions secrets declared in the governance manifest.";
+    };
+
+    secret_manifest_ids = {
+      value = manifestProviderIds;
+      description = "Provider ids for every GitHub Actions secret declared in the manifest.";
+    };
+
+    github_secret_managed_candidate_count = {
+      value = length managedProviderIds;
+      description = "GitHub Actions secret provider ids requested for Terraform management.";
+    };
+
+    github_secret_managed_candidate_ids = {
+      value = managedProviderIds;
+      description = "Provider ids requested for Terraform-managed GitHub Actions secret resources.";
+    };
+
+    github_secret_payload_count = {
+      value = length (attrNames secretPayloads);
+      description = "GitHub-encrypted secret payloads currently available to Terraform.";
+    };
+
+    github_secret_payload_ids = {
+      value = attrNames secretPayloads;
+      description = "Provider ids that currently have GitHub-encrypted payloads.";
+    };
+
+    github_secret_managed_count = {
+      value = length managedSecrets;
+      description = "GitHub Actions secret resources emitted by Terraform from the governance manifest.";
+    };
+
+    github_secret_managed_ids = {
+      value = map (secret: secret.providerId) managedSecrets;
+      description = "Provider ids emitted as GitHub Actions secret resources.";
+    };
+
+    github_organization_secret_count = {
+      value = length organizationSecrets;
+      description = "Organization GitHub Actions secret resources emitted by Terraform.";
+    };
+
+    github_repository_secret_count = {
+      value = length repositorySecrets;
+      description = "Repository GitHub Actions secret resources emitted by Terraform.";
+    };
+
+    github_environment_secret_count = {
+      value = length environmentSecrets;
+      description = "Environment GitHub Actions secret resources emitted by Terraform.";
+    };
+  };
+}

--- a/terraform/github/tests/test-render.sh
+++ b/terraform/github/tests/test-render.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Renders the governance example and checks the engine produces the expected
+# github_* resources and outputs. Offline (Nix eval only); no credentials.
+set -euo pipefail
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+json="$(nix eval --json --impure --expr "import ${here}/../governance.example.nix")"
+fail=0
+
+# Core governance resources the example models.
+need=(
+  github_actions_organization_permissions
+  github_repository
+  github_branch_default
+  github_team_repository
+  github_branch_protection
+  github_repository_environment
+  github_actions_repository_permissions
+  github_actions_variable
+  github_issue_label
+  github_membership
+)
+for t in "${need[@]}"; do
+  n="$(jq --arg t "$t" '.resource[$t] | length' <<<"$json")"
+  [[ "$n" -ge 1 ]] || { echo "FAIL: expected resource $t"; fail=1; }
+done
+
+# The team data source is emitted for the granted team.
+[[ "$(jq '.data.github_team | length' <<<"$json")" -ge 1 ]] || { echo "FAIL: expected github_team data source"; fail=1; }
+
+# Manifest counting output is wired through.
+[[ "$(jq '.output.secret_manifest_count.value' <<<"$json")" == "1" ]] || { echo "FAIL: secret_manifest_count"; fail=1; }
+# The declared-but-unmanaged secret renders no secret resource and needs no payload.
+[[ "$(jq 'has("github_actions_organization_secret") | not' <<<"$(jq .resource <<<"$json")")" == "true" ]] \
+  || { echo "FAIL: unexpected managed secret resource without payload"; fail=1; }
+
+# No company literals leak from the example.
+if jq -e '.. | strings | select(test("agent-harbor|555209622233"))' <<<"$json" >/dev/null 2>&1; then
+  echo "FAIL: example rendered company-specific literals"; fail=1
+fi
+
+[[ "$fail" == 0 ]] && echo "OK: governance example renders expected github_* resources" || exit 1


### PR DESCRIPTION
Extracts the **GitHub governance mapper** — the 588-line engine that turns a declarative governance model (repos, teams, memberships, branch protection, Environments, Actions permissions/variables, labels) plus a secret manifest and rendered payloads into `github_*` resources — out of agent-harbor's governance root into a shared, value-independent module. Pairs with the already-shared `branch-protection.nix` and the `github-bootstrap` driver.

**What moved:** all machinery (name sanitizers, `listToResourceAttrs`, per-resource mappers, `withPayload`, the manifest validation that throws on unknown/missing managed & payload ids) is now `terraform/github/governance.nix`, parameterized by the five company constants (AWS account/region, owner, access-check repo, state key) and the two data documents (`governance`, `manifest`) plus resolved `managedDoc`/`payloadDoc`.

**What stays per-repo:** each org keeps its own `governance.nix` inventory model and `secrets/manifest.nix` registry (the actual repos/teams/secrets) and thin-calls this engine.

**Safety:** verified **byte-identical** against agent-harbor's current governance render — `nix eval --json | jq -S` diff is empty, i.e. zero plan diff. Adds `governance.example.nix` (minimal org-agnostic renderable model) + `tests/test-render.sh` (offline render check, passes). No company literals in any shared file.

Follow-up (separate PR): repoint agent-harbor's `root.nix` at this engine, pinned by rev.