### PR TITLE
chore: scrub recon-grade private names from deployment fixtures/tests

### DIFF
--- a/checks/deployment-incus-rehearsal.nix
+++ b/checks/deployment-incus-rehearsal.nix
@@ -163,7 +163,7 @@ top@{ config, ... }:
                   by_group.setdefault(role.get("targetGroup"), []).append(role)
                   role_networks = set(role["networks"])
                   assert role_networks <= networks, role
-                  if role.get("targetGroup") in {"home-lab-gpu", "solunska"}:
+                  if role.get("targetGroup") in {"home-lab-gpu", "example-site"}:
                       assert role["avahi"] is True, role
                       assert "home-lab" in role_networks, role
                   if role.get("targetGroup") in {"hetzner", "workstation"}:
@@ -174,7 +174,7 @@ top@{ config, ... }:
                       assert "workstation" in role_networks, role
 
               assert by_group["home-lab-gpu"], by_group
-              assert by_group["solunska"], by_group
+              assert by_group["example-site"], by_group
               assert by_group["hetzner"], by_group
               assert by_group["workstation"], by_group
               assert any(role["role"] == "orchestrator" for role in roles), roles

--- a/checks/deployment-reconciler.nix
+++ b/checks/deployment-reconciler.nix
@@ -899,7 +899,7 @@ top@{ config, ... }:
                 controller.succeed("systemctl cat mcl-deployment-reconciler.timer | grep -q 'OnUnitActiveSec=4h'")
                 controller.succeed("systemctl cat mcl-deployment-reconciler.timer | grep -q 'RandomizedDelaySec=0'")
                 controller.succeed("test ! -e /var/lib/mcl-test/restore-runs")
-                controller.succeed("! grep -R -E 'gpu-server|solunska|hetzner|nedislav|eli' /var/lib/mcl/canary-deployments /var/log/mcl 2>/dev/null")
+                controller.succeed("! grep -R -E 'gpu-node|gpu-server|example-site|hetzner|app-node' /var/lib/mcl/canary-deployments /var/log/mcl 2>/dev/null")
 
             with subtest("scheduled canary service applies through the reconciler path"):
                 controller.succeed("systemctl start mcl-deployment-reconciler.service")

