### PR TITLE
fix(terraform): remove real AWS account id from example leak-guards

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -2,7 +2,7 @@
 
 Company-agnostic **Layer-0** bootstrap for an AWS-backed Terraform operating
 layer. Human-applied once per account, out-of-band, and never part of the
-CI-managed state. Extracted verbatim from agent-harbor's production bootstrap;
+CI-managed state. Extracted verbatim from a production bootstrap;
 only the identifiers are parameters now.
 
 ## `tf-bootstrap.nix`

--- a/terraform/aws/example.nix
+++ b/terraform/aws/example.nix
@@ -1,8 +1,8 @@
 # Example caller for tf-bootstrap.nix. A real consumer's
 # bootstrap/aws/<name>/default.nix imports the module and passes its own values;
-# agent-harbor / blocksense / metacraft each supply independent identifiers
-# (blocksense and agent-harbor may point at the same AWS account today, but the
-# variables are per-repo so either can move to a separate account later).
+# each consumer supplies independent identifiers. Two consumers may point at the
+# same AWS account today, but the variables are per-repo so either can move to a
+# separate account later.
 import ./tf-bootstrap.nix {
   awsAccountId = "000000000000";
   awsRegion = "us-east-1";

--- a/terraform/aws/tests/test-render.sh
+++ b/terraform/aws/tests/test-render.sh
@@ -10,8 +10,10 @@ for t in "${need[@]}"; do
   n="$(jq --arg t "$t" '.resource[$t] | length' <<<"$json")"
   [[ "$n" -ge 1 ]] || { echo "FAIL: expected resource $t"; fail=1; }
 done
-# No agent-harbor / real-account leakage from the example.
-if jq -e '.. | strings | select(test("agent-harbor|555209622233"))' <<<"$json" >/dev/null 2>&1; then
+# No real-account leakage from the example.
+# The example must render only placeholder identifiers — flag any 12-digit AWS
+# account id other than the 000000000000 placeholder (no real value embedded here).
+if jq -e '.. | strings | select(test("[0-9]{12}") and (contains("000000000000") | not))' <<<"$json" >/dev/null 2>&1; then
   echo "FAIL: example rendered company-specific literals"; fail=1
 fi
 [[ "$fail" == 0 ]] && echo "OK: tf-bootstrap example renders expected Layer-0 resources" || exit 1

--- a/terraform/github/tests/test-bootstrap-render.sh
+++ b/terraform/github/tests/test-bootstrap-render.sh
@@ -30,7 +30,9 @@ done
   || { echo "FAIL: expected required status checks"; fail=1; }
 
 # No company literals leak from the example.
-if jq -e '.. | strings | select(test("agent-harbor|555209622233"))' <<<"$json" >/dev/null 2>&1; then
+# The example must render only placeholder identifiers — flag any 12-digit AWS
+# account id other than the 000000000000 placeholder (no real value embedded here).
+if jq -e '.. | strings | select(test("[0-9]{12}") and (contains("000000000000") | not))' <<<"$json" >/dev/null 2>&1; then
   echo "FAIL: example rendered company-specific literals"; fail=1
 fi
 

--- a/terraform/github/tests/test-render.sh
+++ b/terraform/github/tests/test-render.sh
@@ -34,7 +34,9 @@ done
   || { echo "FAIL: unexpected managed secret resource without payload"; fail=1; }
 
 # No company literals leak from the example.
-if jq -e '.. | strings | select(test("agent-harbor|555209622233"))' <<<"$json" >/dev/null 2>&1; then
+# The example must render only placeholder identifiers — flag any 12-digit AWS
+# account id other than the 000000000000 placeholder (no real value embedded here).
+if jq -e '.. | strings | select(test("[0-9]{12}") and (contains("000000000000") | not))' <<<"$json" >/dev/null 2>&1; then
   echo "FAIL: example rendered company-specific literals"; fail=1
 fi
 

--- a/terraform/github/tf-bootstrap.example.nix
+++ b/terraform/github/tf-bootstrap.example.nix
@@ -1,7 +1,7 @@
 # Example caller for tf-bootstrap.nix (the CI-enabling GitHub Layer-0 root). A
 # real consumer's bootstrap/github/<name>/default.nix imports the module and
-# passes its own identifiers; agent-harbor / blocksense / metacraft each supply
-# independent values. No company literals here.
+# passes its own identifiers; each consumer supplies independent values. No
+# company literals here.
 import ./tf-bootstrap.nix {
   awsAccountId = "000000000000";
   awsRegion = "us-east-1";


### PR DESCRIPTION
The example render-tests guarded against company data leaking into the shared examples by grepping for the literal `agent-harbor|555209622233` — which **embedded agent-harbor's real AWS account id (and org name) in this public repo**, ironically inside the leak-guard itself.

- Replaces the guard in all three `tests/test-*render.sh` with a value-free check: flag any 12-digit account id other than the `000000000000` placeholder. No real value embedded; all three tests still pass.
- Neutralizes org-naming prose in `terraform/aws/example.nix`, `terraform/github/tf-bootstrap.example.nix`, and `terraform/aws/README.md` so the library reads as vendor-neutral for third-party adoption.

No module behavior change.