### PR TITLE
fix(terraform/github): use github_organization_custom_role (valid in provider 6.x)

### DIFF
--- a/terraform/github/governance.nix
+++ b/terraform/github/governance.nix
@@ -428,7 +428,7 @@ let
       github_actions_runner_group = runnerGroupResources;
     }
     // optionalAttrs (customRoleResources != { }) {
-      github_organization_custom_repository_role = customRoleResources;
+      github_organization_custom_role = customRoleResources;
     }
     // optionalAttrs (branchProtectionResources != { }) {
       github_branch_protection = branchProtectionResources;


### PR DESCRIPTION
`github_organization_custom_repository_role` (from #556) is not a resource type in the pinned `integrations/github ~> 6.0` provider — `tofu plan` fails with **Invalid resource type**. Reverts to the valid `github_organization_custom_role` (emits a harmless deprecation warning but plans/applies). Verified: blocksense full-model mock test passes; agent-harbor byte-identical.