--- a/modules/host-info.nix
+++ b/modules/host-info.nix
@@ -40,7 +40,7 @@ let
 
         configPath = mkOption {
           type = types.str;
-          example = "./machines/server/solunska-server";
+          example = "./machines/server/example-site-server";
           description = ''
             The configuration path for this host relative to the repo root.
           '';

--- a/packages/mcl/src/mcl/commands/ci_matrix.d
+++ b/packages/mcl/src/mcl/commands/ci_matrix.d
@@ -827,13 +827,13 @@ unittest
 unittest
 {
     const deploymentTargetNames = [
-        "Hetzner-FSN1-DC11-i7-4770-16-512-001",
-        "gpu-server-001",
-        "gpu-server-002",
-        "gpu-server-003",
-        "hetzner-002",
-        "hetzner-003",
-        "solunska-server",
+        "bare-metal-001",
+        "gpu-node-001",
+        "gpu-node-002",
+        "gpu-node-003",
+        "app-node-002",
+        "app-node-003",
+        "example-site-server",
     ];
 
     assert(isDeployableServerMachineAttr(
@@ -847,22 +847,22 @@ unittest
     ));
     assert(isDeployableServerMachineAttr(
         "mcl.shard-matrix.result.shards.shard-42",
-        "machine/gpu-server-001/x86_64-linux",
+        "machine/gpu-node-001/x86_64-linux",
         deploymentTargetNames,
     ));
     assert(isDeployableServerMachineAttr(
         "mcl.shard-matrix.result.shards.shard-42",
-        "machine/solunska-server/x86_64-linux",
+        "machine/example-site-server/x86_64-linux",
         deploymentTargetNames,
     ));
     assert(isDeployableServerMachineAttr(
         "mcl.shard-matrix.result.shards.shard-42",
-        "machine/hetzner-002/x86_64-linux",
+        "machine/app-node-002/x86_64-linux",
         deploymentTargetNames,
     ));
     assert(isDeployableServerMachineAttr(
         "mcl.shard-matrix.result.shards.shard-42",
-        "machine/Hetzner-FSN1-DC11-i7-4770-16-512-001/x86_64-linux",
+        "machine/bare-metal-001/x86_64-linux",
         deploymentTargetNames,
     ));
     assert(!isDeployableServerMachineAttr(
@@ -877,12 +877,12 @@ unittest
     ));
     assert(!isDeployableServerMachineAttr(
         "legacyPackages.x86_64-linux.checks",
-        "machine/gpu-server-001/x86_64-linux",
+        "machine/gpu-node-001/x86_64-linux",
         deploymentTargetNames,
     ));
 
     auto server = `{
-        "attr": "machine/gpu-server-001/x86_64-linux",
+        "attr": "machine/gpu-node-001/x86_64-linux",
         "drvPath": "/nix/store/server.drv",
         "outputs": { "out": "/nix/store/11111111111111111111111111111111-server" },
         "system": "x86_64-linux"

--- a/scripts/deployment-incus-rehearsal.sh
+++ b/scripts/deployment-incus-rehearsal.sh
@@ -120,12 +120,12 @@ validate_topology() {
     and any(.roles[]; .role == "attic-cache")
     and any(.roles[]; .role == "monitoring")
     and any(.roles[]; .targetGroup == "home-lab-gpu" and .avahi == true)
-    and any(.roles[]; .targetGroup == "solunska" and .avahi == true)
+    and any(.roles[]; .targetGroup == "example-site" and .avahi == true)
     and any(.roles[]; .targetGroup == "hetzner" and .avahi == false)
     and any(.roles[]; .targetGroup == "workstation" and .avahi == false)
     and all(.roles[]; . as $role | (.networks | type == "array" and length > 0 and all(. as $network | $networkNames | index($network))))
     and all(.roles[]; . as $role | ((has("targetGroup") | not) or ($targetGroupNames | index($role.targetGroup))))
-    and all(.roles[] | select(.targetGroup == "home-lab-gpu" or .targetGroup == "solunska"); (.networks | index("home-lab")))
+    and all(.roles[] | select(.targetGroup == "home-lab-gpu" or .targetGroup == "example-site"); (.networks | index("home-lab")))
     and all(.roles[] | select(.targetGroup == "hetzner"); (.networks | index("hetzner")))
     and all(.roles[] | select(.targetGroup == "workstation"); (.networks | index("workstation")))
     and (controlsText("full-topology") | contains("runner") and contains("attic") and contains("monitoring") and contains("hetzner") and contains("workstation") and contains("deploy"))
@@ -672,7 +672,7 @@ avahi="$(jq -r '.role.avahi // false' "$meta")"
 jq -e '.schemaVersion == 1 and (.role.name | length > 0) and (.role.role | length > 0)' "$meta" >/dev/null
 
 case "$target_group" in
-  home-lab-gpu | solunska)
+  home-lab-gpu | example-site)
     [[ "$avahi" == "true" ]] || {
       echo "expected Avahi enabled for target group $target_group" >&2
       exit 1
@@ -795,9 +795,9 @@ elif scenario == "full-topology-failures":
     event("cache-missing-object", cache="attic", storePath="/nix/store/synthetic-missing", exitCode=evidence["missingCacheObject"]["exitCode"])
     event("manifest-rejected", reason="invalid-signature", deploymentId=42, exitCode=evidence["invalidSignature"]["exitCode"])
     event("switch-failed", targetGroup="hetzner", deploymentId=43, exitCode=evidence["switchFailure"]["exitCode"])
-    event("healthcheck-failed", targetGroup="solunska", deploymentId=44, exitCode=evidence["healthCheckFailure"]["exitCode"])
-    event("rollback-started", targetGroup="solunska", fromDeploymentId=44)
-    event("rollback-complete", targetGroup="solunska", restoredDeploymentId=evidence["rollback"]["restoredDeploymentId"])
+    event("healthcheck-failed", targetGroup="example-site", deploymentId=44, exitCode=evidence["healthCheckFailure"]["exitCode"])
+    event("rollback-started", targetGroup="example-site", fromDeploymentId=44)
+    event("rollback-complete", targetGroup="example-site", restoredDeploymentId=evidence["rollback"]["restoredDeploymentId"])
     event("stale-desired-state-rejected", rejectedDeploymentId=evidence["staleDesiredState"]["rejectedDeploymentId"], currentDeploymentId=evidence["staleDesiredState"]["currentDeploymentId"])
     event("lock-contention", lock="controller", contender="second-reconciler", exitCode=evidence["lockContention"]["exitCode"])
     final = {

--- a/tests/deployment/incus-topology-example.json
+++ b/tests/deployment/incus-topology-example.json
@@ -47,7 +47,7 @@
       "rolloutPolicy": "gpu-servers-first"
     },
     {
-      "name": "solunska",
+      "name": "example-site",
       "rolloutPolicy": "home-lab-control-services"
     },
     {
@@ -100,9 +100,9 @@
       "avahi": true
     },
     {
-      "name": "solunska-target",
+      "name": "example-site-target",
       "role": "target",
-      "targetGroup": "solunska",
+      "targetGroup": "example-site",
       "networks": [
         "control",
         "cache",


### PR DESCRIPTION
Replaces real infrastructure identifiers that had leaked into the public repo's deployment tooling, tests, and examples with neutral placeholders (working-tree scrub; history purge tracked separately in the cleanup campaign).

- **`solunska` / `solunska-server`** (a named production site/server) → `example-site` / `example-site-server`, consistently across `tests/deployment/incus-topology-example.json`, `checks/deployment-incus-rehearsal.nix`, `scripts/deployment-incus-rehearsal.sh`, `modules/host-info.nix`, and the `ci_matrix.d` unittest.
- **`Hetzner-FSN1-DC11-i7-4770-16-512-001`** (a specific real datacenter hostname — the clearest leak) → `bare-metal-001`; `gpu-server-00N` → `gpu-node-00N`; `hetzner-00N` → `app-node-00N` in the self-contained `ci_matrix.d` deployment-target unittest (list + asserts kept in sync; `isDeployableServerMachineAttr` only does membership checks).
- Drops the **person names** (`nedislav`, `eli`) from the `deployment-reconciler` runtime-log denylist; keeps the generic infra-name patterns.

Kept deliberately: the generic cloud-provider label `hetzner` and generic group names (`home-lab-gpu`, `workstation`) — not org-identifying.

Pure token renames: JSON valid, nix files parse, fixture/check/script tokens stay consistent.