### PR TITLE
feat(terraform/github): shared secret adoption + rotation tooling (M3/M4)

### DIFF
--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -159,6 +159,37 @@ org — owner / root-config / repo-root are parameters.
   (`GOVERNANCE_ROOT_CONFIG`, `GOVERNANCE_ROOT`, `GOVERNANCE_RESULT_ROOT`,
   `BACKEND_CONFIG_FILE`, `GOVERNANCE_TOKEN_PATH`).
 
+## Secret adoption + rotation tooling (M3/M4)
+
+Company-agnostic tools for the secret side of governance — backing up, rendering,
+and rotating the GitHub Actions secrets the [governance engine](#governancenix--github-governance-engine)
+manages. All are parameterized by env: `GOVERNANCE_ROOT_CONFIG`
+(e.g. `github/<name>-governance-prod`) and `GOVERNANCE_REPO_ROOT` (default CWD).
+See the [import-phase methodology](../../docs/Terraform-Import-Phase.md) (M3/M4)
+and [secret-rotation methodology](../../docs/GitHub-Secret-Rotation.md).
+
+- **`github-governance-secrets-render`** — renders GitHub-encrypted (libsodium
+  sealed-box) payloads for the managed secrets from their agenix `.age` sources,
+  writing `secrets/{payloads,managed}.generated.nix`. Plaintext is decrypted only
+  into a private temp dir, never onto the command line. Select with `--secret`,
+  `--group`, `--all`, or `--set SET` (data-driven: matches the manifest secret's
+  `sets` field — no hardcoded credential sets).
+- **`github-secret-rotation-intake`** — creates/verifies the `.age` replacement
+  files for rotation; never writes to GitHub, never prints values.
+- **`github-secret-rotation-plan`** / **`github-secret-consumer-matrix`** —
+  read-only Markdown reports (rotation groups from the manifest; consumer matrix
+  from `secrets/consumers.nix`).
+- **`github-secret-rotate`** — issuer-aware dispatcher. Reads the matched
+  manifest secret's `rotationHandler` and execs the per-repo handler under
+  `$GOVERNANCE_SECRET_HANDLERS_DIR` (default `<root>/secret-handlers`); prints the
+  manifest entry and stops if none is declared. Issuer handlers stay per-repo.
+- **`github-governance-token`** — CI helper that mints a short-lived GitHub App
+  installation token (already org-agnostic).
+
+To adopt secrets, a consumer adds entries to `secrets/manifest.nix` (optionally
+with `sets` / `rotationHandler`), places `.age` sources under `secrets/actions/`,
+then runs render → reviewed governance plan/apply.
+
 ## `github-bootstrap` — GitHub Layer-0 driver
 
 Org-admin driver for the GitHub side of Layer 0: the CI-enabling repo settings

--- a/terraform/github/github-governance-secrets-render
+++ b/terraform/github/github-governance-secrets-render
@@ -1,0 +1,519 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${GOVERNANCE_ROOT_CONFIG:?set GOVERNANCE_ROOT_CONFIG to the governance root config, e.g. github/<name>-governance-prod}"
+
+root="${GOVERNANCE_REPO_ROOT:-$PWD}"
+governance_dir="${root}/bootstrap/${GOVERNANCE_ROOT_CONFIG}"
+secrets_dir="${governance_dir}/secrets"
+manifest="${secrets_dir}/manifest.nix"
+rules="${secrets_dir}/secrets.nix"
+output="${secrets_dir}/payloads.generated.nix"
+managed_output="${secrets_dir}/managed.generated.nix"
+
+usage() {
+  cat <<'USAGE'
+Usage: github-governance-secrets-render [options]
+
+Render GitHub-public-key encrypted values for Terraform-managed
+github_actions_*_secret resources. Plaintext is decrypted only into a private
+temporary directory and is never passed through command-line arguments.
+
+Selection:
+  --secret SECRET       Select by providerId, or by name if the name is unique.
+                        May be repeated.
+  --group GROUP         Select one rotationGroup from the manifest. May repeat.
+  --set SET             Select secrets whose manifest 'sets' field contains SET.
+  --all                 Select all manifest secrets. This is also the default.
+
+Modes:
+  --dry-run             Print selected entries and file status only.
+  --force               Re-encrypt even if the age file hash and GitHub key id
+                        match an existing rendered payload.
+
+Verification:
+  --identity PATH       Private SSH key passed to agenix decrypt operations.
+  --output PATH         Render to a non-default Nix payload file.
+  --managed-output PATH Render managed secret provider ids to a non-default Nix
+                        file.
+
+Examples:
+  github-governance-secrets-render --set cloudflare-release-r2
+  github-governance-secrets-render --secret <owner>/<repo>:SECRET_NAME
+  github-governance-secrets-render --group attic-cache --dry-run
+USAGE
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    fail "missing required command: sha256sum or shasum"
+  fi
+}
+
+json_array_from_args() {
+  if (($# == 0)); then
+    printf '[]\n'
+  else
+    printf '%s\n' "$@" | jq -R -s -c 'split("\n")[:-1]'
+  fi
+}
+
+relative_age_file() {
+  local age_file="$1"
+  if [[ "$age_file" != secrets/* ]]; then
+    fail "manifest ageFile must start with secrets/: $age_file"
+  fi
+  printf '%s\n' "${age_file#secrets/}"
+}
+
+target_for_secret_json() {
+  jq -r '
+    if .scope == "organization" then
+      "org"
+    elif .environment then
+      .repository + "/" + .environment
+    else
+      .repository
+    end
+  '
+}
+
+urlencode() {
+  jq -nr --arg value "$1" '$value | @uri'
+}
+
+public_key_endpoint() {
+  local secret_json="$1"
+  local owner scope repository environment encoded_environment
+
+  owner="$(jq -r '.providerId | split("/")[0]' <<<"$secret_json")"
+  scope="$(jq -r '.scope' <<<"$secret_json")"
+  repository="$(jq -r '.repository // ""' <<<"$secret_json")"
+  environment="$(jq -r '.environment // ""' <<<"$secret_json")"
+
+  case "$scope" in
+    organization)
+      printf 'orgs/%s/actions/secrets/public-key\n' "$owner"
+      ;;
+    repository)
+      [[ -n "$repository" ]] || fail "repository secret is missing repository"
+      printf 'repos/%s/%s/actions/secrets/public-key\n' "$owner" "$repository"
+      ;;
+    environment)
+      [[ -n "$repository" ]] || fail "environment secret is missing repository"
+      [[ -n "$environment" ]] || fail "environment secret is missing environment"
+      encoded_environment="$(urlencode "$environment")"
+      printf 'repos/%s/%s/environments/%s/secrets/public-key\n' "$owner" "$repository" "$encoded_environment"
+      ;;
+    *)
+      fail "unsupported secret scope: $scope"
+      ;;
+  esac
+}
+
+fetch_key_id() {
+  local endpoint="$1"
+  gh api "$endpoint" -q '.key_id'
+}
+
+encrypt_for_github() {
+  local secret_json="$1"
+  local plaintext_file="$2"
+  local owner scope repository environment visibility name
+
+  owner="$(jq -r '.providerId | split("/")[0]' <<<"$secret_json")"
+  scope="$(jq -r '.scope' <<<"$secret_json")"
+  repository="$(jq -r '.repository // ""' <<<"$secret_json")"
+  environment="$(jq -r '.environment // ""' <<<"$secret_json")"
+  visibility="$(jq -r '.visibility // ""' <<<"$secret_json")"
+  name="$(jq -r '.name' <<<"$secret_json")"
+
+  case "$scope" in
+    organization)
+      [[ -n "$visibility" ]] || fail "organization secret ${name} is missing visibility"
+      gh secret set "$name" --app actions --org "$owner" --visibility "$visibility" --no-store < "$plaintext_file"
+      ;;
+    repository)
+      [[ -n "$repository" ]] || fail "repository secret ${name} is missing repository"
+      gh secret set "$name" --app actions --repo "${owner}/${repository}" --no-store < "$plaintext_file"
+      ;;
+    environment)
+      [[ -n "$repository" ]] || fail "environment secret ${name} is missing repository"
+      [[ -n "$environment" ]] || fail "environment secret ${name} is missing environment"
+      gh secret set "$name" --app actions --repo "${owner}/${repository}" --env "$environment" --no-store < "$plaintext_file"
+      ;;
+    *)
+      fail "unsupported secret scope: $scope"
+      ;;
+  esac
+}
+
+write_payloads_nix() {
+  local payloads_json_file="$1"
+  local output_file="$2"
+  local tmp_output="$3"
+
+  {
+    echo "# Generated by github-governance-secrets-render."
+    echo "# Values are encrypted to GitHub Actions public keys; do not edit by hand."
+    echo "{"
+    echo "  version = 1;"
+    echo "  payloads = {"
+    jq -r '
+      def q: @json;
+      to_entries
+      | sort_by(.key)
+      | .[]
+      | . as $entry
+      | (
+          [
+            "    \($entry.key | q) = {",
+            "      version = \($entry.value.version // 1);",
+            "      providerId = \($entry.value.providerId | q);",
+            "      providerResource = \($entry.value.providerResource | q);",
+            "      scope = \($entry.value.scope | q);",
+            "      owner = \($entry.value.owner | q);",
+            "      name = \($entry.value.name | q);"
+          ]
+          + (if $entry.value.repository then [ "      repository = \($entry.value.repository | q);" ] else [] end)
+          + (if $entry.value.environment then [ "      environment = \($entry.value.environment | q);" ] else [] end)
+          + (if $entry.value.visibility then [ "      visibility = \($entry.value.visibility | q);" ] else [] end)
+          + [
+            "      ageFile = \($entry.value.ageFile | q);",
+            "      ageFileSha256 = \($entry.value.ageFileSha256 | q);",
+            "      keyId = \($entry.value.keyId | q);",
+            "      valueEncrypted = \($entry.value.valueEncrypted | q);",
+            "      renderedWith = \($entry.value.renderedWith | q);",
+            "    };"
+          ]
+        )
+      | .[]
+    ' "$payloads_json_file"
+    echo "  };"
+    echo "}"
+  } > "$tmp_output"
+
+  mv "$tmp_output" "$output_file"
+}
+
+write_managed_nix() {
+  local managed_json_file="$1"
+  local output_file="$2"
+  local tmp_output="$3"
+
+  {
+    echo "# Generated by github-governance-secrets-render."
+    echo "# Provider ids listed here are enforced as Terraform-managed GitHub Actions secrets."
+    echo "{"
+    echo "  version = 1;"
+    echo "  providerIds = ["
+    jq -r 'sort | unique | .[] | "    \(tojson)"' "$managed_json_file"
+    echo "  ];"
+    echo "}"
+  } > "$tmp_output"
+
+  mv "$tmp_output" "$output_file"
+}
+
+secret_selectors=()
+group_selectors=()
+set_selectors=()
+select_all=0
+dry_run=0
+force=0
+identity=""
+
+while (($# > 0)); do
+  case "$1" in
+    --secret)
+      secret_selectors+=("${2:-}")
+      [[ -n "${2:-}" ]] || fail "--secret requires a value"
+      shift 2
+      ;;
+    --group)
+      group_selectors+=("${2:-}")
+      [[ -n "${2:-}" ]] || fail "--group requires a value"
+      shift 2
+      ;;
+    --set)
+      set_selectors+=("${2:-}")
+      [[ -n "${2:-}" ]] || fail "--set requires a value"
+      shift 2
+      ;;
+    --all)
+      select_all=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --force)
+      force=1
+      shift
+      ;;
+    --identity)
+      identity="${2:-}"
+      [[ -n "$identity" ]] || fail "--identity requires a value"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      [[ -n "$output" ]] || fail "--output requires a value"
+      shift 2
+      ;;
+    --managed-output)
+      managed_output="${2:-}"
+      [[ -n "$managed_output" ]] || fail "--managed-output requires a value"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+if [[ ${#secret_selectors[@]} -eq 0 && ${#group_selectors[@]} -eq 0 && ${#set_selectors[@]} -eq 0 && "$select_all" == "0" ]]; then
+  select_all=1
+fi
+
+if [[ -n "$identity" ]]; then
+  identity="$(eval echo "$identity")"
+  [[ -f "$identity" ]] || fail "identity not found: $identity"
+fi
+
+need jq
+need nix
+
+[[ -f "$manifest" ]] || fail "missing manifest: $manifest"
+[[ -f "$rules" ]] || fail "missing agenix rules file: $rules"
+
+json="$(nix eval --json --file "$manifest")"
+secret_selector_json="$(json_array_from_args "${secret_selectors[@]}")"
+group_selector_json="$(json_array_from_args "${group_selectors[@]}")"
+set_selector_json="$(json_array_from_args "${set_selectors[@]}")"
+
+for selector in "${secret_selectors[@]}"; do
+  exact_count="$(jq --arg secret "$selector" '[.secrets[] | select(.providerId == $secret)] | length' <<<"$json")"
+  name_count="$(jq --arg secret "$selector" '[.secrets[] | select(.name == $secret)] | length' <<<"$json")"
+  if [[ "$exact_count" == "0" && "$name_count" != "1" ]]; then
+    fail "secret name '${selector}' matched ${name_count} entries; use a full providerId"
+  fi
+done
+
+selected="$(
+  jq -c \
+    --argjson select_all "$select_all" \
+    --argjson secrets "$secret_selector_json" \
+    --argjson groups "$group_selector_json" \
+    --argjson sets "$set_selector_json" '
+      def in_array($arr; $value): any($arr[]; . == $value);
+      .secrets
+      | map(select(
+          ($select_all == 1)
+          or (($groups | length) > 0 and in_array($groups; .rotationGroup))
+          or (($secrets | length) > 0 and (in_array($secrets; .providerId) or in_array($secrets; .name)))
+          or (($sets | length) > 0 and ((.sets // []) | any(in_array($sets; .))))
+        ))
+      | sort_by(.rotationGroup, .scope, (.repository // ""), (.environment // ""), .name)
+    ' <<<"$json"
+)"
+
+selected_count="$(jq 'length' <<<"$selected")"
+if [[ "$selected_count" == "0" ]]; then
+  fail "no manifest secrets matched the requested selection"
+fi
+
+if [[ -f "$output" ]]; then
+  payloads_json="$(nix eval --json --file "$output" | jq -c '.payloads // {}')"
+else
+  payloads_json="{}"
+fi
+
+if [[ -f "$managed_output" ]]; then
+  managed_json="$(nix eval --json --file "$managed_output" | jq -c '.providerIds // []')"
+else
+  managed_json="[]"
+fi
+
+if ((dry_run)); then
+  printf '%-28s %-38s %-34s %-8s %-8s %-8s %s\n' "group" "target" "name" "age" "payload" "managed" "provider id"
+  jq -r '.[] | @base64' <<<"$selected" | while IFS= read -r encoded; do
+    secret_json="$(printf '%s' "$encoded" | base64 -d)"
+    rotation_group="$(jq -r '.rotationGroup' <<<"$secret_json")"
+    target="$(target_for_secret_json <<<"$secret_json")"
+    name="$(jq -r '.name' <<<"$secret_json")"
+    provider_id="$(jq -r '.providerId' <<<"$secret_json")"
+    relative="$(relative_age_file "$(jq -r '.ageFile' <<<"$secret_json")")"
+    age_status=no
+    payload_status=no
+    managed_status=no
+    [[ -s "${secrets_dir}/${relative}" ]] && age_status=yes
+    jq -e --arg provider_id "$provider_id" 'has($provider_id)' <<<"$payloads_json" >/dev/null && payload_status=yes
+    jq -e --arg provider_id "$provider_id" 'index($provider_id) != null' <<<"$managed_json" >/dev/null && managed_status=yes
+    printf '%-28s %-38s %-34s %-8s %-8s %-8s %s\n' \
+      "$rotation_group" "$target" "$name" "$age_status" "$payload_status" "$managed_status" "$provider_id"
+  done
+  exit 0
+fi
+
+need agenix
+need gh
+gh auth status --hostname github.com >/dev/null
+
+mkdir -p "${root}/.result/secrets"
+tmp_dir="$(mktemp -d "${root}/.result/secrets/github-governance-render.XXXXXX")"
+chmod 0700 "$tmp_dir"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+echo "Rendering GitHub-encrypted payloads for ${selected_count} secret(s)."
+echo "Output: ${output#"$root/"}"
+echo "Managed ids: ${managed_output#"$root/"}"
+
+index=0
+while IFS= read -r encoded; do
+  index=$((index + 1))
+  secret_json="$(printf '%s' "$encoded" | base64 -d)"
+  provider_id="$(jq -r '.providerId' <<<"$secret_json")"
+  provider_resource="$(jq -r '.providerResource' <<<"$secret_json")"
+  scope="$(jq -r '.scope' <<<"$secret_json")"
+  owner="$(jq -r '.providerId | split("/")[0]' <<<"$secret_json")"
+  name="$(jq -r '.name' <<<"$secret_json")"
+  repository="$(jq -r '.repository // ""' <<<"$secret_json")"
+  environment="$(jq -r '.environment // ""' <<<"$secret_json")"
+  visibility="$(jq -r '.visibility // ""' <<<"$secret_json")"
+  age_file="$(jq -r '.ageFile' <<<"$secret_json")"
+  relative="$(relative_age_file "$age_file")"
+  absolute="${secrets_dir}/${relative}"
+  endpoint="$(public_key_endpoint "$secret_json")"
+  plaintext_file="${tmp_dir}/plaintext-${index}"
+  key_id_before=""
+  key_id_after=""
+  age_hash=""
+  encrypted_value=""
+  existing_matches=0
+  args=(-d "$relative")
+
+  [[ -s "$absolute" ]] || fail "missing age file for ${provider_id}: ${age_file}"
+  age_hash="$(file_sha256 "$absolute")"
+  key_id_before="$(fetch_key_id "$endpoint")"
+  [[ -n "$key_id_before" && "$key_id_before" != "null" ]] || fail "GitHub did not return a key id for ${provider_id}"
+
+  if ((force == 0)); then
+    if jq -e \
+      --arg provider_id "$provider_id" \
+      --arg key_id "$key_id_before" \
+      --arg age_hash "$age_hash" '
+        .[$provider_id].keyId == $key_id
+        and .[$provider_id].ageFileSha256 == $age_hash
+        and (.[$provider_id].valueEncrypted | type == "string")
+        and (.[$provider_id].valueEncrypted | length > 0)
+      ' <<<"$payloads_json" >/dev/null; then
+      existing_matches=1
+    fi
+  fi
+
+  if ((existing_matches)); then
+    managed_json="$(jq -c --arg provider_id "$provider_id" '. + [$provider_id] | unique | sort' <<<"$managed_json")"
+    echo "unchanged: ${provider_id}"
+    continue
+  fi
+
+  if [[ -n "$identity" ]]; then
+    args+=(-i "$identity")
+  fi
+  (
+    cd "$secrets_dir"
+    umask 077
+    RULES="$rules" agenix "${args[@]}" > "$plaintext_file"
+  )
+  [[ -s "$plaintext_file" ]] || fail "agenix produced an empty plaintext file for ${provider_id}"
+
+  encrypted_value="$(encrypt_for_github "$secret_json" "$plaintext_file")"
+  rm -f "$plaintext_file"
+  [[ -n "$encrypted_value" ]] || fail "GitHub encryption returned an empty value for ${provider_id}"
+
+  key_id_after="$(fetch_key_id "$endpoint")"
+  if [[ "$key_id_before" != "$key_id_after" ]]; then
+    fail "GitHub public key changed while rendering ${provider_id}; retry"
+  fi
+
+  payload_update="$(
+    jq -n -c \
+      --arg provider_id "$provider_id" \
+      --arg provider_resource "$provider_resource" \
+      --arg scope "$scope" \
+      --arg owner "$owner" \
+      --arg name "$name" \
+      --arg repository "$repository" \
+      --arg environment "$environment" \
+      --arg visibility "$visibility" \
+      --arg age_file "$age_file" \
+      --arg age_hash "$age_hash" \
+      --arg key_id "$key_id_before" \
+      --arg value_encrypted "$encrypted_value" '
+        {
+          ($provider_id): (
+            {
+              version: 1,
+              providerId: $provider_id,
+              providerResource: $provider_resource,
+              scope: $scope,
+              owner: $owner,
+              name: $name,
+              ageFile: $age_file,
+              ageFileSha256: $age_hash,
+              keyId: $key_id,
+              valueEncrypted: $value_encrypted,
+              renderedWith: "gh-secret-set-no-store"
+            }
+            + (if $repository != "" then {repository: $repository} else {} end)
+            + (if $environment != "" then {environment: $environment} else {} end)
+            + (if $visibility != "" then {visibility: $visibility} else {} end)
+          )
+        }
+      '
+  )"
+  payloads_json="$(jq -c --argjson update "$payload_update" '. * $update' <<<"$payloads_json")"
+  managed_json="$(jq -c --arg provider_id "$provider_id" '. + [$provider_id] | unique | sort' <<<"$managed_json")"
+  echo "rendered: ${provider_id}"
+done < <(jq -r '.[] | @base64' <<<"$selected")
+
+payloads_json_file="${tmp_dir}/payloads.json"
+printf '%s\n' "$payloads_json" > "$payloads_json_file"
+managed_json_file="${tmp_dir}/managed.json"
+printf '%s\n' "$managed_json" > "$managed_json_file"
+mkdir -p "$(dirname "$output")"
+mkdir -p "$(dirname "$managed_output")"
+write_payloads_nix "$payloads_json_file" "$output" "${tmp_dir}/payloads.generated.nix"
+write_managed_nix "$managed_json_file" "$managed_output" "${tmp_dir}/managed.generated.nix"
+
+echo
+echo "Rendered payloads written to:"
+echo "  ${output}"
+echo "Managed provider ids written to:"
+echo "  ${managed_output}"
+echo
+echo "Next:"
+echo "  1. Review and commit the updated .age files, ${output#"$root/"}, and ${managed_output#"$root/"}."
+echo "  2. Run: just bootstrap-offline "${GOVERNANCE_ROOT_CONFIG}""
+echo "  3. Have a human run a reviewed GitHub governance plan/apply."

--- a/terraform/github/github-governance-token
+++ b/terraform/github/github-governance-token
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "::error::${name} is required." >&2
+    exit 1
+  fi
+}
+
+base64url() {
+  openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+require_env GITHUB_OUTPUT
+require_env GITHUB_REPOSITORY_OWNER
+require_env RUNNER_TEMP
+
+token_path="${RUNNER_TEMP}/github-governance-token"
+
+if [ -n "${GOVERNANCE_STATIC_TOKEN:-}" ]; then
+  printf '%s' "$GOVERNANCE_STATIC_TOKEN" > "$token_path"
+  echo "::add-mask::$GOVERNANCE_STATIC_TOKEN"
+  echo "token_source=GH_GOVERNANCE_TOKEN" >> "$GITHUB_OUTPUT"
+  echo "Selected GitHub governance token source: GH_GOVERNANCE_TOKEN"
+else
+  app_id=""
+  app_private_key=""
+  app_source=""
+
+  if [ -n "${GH_GOVERNANCE_APP_ID:-}" ] && [ -n "${GH_GOVERNANCE_APP_PRIVATE_KEY:-}" ]; then
+    app_id="$GH_GOVERNANCE_APP_ID"
+    app_private_key="$GH_GOVERNANCE_APP_PRIVATE_KEY"
+    app_source="GH_GOVERNANCE_APP"
+  elif [ -n "${CI_TOKEN_PROVIDER_APP_ID:-}" ] && [ -n "${CI_TOKEN_PROVIDER_PRIVATE_KEY:-}" ]; then
+    app_id="$CI_TOKEN_PROVIDER_APP_ID"
+    app_private_key="$CI_TOKEN_PROVIDER_PRIVATE_KEY"
+    app_source="CI_TOKEN_PROVIDER_APP"
+  fi
+
+  if [ -z "$app_id" ] || [ -z "$app_private_key" ]; then
+    echo "::error::No GitHub governance credential is configured. Set GH_GOVERNANCE_TOKEN, GH_GOVERNANCE_APP_ID/GH_GOVERNANCE_APP_PRIVATE_KEY, or CI_TOKEN_PROVIDER_APP_ID/CI_TOKEN_PROVIDER_PRIVATE_KEY." >&2
+    exit 1
+  fi
+
+  key_path="${RUNNER_TEMP}/github-governance-app-key.pem"
+  printf '%s\n' "$app_private_key" > "$key_path"
+  chmod 600 "$key_path"
+
+  api_url="${GITHUB_API_URL:-https://api.github.com}"
+  now="$(date +%s)"
+  iat="$((now - 60))"
+  exp="$((now + 540))"
+
+  header="$(printf '{"alg":"RS256","typ":"JWT"}' | base64url)"
+  payload="$(
+    jq -nc \
+      --argjson iat "$iat" \
+      --argjson exp "$exp" \
+      --arg iss "$app_id" \
+      '{iat: $iat, exp: $exp, iss: $iss}'
+  )"
+  payload64="$(printf '%s' "$payload" | base64url)"
+  signing_input="${header}.${payload64}"
+  signature="$(
+    printf '%s' "$signing_input" \
+      | openssl dgst -sha256 -sign "$key_path" -binary \
+      | base64url
+  )"
+  jwt="${signing_input}.${signature}"
+
+  installation_id="$(
+    curl -fsSL \
+      -H "Authorization: Bearer ${jwt}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "${api_url}/app/installations" \
+      | jq -r --arg owner "$GITHUB_REPOSITORY_OWNER" \
+          '.[] | select(.account.login == $owner) | .id' \
+      | head -n 1
+  )"
+
+  if [ -z "$installation_id" ] || [ "$installation_id" = "null" ]; then
+    echo "::error::Could not find a GitHub App installation for ${GITHUB_REPOSITORY_OWNER}." >&2
+    exit 1
+  fi
+
+  app_token="$(
+    curl -fsSL \
+      -X POST \
+      -H "Authorization: Bearer ${jwt}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "${api_url}/app/installations/${installation_id}/access_tokens" \
+      | jq -r '.token // empty'
+  )"
+
+  if [ -z "$app_token" ]; then
+    echo "::error::GitHub governance app did not return an installation token." >&2
+    exit 1
+  fi
+
+  printf '%s' "$app_token" > "$token_path"
+  echo "::add-mask::$app_token"
+  echo "token_source=$app_source" >> "$GITHUB_OUTPUT"
+  echo "Selected GitHub governance token source: $app_source"
+fi
+
+chmod 600 "$token_path"
+echo "token_path=$token_path" >> "$GITHUB_OUTPUT"

--- a/terraform/github/github-secret-consumer-matrix
+++ b/terraform/github/github-secret-consumer-matrix
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${GOVERNANCE_ROOT_CONFIG:?set GOVERNANCE_ROOT_CONFIG to the governance root config, e.g. github/<name>-governance-prod}"
+
+root="${GOVERNANCE_REPO_ROOT:-$PWD}"
+matrix="${root}/bootstrap/${GOVERNANCE_ROOT_CONFIG}/secrets/consumers.nix"
+
+json="$(nix eval --json --file "$matrix")"
+
+jq -r '
+  def md:
+    tostring
+    | gsub("\\|"; "\\|")
+    | gsub("\n"; " ");
+
+  def line($s): $s;
+  def bullets($title; $items):
+    line("### " + $title),
+    (
+      if (($items // []) | length) == 0 then
+        line("- None.")
+      else
+        ($items[] | line("- " + (. | md)))
+      end
+    ),
+    line("");
+
+  def age_inventory($items):
+    line("### Age Secret Inventory"),
+    (
+      if (($items // []) | length) == 0 then
+        line("- None.")
+      else
+        ($items[]
+          | line("- " + (.checkout | md) + ": " + (.finding | md)
+              + (
+                  if ((.paths // []) | length) == 0 then
+                    ""
+                  else
+                    " Paths: " + ((.paths // []) | map("`" + . + "`") | join(", "))
+                  end
+                )))
+      end
+    ),
+    line("");
+
+  def age_usage($items):
+    (
+      if (($items // []) | length) == 0 then
+        empty
+      else
+        line("### Age Secret Usage"),
+        ($items[]
+          | line("- `" + (.path | md) + "`: " + (.storageRole | md)
+              + " Decrypted by: " + (.decryptedBy | md)
+              + " Exposes as: " + (.exposesAs | md)
+              + " Evidence: " + ((.evidence // []) | map("`" + . + "`") | join(", ")))),
+        line("")
+      end
+    );
+
+  . as $root
+  | line("# GitHub Secret Consumer Matrix"),
+    line(""),
+    line("- Owner: " + $root.owner),
+    line("- Source inventory: " + $root.sourceInventory.runId),
+    line("- Reviewed: " + $root.sourceReview.reviewedAt),
+    line("- Current inventory audit: " + $root.sourceReview.currentInventoryRunId),
+    line("- Secret count: " + (($root.bySecret | keys | length) | tostring)),
+    line(""),
+    line($root.sourceReview.currentInventoryResult),
+    line(""),
+    bullets("Review Method"; $root.sourceReview.reviewMethod),
+    age_inventory($root.sourceReview.ageSecretInventory),
+    bullets("Limitations"; $root.sourceReview.limitations),
+    line("## Active Workflow Gaps"),
+    line(""),
+    line("These default-branch workflow references are not present in the current GitHub secret inventory. They are not part of the rotate-all-existing manifest until intentionally added."),
+    line(""),
+    line("| provider id | status | recommended action | evidence |"),
+    line("| --- | --- | --- | --- |"),
+    (
+      ($root.workflowGaps // [])
+      | sort_by(.providerId)
+      | .[]
+      | line(
+          "| `" + (.providerId | md) + "`"
+          + " | " + (.status | md)
+          + " | " + (.recommendedAction | md)
+          + " | " + ((.evidence // []) | map("`" + . + "`") | join(", "))
+          + " |"
+        )
+    ),
+    line(""),
+    (
+      $root.rotationGroups
+      | to_entries
+      | sort_by(.key)
+      | .[]
+      | . as $group
+      | line("## " + $group.key),
+        line(""),
+        line("- Logical credential: " + ($group.value.logicalCredential | md)),
+        line("- Issuer: " + ($group.value.issuer | md)),
+        line("- Candidate placement: " + ($group.value.candidatePlacement | md)),
+        line(""),
+        bullets("Current Placement"; $group.value.currentPlacement),
+        line("### Consumers"),
+        (
+          $group.value.consumers[]
+          | line("- " + (.scope | md) + ": " + (.purpose | md) + " Evidence: " + ((.evidence // []) | map("`" + . + "`") | join(", ")))
+        ),
+        line(""),
+        age_usage($group.value.ageSecretUsage),
+        bullets("Rotation Scope"; $group.value.rotationScope),
+        bullets("Validation"; $group.value.validation),
+        bullets("Notes"; $group.value.notes),
+        line("### Secrets"),
+        line("| provider id | name | scope | status | recommended action | age file |"),
+        line("| --- | --- | --- | --- | --- | --- |"),
+        (
+          $root.bySecret
+          | to_entries
+          | map(select(.value.manifestSecret.rotationGroup == $group.key))
+          | sort_by(.value.manifestSecret.scope, (.value.manifestSecret.repository // ""), .value.manifestSecret.name)
+          | .[]
+          | .value as $entry
+          | $entry.manifestSecret as $secret
+          | $entry.secretReview as $review
+          | line(
+              "| `" + ($secret.providerId | md) + "`"
+              + " | `" + ($secret.name | md) + "`"
+              + " | " + ($secret.scope | md)
+              + " | " + (($review.consumerStatus // "") | md)
+              + " | " + (($review.recommendedAction // "") | md)
+              + " | `" + ($secret.ageFile | md) + "` |"
+            )
+        ),
+        line("")
+    )
+' <<<"$json"

--- a/terraform/github/github-secret-rotate
+++ b/terraform/github/github-secret-rotate
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Company-agnostic issuer-aware secret-rotation dispatcher.
+#
+# Routes a rotation request for one GitHub secret (or a named credential set) to
+# the per-repo handler declared in the governance manifest. The manifest secret
+# carries an optional `rotationHandler` (a handler name); the handler scripts
+# live in the consumer repo under $GOVERNANCE_SECRET_HANDLERS_DIR (default
+# <root>/secret-handlers). Nothing issuer-specific is hardcoded here.
+#
+# If no handler is declared/found, this prints the manifest entry via the intake
+# helper and exits without changing anything.
+set -euo pipefail
+: "${GOVERNANCE_ROOT_CONFIG:?set GOVERNANCE_ROOT_CONFIG to the governance root config, e.g. github/<name>-governance-prod}"
+
+root="${GOVERNANCE_REPO_ROOT:-$PWD}"
+governance_dir="${root}/bootstrap/${GOVERNANCE_ROOT_CONFIG}"
+manifest="${governance_dir}/secrets/manifest.nix"
+handlers_dir="${GOVERNANCE_SECRET_HANDLERS_DIR:-${root}/secret-handlers}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  github-secret-rotate --secret SECRET [handler-options...]
+  github-secret-rotate --set SET [handler-options...]
+
+Dispatch to the issuer-aware rotation handler for one GitHub secret or credential
+set. SECRET is a providerId (e.g. <owner>/<repo>:NAME) or a unique secret name.
+SET matches the manifest `sets` field. The handler to run is read from the
+matched manifest secret's `rotationHandler` and resolved under
+$GOVERNANCE_SECRET_HANDLERS_DIR (default <root>/secret-handlers).
+
+If no handler is declared, this prints the manifest entry and exits without
+changing anything. Add a handler and set `rotationHandler` on the secret before
+rotating that credential.
+
+Environment:
+  GOVERNANCE_ROOT_CONFIG         Governance root config, e.g. github/<name>-governance-prod.
+  GOVERNANCE_REPO_ROOT           Consumer repo root (default: CWD).
+  GOVERNANCE_SECRET_HANDLERS_DIR Directory of per-repo handler scripts.
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+mode=""
+selector=""
+while (($#)); do
+  case "$1" in
+    --secret)
+      mode="secret"
+      selector="${2:-}"
+      [[ -n "$selector" ]] || fail "--secret requires a value"
+      shift 2
+      break
+      ;;
+    --set | --group)
+      mode="set"
+      selector="${2:-}"
+      [[ -n "$selector" ]] || fail "--set requires a value"
+      shift 2
+      break
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "expected --secret or --set, got: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$mode" ]]; then
+  usage >&2
+  exit 1
+fi
+
+command -v jq >/dev/null 2>&1 || fail "missing required command: jq"
+command -v nix >/dev/null 2>&1 || fail "missing required command: nix"
+[[ -f "$manifest" ]] || fail "missing manifest: $manifest"
+json="$(nix eval --json --file "$manifest")"
+
+# Resolve the handler name from the matched manifest secret(s).
+if [[ "$mode" == "secret" ]]; then
+  handler="$(jq -r --arg s "$selector" '
+    [.secrets[] | select(.providerId == $s or .name == $s) | .rotationHandler // empty] | unique | .[0] // ""
+  ' <<<"$json")"
+else
+  handler="$(jq -r --arg s "$selector" '
+    [.secrets[] | select((.sets // []) | index($s)) | .rotationHandler // empty] | unique | .[0] // ""
+  ' <<<"$json")"
+fi
+
+if [[ -n "$handler" ]]; then
+  handler_path="${handlers_dir}/${handler}"
+  if [[ -x "$handler_path" ]]; then
+    exec "$handler_path" "$@"
+  fi
+  cat >&2 <<EOF
+Manifest declares rotationHandler '${handler}' for ${mode} '${selector}', but no
+executable handler was found at:
+  ${handler_path}
+Set GOVERNANCE_SECRET_HANDLERS_DIR or add the handler script.
+EOF
+  exit 2
+fi
+
+cat >&2 <<EOF
+No rotationHandler is declared for ${mode} '${selector}'.
+
+Manifest entry preview:
+EOF
+if [[ "$mode" == "secret" ]]; then
+  github-secret-rotation-intake --secret "$selector" --dry-run >&2 || true
+else
+  github-secret-rotation-intake --group "$selector" --dry-run >&2 || true
+fi
+
+cat >&2 <<'EOF'
+
+Add a dedicated handler before rotating this credential, and set the secret's
+`rotationHandler` in the manifest. A compliant handler must explain the
+issuer-side operation, capture or create the replacement value, write the
+declared .age backup, render Terraform's GitHub-encrypted payload, and print
+validation and old-credential revocation steps.
+EOF
+
+exit 2

--- a/terraform/github/github-secret-rotation-intake
+++ b/terraform/github/github-secret-rotation-intake
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${GOVERNANCE_ROOT_CONFIG:?set GOVERNANCE_ROOT_CONFIG to the governance root config, e.g. github/<name>-governance-prod}"
+
+root="${GOVERNANCE_REPO_ROOT:-$PWD}"
+governance_dir="${root}/bootstrap/${GOVERNANCE_ROOT_CONFIG}"
+secrets_dir="${governance_dir}/secrets"
+manifest="${secrets_dir}/manifest.nix"
+rules="${secrets_dir}/secrets.nix"
+
+usage() {
+  cat <<'USAGE'
+Usage: github-secret-rotation-intake [options]
+
+Create or verify age-encrypted replacement values for GitHub secret rotation.
+This helper never writes to GitHub and never prints secret values.
+
+Selection:
+  --group GROUP         Select one rotationGroup from the manifest.
+  --secret SECRET       Select by providerId, or by name if the name is unique.
+  --all                 Select all manifest secrets.
+  --list-groups         Print available rotation groups and exit.
+
+Modes:
+  --dry-run             Print selected entries and file status only.
+  --verify-only         Verify selected age files can be decrypted.
+  --force               Re-edit age files that already exist.
+
+Verification:
+  --identity PATH       Private SSH key to pass to agenix for decrypt checks.
+  --no-verify           Do not decrypt-check files after editing.
+
+Examples:
+  github-secret-rotation-intake --list-groups
+  github-secret-rotation-intake --group attic-cache --dry-run
+  github-secret-rotation-intake --group attic-cache
+  github-secret-rotation-intake --secret <owner>/<repo>:SECRET_NAME --force
+  github-secret-rotation-intake --all --verify-only --identity ~/.ssh/metacraft_strong
+USAGE
+}
+
+group=""
+secret_selector=""
+select_all=0
+list_groups=0
+dry_run=0
+verify_only=0
+force=0
+verify_after_edit=1
+identity=""
+
+while (($# > 0)); do
+  case "$1" in
+    --group)
+      group="${2:-}"
+      shift 2
+      ;;
+    --secret)
+      secret_selector="${2:-}"
+      shift 2
+      ;;
+    --all)
+      select_all=1
+      shift
+      ;;
+    --list-groups)
+      list_groups=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --verify-only)
+      verify_only=1
+      shift
+      ;;
+    --force)
+      force=1
+      shift
+      ;;
+    --identity)
+      identity="${2:-}"
+      shift 2
+      ;;
+    --no-verify)
+      verify_after_edit=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$identity" ]]; then
+  identity="$(eval echo "$identity")"
+  if [[ ! -f "$identity" ]]; then
+    echo "identity not found: $identity" >&2
+    exit 1
+  fi
+fi
+
+json="$(nix eval --json --file "$manifest")"
+
+if ((list_groups)); then
+  jq -r '
+    .secrets
+    | group_by(.rotationGroup)
+    | map({group: .[0].rotationGroup, count: length})
+    | sort_by(.group)
+    | .[]
+    | "\(.group)\t\(.count)"
+  ' <<<"$json"
+  exit 0
+fi
+
+if ((select_all == 0)) && [[ -z "$group" && -z "$secret_selector" ]] && ((verify_only == 0)); then
+  echo "select --group, --secret, or --all; use --dry-run to preview first" >&2
+  exit 1
+fi
+
+selected="$(jq -c \
+  --arg group "$group" \
+  --arg secret "$secret_selector" \
+  --argjson select_all "$select_all" '
+  .secrets
+  | map(select(
+      (($select_all == 1) or ($group == "") or (.rotationGroup == $group))
+      and
+      (($secret == "") or (.providerId == $secret) or (.name == $secret))
+    ))
+  | sort_by(.rotationGroup, .scope, (.repository // ""), (.environment // ""), .name)
+' <<<"$json")"
+
+selected_count="$(jq 'length' <<<"$selected")"
+if [[ "$selected_count" == "0" ]]; then
+  echo "no manifest secrets matched the requested selection" >&2
+  exit 1
+fi
+
+if [[ -n "$secret_selector" ]]; then
+  exact_count="$(jq --arg secret "$secret_selector" '[.[] | select(.providerId == $secret)] | length' <<<"$selected")"
+  name_count="$(jq --arg secret "$secret_selector" '[.[] | select(.name == $secret)] | length' <<<"$selected")"
+  if [[ "$exact_count" == "0" && "$name_count" != "1" ]]; then
+    echo "secret name '${secret_selector}' matched ${name_count} entries; use a full providerId" >&2
+    exit 1
+  fi
+fi
+
+target_for_secret() {
+  jq -r '
+    if .scope == "organization" then
+      "org"
+    elif .environment then
+      .repository + "/" + .environment
+    else
+      .repository
+    end
+  '
+}
+
+relative_age_file() {
+  local age_file="$1"
+  if [[ "$age_file" != secrets/* ]]; then
+    echo "manifest ageFile must start with secrets/: $age_file" >&2
+    return 1
+  fi
+  printf '%s\n' "${age_file#secrets/}"
+}
+
+agenix_decrypt_check() {
+  local relative="$1"
+  local args=(-d "$relative")
+  if [[ -n "$identity" ]]; then
+    args+=(-i "$identity")
+  fi
+  (
+    cd "$secrets_dir"
+    RULES="$rules" agenix "${args[@]}" >/dev/null
+  )
+}
+
+print_selected() {
+  printf '%-28s %-38s %-34s %-8s %s\n' "group" "target" "name" "exists" "age file"
+  jq -r '.[] | @base64' <<<"$selected" | while IFS= read -r encoded; do
+    secret_json="$(printf '%s' "$encoded" | base64 -d)"
+    rotation_group="$(jq -r '.rotationGroup' <<<"$secret_json")"
+    target="$(target_for_secret <<<"$secret_json")"
+    name="$(jq -r '.name' <<<"$secret_json")"
+    age_file="$(jq -r '.ageFile' <<<"$secret_json")"
+    relative="$(relative_age_file "$age_file")"
+    if [[ -s "${secrets_dir}/${relative}" ]]; then
+      exists=yes
+    else
+      exists=no
+    fi
+    printf '%-28s %-38s %-34s %-8s %s\n' \
+      "$rotation_group" "$target" "$name" "$exists" "$age_file"
+  done
+}
+
+if ((dry_run)); then
+  print_selected
+  exit 0
+fi
+
+if ((verify_only)); then
+  failures=0
+  while IFS= read -r encoded; do
+    secret_json="$(printf '%s' "$encoded" | base64 -d)"
+    name="$(jq -r '.name' <<<"$secret_json")"
+    target="$(target_for_secret <<<"$secret_json")"
+    age_file="$(jq -r '.ageFile' <<<"$secret_json")"
+    relative="$(relative_age_file "$age_file")"
+    if [[ ! -s "${secrets_dir}/${relative}" ]]; then
+      echo "missing: ${target}:${name} -> ${age_file}" >&2
+      failures=1
+      continue
+    fi
+    if agenix_decrypt_check "$relative"; then
+      echo "ok: ${target}:${name} -> ${age_file}"
+    else
+      echo "decrypt failed: ${target}:${name} -> ${age_file}" >&2
+      failures=1
+    fi
+  done < <(jq -r '.[] | @base64' <<<"$selected")
+  exit "$failures"
+fi
+
+echo "Selected ${selected_count} GitHub secret(s). Values will be edited with agenix."
+echo "Rules: ${rules}"
+echo
+
+jq -r '.[] | @base64' <<<"$selected" | while IFS= read -r encoded; do
+  secret_json="$(printf '%s' "$encoded" | base64 -d)"
+  rotation_group="$(jq -r '.rotationGroup' <<<"$secret_json")"
+  target="$(target_for_secret <<<"$secret_json")"
+  name="$(jq -r '.name' <<<"$secret_json")"
+  age_file="$(jq -r '.ageFile' <<<"$secret_json")"
+  relative="$(relative_age_file "$age_file")"
+  absolute="${secrets_dir}/${relative}"
+
+  echo "== ${rotation_group}: ${target}:${name}"
+  echo "age file: ${age_file}"
+
+  if [[ -s "$absolute" && "$force" != "1" ]]; then
+    echo "already exists; pass --force to replace"
+    echo
+    continue
+  fi
+
+  mkdir -p "$(dirname "$absolute")"
+
+  reply=""
+  if [[ -t 0 ]]; then
+    read -r -p "Press Enter to edit this value, or type 'skip': " reply
+  fi
+  if [[ "$reply" == "skip" ]]; then
+    echo "skipped"
+    echo
+    continue
+  fi
+
+  args=(-e "$relative")
+  if [[ -n "$identity" ]]; then
+    args+=(-i "$identity")
+  fi
+
+  (
+    cd "$secrets_dir"
+    RULES="$rules" agenix "${args[@]}"
+  )
+
+  if [[ ! -s "$absolute" ]]; then
+    echo "agenix did not create a non-empty file: ${age_file}" >&2
+    exit 1
+  fi
+
+  if ((verify_after_edit)); then
+    if agenix_decrypt_check "$relative"; then
+      echo "verified decryptability"
+    else
+      echo "decrypt check failed for ${age_file}" >&2
+      exit 1
+    fi
+  fi
+  echo
+done

--- a/terraform/github/github-secret-rotation-plan
+++ b/terraform/github/github-secret-rotation-plan
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${GOVERNANCE_ROOT_CONFIG:?set GOVERNANCE_ROOT_CONFIG to the governance root config, e.g. github/<name>-governance-prod}"
+
+root="${GOVERNANCE_REPO_ROOT:-$PWD}"
+manifest="${root}/bootstrap/${GOVERNANCE_ROOT_CONFIG}/secrets/manifest.nix"
+
+json="$(nix eval --json --file "$manifest")"
+
+jq -r '
+  def line($s): $s;
+
+  line("# GitHub Secret Rotation Plan"),
+  line(""),
+  line("- Owner: " + .owner),
+  line("- Source inventory: " + .sourceInventory.runId),
+  line("- Rotation mode: " + .policy.rotationMode),
+  line("- Secret count: " + (.secrets | length | tostring)),
+  line(""),
+  (
+    .secrets
+    | group_by(.rotationGroup)
+    | map({group: .[0].rotationGroup, secrets: .})
+    | sort_by(.group)
+    | .[]
+    | line("## " + .group),
+      line(""),
+      line("| scope | target | name | age file |"),
+      line("| --- | --- | --- | --- |"),
+      (
+        .secrets[]
+        | . as $secret
+        | (
+            if $secret.scope == "organization" then "org"
+            elif $secret.environment then ($secret.repository + "/" + $secret.environment)
+            else $secret.repository
+            end
+          ) as $target
+        | line("| " + $secret.scope + " | " + $target + " | " + $secret.name + " | `" + $secret.ageFile + "` |")
+      ),
+      line("")
+  )
+' <<<"$json"


### PR DESCRIPTION
Completes the import-phase tooling by extracting agent-harbor's GitHub **secret** backup/render/rotate machinery (M3/M4) into company-agnostic shared scripts — the piece deferred from #549 because the renderer embedded an org-specific credential-set shortcut. Now metacraft/blocksense can adopt *secrets*, not just non-secret governance.

**Scripts** (`terraform/github/`), all parameterized by `GOVERNANCE_ROOT_CONFIG` + `GOVERNANCE_REPO_ROOT`, zero residual `agent-harbor` literals, syntax-checked, smoke-tested against a fixture manifest:
- `github-governance-secrets-render` — renders GitHub-encrypted (sealed-box) payloads from agenix `.age` sources into `secrets/{payloads,managed}.generated.nix`. **The `--set` selector is now data-driven** — it matches the manifest secret's `sets` field instead of the hardcoded `cloudflare-release-r2` jq case. (Verified: `--set release-r2` selects only the secret tagged with it.)
- `github-secret-rotation-intake`, `github-secret-rotation-plan`, `github-secret-consumer-matrix` — parameterized path coupling.
- `github-secret-rotate` — **rewritten as a data-driven dispatcher**: reads the matched secret's `rotationHandler` from the manifest and execs the per-repo handler under `$GOVERNANCE_SECRET_HANDLERS_DIR`; the org-specific issuer handlers (e.g. the R2 rotator) stay per-repo.
- `github-governance-token` — moved as-is (already org-agnostic).

Follow-ups: wire the consumer Justfile targets, and (for agent-harbor) add `sets`/`rotationHandler` to its manifest + repoint at the shared copies. README documents the tools + the M3/M4 flow.