### PR TITLE
fix(terraform/github): omit empty data block in governance engine

### DIFF
--- a/terraform/github/governance.nix
+++ b/terraform/github/governance.nix
@@ -391,10 +391,6 @@ in
     owner = githubOwner;
   };
 
-  data = optionalAttrs (teamDataSources != { }) {
-    github_team = teamDataSources;
-  };
-
   resource = resources;
 
   output = {
@@ -568,4 +564,9 @@ in
       description = "Environment GitHub Actions secret resources emitted by Terraform.";
     };
   };
+}
+# Only emit the `data` block when there are team data sources; an empty
+# `data = { }` is invalid Terraform JSON (relevant to a pre-inventory skeleton).
+// optionalAttrs (teamDataSources != { }) {
+  data.github_team = teamDataSources;
 }


### PR DESCRIPTION
A governance model with **no team-repository grants** (the pre-inventory skeleton state a fresh consumer starts from) made the engine render an empty `data = { }`, which OpenTofu rejects (`Missing block label`). This emits the `data` block only when there are team data sources.

**No-op for a populated model** — verified **byte-identical** against agent-harbor's governance render (empty `diff`). With the fix, a fresh consumer's skeleton governance root passes `tofu validate` + `tofu test` before its inventory is populated (needed for the metacraft/blocksense import-ready scaffolding).