### PR TITLE
feat(terraform/github): CI-enabling GitHub Layer-0 bootstrap module

### DIFF
--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -70,6 +70,37 @@ The example is validated against the real `integrations/github` provider
 schema (`tofu validate` → `Success`). A real consumer swaps the fixture for the
 shared policy file and its own repository list.
 
+## `tf-bootstrap.nix` — CI-enabling GitHub Layer-0 root
+
+The GitHub counterpart of the AWS `tf-bootstrap.nix`: a value-independent module
+rendering the minimal GitHub facts the CI/CD pipeline depends on to run — the
+reviewer team, the deploy Environment, the AWS OIDC role-ARN Actions variables,
+the Terraform safety labels, and branch protection for the deploy branch. Each
+consumer's `bootstrap/github/<name>/default.nix` is a thin caller:
+
+```nix
+{ ... }:
+import "${inputs.nixos-modules}/terraform/github/tf-bootstrap.nix" {
+  awsAccountId = "…";
+  namePrefix = "…-prod";               # state key derives: bootstrap/github/<namePrefix>.tfstate
+  githubOwner = "…";                   # githubRepo defaults to "infra", protectedBranch to "live"
+  reviewerTeam = {
+    name = "infra";
+    slug = "infra";
+    description = "Maintainers for … infrastructure.";
+    initialMaintainer = "…";           # the bootstrap admin username
+  };
+  requiredStatusCheckContexts = [ "…" ];   # the repo's real CI check contexts
+}
+```
+
+Broader org governance (repositories, memberships, org secrets) is the separate
+[`governance.nix`](#governancenix--github-governance-engine) engine — this module
+is only the per-repo settings that unblock the pipeline. See
+[`tf-bootstrap.example.nix`](./tf-bootstrap.example.nix) and
+[`tests/test-bootstrap-render.sh`](./tests/test-bootstrap-render.sh). Verifying an
+extraction is a no-op is the same `nix eval --json | jq -S` diff as the AWS module.
+
 ## `governance.nix` — GitHub governance engine
 
 Maps a declarative **governance model** (repositories, memberships, teams,

--- a/terraform/github/tests/test-bootstrap-render.sh
+++ b/terraform/github/tests/test-bootstrap-render.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Renders the CI-enabling GitHub bootstrap example and checks it produces the
+# expected Layer-0 resources and outputs. Offline (Nix eval only); no creds.
+set -euo pipefail
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+json="$(nix eval --json --impure --expr "import ${here}/../tf-bootstrap.example.nix")"
+fail=0
+
+need=(
+  github_team
+  github_team_membership
+  github_team_repository
+  github_actions_variable
+  github_issue_label
+  github_repository_environment
+  github_branch_protection
+)
+for t in "${need[@]}"; do
+  n="$(jq --arg t "$t" '.resource[$t] | length' <<<"$json")"
+  [[ "$n" -ge 1 ]] || { echo "FAIL: expected resource $t"; fail=1; }
+done
+
+# The three AWS OIDC role-ARN variables plus the backend-config variable.
+[[ "$(jq '.resource.github_actions_variable | length' <<<"$json")" == "4" ]] \
+  || { echo "FAIL: expected 4 github_actions_variable"; fail=1; }
+# Single-maintainer bootstrap default relaxes PR-review gates but keeps checks.
+[[ "$(jq '.output.branch_protection_requires_pull_request_reviews.value' <<<"$json")" == "false" ]] \
+  || { echo "FAIL: expected relaxed PR reviews under single-maintainer bootstrap"; fail=1; }
+[[ "$(jq '.resource.github_branch_protection.main.required_status_checks[0].contexts | length' <<<"$json")" -ge 1 ]] \
+  || { echo "FAIL: expected required status checks"; fail=1; }
+
+# No company literals leak from the example.
+if jq -e '.. | strings | select(test("agent-harbor|555209622233"))' <<<"$json" >/dev/null 2>&1; then
+  echo "FAIL: example rendered company-specific literals"; fail=1
+fi
+
+[[ "$fail" == 0 ]] && echo "OK: github tf-bootstrap example renders expected Layer-0 resources" || exit 1

--- a/terraform/github/tf-bootstrap.example.nix
+++ b/terraform/github/tf-bootstrap.example.nix
@@ -1,0 +1,22 @@
+# Example caller for tf-bootstrap.nix (the CI-enabling GitHub Layer-0 root). A
+# real consumer's bootstrap/github/<name>/default.nix imports the module and
+# passes its own identifiers; agent-harbor / blocksense / metacraft each supply
+# independent values. No company literals here.
+import ./tf-bootstrap.nix {
+  awsAccountId = "000000000000";
+  awsRegion = "us-east-1";
+  namePrefix = "example-prod";
+  githubOwner = "example-org";
+  githubRepo = "infra";
+  protectedBranch = "live";
+  reviewerTeam = {
+    name = "infra";
+    slug = "infra";
+    description = "Maintainers for Example infrastructure.";
+    initialMaintainer = "example-admin";
+  };
+  requiredStatusCheckContexts = [
+    "pr (terraform/aws/example-prod) / offline-checks"
+    "pr (terraform/aws/example-prod) / credentialed-plan"
+  ];
+}

--- a/terraform/github/tf-bootstrap.nix
+++ b/terraform/github/tf-bootstrap.nix
@@ -1,0 +1,246 @@
+# Company-agnostic GitHub Layer-0 bootstrap module (CI-enabling repo settings).
+#
+# Renders the minimal GitHub facts the CI/CD pipeline depends on to run: the
+# reviewer team, the deploy Environment, the AWS OIDC role-ARN Actions variables,
+# the Terraform safety labels, and branch protection for the deploy branch. This
+# is the GitHub counterpart of tf-bootstrap.nix on the AWS side — a value-
+# independent module; each consumer's bootstrap/github/<name>/default.nix thin-
+# calls it with its own identifiers. Broader org governance (repos, memberships,
+# org secrets) lives in the separate governance engine (governance.nix).
+{
+  awsAccountId,
+  awsRegion ? "us-east-1",
+  namePrefix,
+  githubOwner,
+  githubRepo ? "infra",
+  githubEnvironment ? "production",
+  protectedBranch ? "live",
+  # { name, slug, description, initialMaintainer }
+  reviewerTeam,
+  # During single-maintainer bootstrap, mandatory PR-review gates would block
+  # every PR. Required checks stay enforced regardless; flip to false once the
+  # reviewer team has at least two admins.
+  singleMaintainerBootstrap ? true,
+  productionEnvironmentRequiresManualApproval ? false,
+  productionEnvironmentUsesBranchPolicy ? true,
+  requiredStatusCheckContexts,
+  backendConfigFile ? "backends/aws-${namePrefix}.hcl",
+}:
+let
+  githubRepository = "${githubOwner}/${githubRepo}";
+  githubBootstrapStateKey = "bootstrap/github/${namePrefix}.tfstate";
+  requirePullRequestReviews = !singleMaintainerBootstrap;
+  terraformRoles = {
+    AWS_TERRAFORM_PLAN_ROLE_ARN = "arn:aws:iam::${awsAccountId}:role/${namePrefix}-terraform-plan";
+    AWS_TERRAFORM_APPLY_ROLE_ARN = "arn:aws:iam::${awsAccountId}:role/${namePrefix}-terraform-apply";
+    AWS_TERRAFORM_DRIFT_ROLE_ARN = "arn:aws:iam::${awsAccountId}:role/${namePrefix}-terraform-drift";
+  };
+  # Retained until all existing workflow consumers have moved to per-root
+  # backend config discovery.
+  githubActionsVariables = terraformRoles // {
+    BACKEND_CONFIG_FILE = backendConfigFile;
+  };
+in
+{
+  terraform = {
+    required_version = ">= 1.8.0";
+    backend.s3 = { };
+    required_providers.github = {
+      source = "integrations/github";
+      version = "~> 6.0";
+    };
+  };
+
+  provider.github = {
+    owner = githubOwner;
+  };
+
+  resource = {
+    github_team.infra = {
+      name = reviewerTeam.name;
+      description = reviewerTeam.description;
+      privacy = "closed";
+    };
+
+    github_team_membership.infra_initial_maintainer = {
+      team_id = "\${github_team.infra.id}";
+      username = reviewerTeam.initialMaintainer;
+      role = "maintainer";
+    };
+
+    github_team_repository.infra = {
+      team_id = "\${github_team.infra.id}";
+      repository = githubRepo;
+      permission = "maintain";
+    };
+
+    github_actions_variable = {
+      backend_config_file = {
+        repository = githubRepo;
+        variable_name = "BACKEND_CONFIG_FILE";
+        value = githubActionsVariables.BACKEND_CONFIG_FILE;
+      };
+
+      aws_terraform_plan_role_arn = {
+        repository = githubRepo;
+        variable_name = "AWS_TERRAFORM_PLAN_ROLE_ARN";
+        value = githubActionsVariables.AWS_TERRAFORM_PLAN_ROLE_ARN;
+      };
+
+      aws_terraform_apply_role_arn = {
+        repository = githubRepo;
+        variable_name = "AWS_TERRAFORM_APPLY_ROLE_ARN";
+        value = githubActionsVariables.AWS_TERRAFORM_APPLY_ROLE_ARN;
+      };
+
+      aws_terraform_drift_role_arn = {
+        repository = githubRepo;
+        variable_name = "AWS_TERRAFORM_DRIFT_ROLE_ARN";
+        value = githubActionsVariables.AWS_TERRAFORM_DRIFT_ROLE_ARN;
+      };
+    };
+
+    github_issue_label = {
+      sensitive_change = {
+        repository = githubRepo;
+        name = "sensitive-change";
+        color = "D93F0B";
+        description = "Terraform safety gate";
+      };
+
+      allow_destroy = {
+        repository = githubRepo;
+        name = "allow-destroy";
+        color = "D93F0B";
+        description = "Terraform safety gate";
+      };
+    };
+
+    github_repository_environment.production = {
+      repository = githubRepo;
+      environment = githubEnvironment;
+      wait_timer = 0;
+      can_admins_bypass = false;
+      deployment_branch_policy = [
+        {
+          protected_branches = productionEnvironmentUsesBranchPolicy;
+          custom_branch_policies = false;
+        }
+      ];
+    };
+
+    github_branch_protection.main = {
+      repository_id = githubRepo;
+      pattern = protectedBranch;
+      enforce_admins = true;
+      allows_deletions = false;
+      allows_force_pushes = false;
+      require_conversation_resolution = true;
+      required_linear_history = true;
+
+      required_status_checks = [
+        {
+          strict = true;
+          contexts = requiredStatusCheckContexts;
+        }
+      ];
+    }
+    // (
+      if requirePullRequestReviews then
+        {
+          required_pull_request_reviews = [
+            {
+              dismiss_stale_reviews = true;
+              require_code_owner_reviews = true;
+              require_last_push_approval = true;
+              required_approving_review_count = 1;
+            }
+          ];
+        }
+      else
+        { }
+    );
+  };
+
+  output = {
+    expected_aws_account_id = {
+      value = awsAccountId;
+      description = "Expected AWS account ID for the S3 backend used by this bootstrap layer.";
+    };
+
+    aws_region = {
+      value = awsRegion;
+      description = "AWS region for the S3 backend used by this bootstrap layer.";
+    };
+
+    github_owner = {
+      value = githubOwner;
+      description = "GitHub organization that owns the repository.";
+    };
+
+    github_repository = {
+      value = githubRepository;
+      description = "GitHub repository managed by this bootstrap layer.";
+    };
+
+    github_environment = {
+      value = githubEnvironment;
+      description = "GitHub Environment used by Terraform apply jobs.";
+    };
+
+    github_reviewer_team_slug = {
+      value = reviewerTeam.slug;
+      description = "GitHub team slug used for CODEOWNERS and future PR review rules.";
+    };
+
+    github_reviewer_team_name = {
+      value = "\${github_team.infra.name}";
+      description = "GitHub team name managed by this bootstrap layer.";
+    };
+
+    github_reviewer_team_initial_maintainer = {
+      value = reviewerTeam.initialMaintainer;
+      description = "Initial maintainer for the Terraform-managed infrastructure reviewer team.";
+    };
+
+    single_maintainer_bootstrap = {
+      value = singleMaintainerBootstrap;
+      description = "Whether GitHub PR review gates are relaxed for a single-maintainer bootstrap phase.";
+    };
+
+    production_environment_requires_manual_approval = {
+      value = productionEnvironmentRequiresManualApproval;
+      description = "Whether production Environment requires a separate post-merge deployment approval.";
+    };
+
+    production_environment_uses_branch_policy = {
+      value = productionEnvironmentUsesBranchPolicy;
+      description = "Whether production Environment deployments are limited to protected branches.";
+    };
+
+    branch_protection_requires_pull_request_reviews = {
+      value = requirePullRequestReviews;
+      description = "Whether branch protection requires pull request reviews.";
+    };
+
+    protected_branch = {
+      value = protectedBranch;
+      description = "GitHub branch protected by this bootstrap layer.";
+    };
+
+    required_status_check_contexts = {
+      value = requiredStatusCheckContexts;
+      description = "Required GitHub status check contexts for the protected branch.";
+    };
+
+    github_bootstrap_state_key = {
+      value = githubBootstrapStateKey;
+      description = "S3 key for the manually applied GitHub bootstrap Terraform state file.";
+    };
+
+    github_actions_variables = {
+      value = githubActionsVariables;
+      description = "GitHub Actions repository variables managed by the GitHub provider.";
+    };
+  };
+}


### PR DESCRIPTION
The GitHub counterpart of `terraform/aws/tf-bootstrap.nix`. Extracts agent-harbor's inlined **CI-enabling GitHub bootstrap root** into a shared, value-independent module so blocksense and metacraft get the same facility.

Renders the minimal GitHub Layer-0 facts CI depends on to run: the reviewer team, the deploy Environment, the three AWS OIDC role-ARN Actions variables + backend-config variable, the Terraform safety labels, and deploy-branch protection (with single-maintainer-bootstrap relaxation of PR-review gates). Company identifiers (`awsAccountId`, `namePrefix`, `githubOwner`, `reviewerTeam`, `requiredStatusCheckContexts`, …) are parameters; the state key and role ARNs derive from `namePrefix`.

**Safety:** verified **byte-identical** against agent-harbor's current inlined `bootstrap/github/agent-harbor-prod/default.nix` render (6,370 B, `diff` empty) → zero plan diff. Adds `tf-bootstrap.example.nix` + `tests/test-bootstrap-render.sh` (passes); no company literals in shared files.

Broader org governance stays in the separate `governance.nix` engine (#546). Follow-ups: repoint agent-harbor at this module, and add blocksense/metacraft github bootstrap roots that thin-call it.