### PR TITLE
feat(terraform/github): import blocks for teams and team memberships

### DIFF
--- a/terraform/github/github-governance-import-blocks
+++ b/terraform/github/github-governance-import-blocks
@@ -26,6 +26,8 @@ SCOPES = {
     "all",
     "organization",
     "memberships",
+    "teams",
+    "team-memberships",
     "repositories",
     "branch-defaults",
     "collaborators",
@@ -170,6 +172,28 @@ def generate_blocks(governance: dict, scope: str, owner: str, root_config: str) 
                     "github_repository_collaborator."
                     f"{resource_key(f'repo-collaborator:{repository}:{username}')}",
                     f"{repository}:{username}",
+                )
+            )
+
+    if include_scope(scope, "teams"):
+        for team in governance.get("teams", []):
+            slug = team["slug"]
+            blocks.append(
+                import_block(
+                    f"github_team.{resource_key(f'team:{slug}')}",
+                    slug,
+                )
+            )
+
+    if include_scope(scope, "team-memberships"):
+        for m in governance.get("teamMemberships", []):
+            team_slug = m["teamSlug"]
+            username = m["username"]
+            blocks.append(
+                import_block(
+                    "github_team_membership."
+                    f"{resource_key(f'team-membership:{team_slug}:{username}')}",
+                    f"{team_slug}:{username}",
                 )
             )
 


### PR DESCRIPTION
Adds `teams` and `team-memberships` scopes to the import-block generator, matching the engine's new `github_team` / `github_team_membership` resources (slug-based import ids). Backward-compatible (`.get` default `[]`). Verified against the blocksense model — total import blocks 909 → 1192 (adds 256 collaborators + 10 teams + 17 memberships).