### PR TITLE
garm-provider-vmharness: sweep leaked ephemeral resources after delete

### DIFF
--- a/packages/garm-provider-vmharness/src/internal/backend/vmharness.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/vmharness.go
@@ -356,6 +356,69 @@ func (b *VMHarnessRunBackend) cleanupTartEphemerals(ctx context.Context, prefix 
 	}
 }
 
+// pruneStem is the shared ephemeral-name prefix vm-harness stamps onto every
+// instance this backend starts. Per-instance Create prefixes extend it with
+// the runner name, so the stem matches all of a backend's ephemerals at once.
+// Empty means the backend has no vm-harness-managed ephemerals to reclaim.
+func (b *VMHarnessRunBackend) pruneStem() string {
+	switch b.BackendID {
+	case "tart-macos":
+		return "repro-vm-tart-macos"
+	case "tart-linux-arm":
+		return "repro-vm-tart-linux"
+	case "qemu-windows-arm":
+		// qemu-windows-arm Create passes no --ephemeral-prefix, so vm-harness
+		// uses its DefaultQemuWindowsArmPrefix for every instance.
+		return "repro-vm-qemu-windows-arm"
+	default:
+		return ""
+	}
+}
+
+func (b *VMHarnessRunBackend) pruneBackendArg() string {
+	switch b.BackendID {
+	case "tart-macos", "tart-linux-arm":
+		return "tart"
+	case "qemu-windows-arm":
+		return "qemu-windows-arm"
+	default:
+		return "all"
+	}
+}
+
+// Sweep reclaims ephemeral resources leaked by vm-harness launchers that were
+// hard-killed (host crash, OOM, service restart) before their own teardown —
+// and before Delete — could run: orphaned qemu overlay directories, stranded
+// Tart clones, and stale SSH-password/scratch files in the temp dir. It shells
+// `vm-harness prune`, scoped to this backend's shared ephemeral prefix so it
+// never touches another project's resources, and is safe to call at any time:
+// vm-harness refuses to remove any instance whose owner is still alive (advisory
+// lock held, or creator PID live). Best-effort — failures are swallowed.
+func (b *VMHarnessRunBackend) Sweep(ctx context.Context) {
+	stem := b.pruneStem()
+	if stem == "" {
+		return
+	}
+	argv := []string{
+		"prune",
+		"--ephemeral-prefix", stem,
+		"--backend", b.pruneBackendArg(),
+		"--sweep-tmp",
+		"--log-format", "json",
+	}
+	// qemu-windows-arm keeps its overlay instances under vm-harness' own state
+	// dir. Point prune at the same one the run path uses when it is overridden;
+	// otherwise both default off the shared HOME and agree implicitly.
+	if b.BackendID == "qemu-windows-arm" {
+		if sd := os.Getenv("VM_HARNESS_QEMU_WINDOWS_ARM_STATE_DIR"); sd != "" {
+			argv = append(argv, "--state-dir", sd)
+		}
+	}
+	cmd := exec.CommandContext(ctx, b.VMHarnessPath, argv...)
+	cmd.Env = vmHarnessChildEnv(b.BackendID)
+	_ = cmd.Run()
+}
+
 func (b *VMHarnessRunBackend) Get(ctx context.Context, idOrName string) (Instance, error) {
 	st, err := b.load(idOrName)
 	if err != nil {

--- a/packages/garm-provider-vmharness/src/internal/backend/vmharness_test.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/vmharness_test.go
@@ -419,3 +419,85 @@ func TestVMHarnessRunBackendDoneMarkerOverridesLivePID(t *testing.T) {
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
+
+// TestVMHarnessRunBackendSweepInvokesPrune asserts that Sweep shells
+// `vm-harness prune` scoped to the backend's shared ephemeral prefix, so a
+// hard-killed launcher's leaked orphans get reclaimed without ever touching a
+// live instance or another project's resources.
+func TestVMHarnessRunBackendSweepInvokesPrune(t *testing.T) {
+	cases := []struct {
+		backendID   string
+		wantStem    string
+		wantBackend string
+	}{
+		{"tart-macos", "repro-vm-tart-macos", "tart"},
+		{"tart-linux-arm", "repro-vm-tart-linux", "tart"},
+		{"qemu-windows-arm", "repro-vm-qemu-windows-arm", "qemu-windows-arm"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.backendID, func(t *testing.T) {
+			tmp := t.TempDir()
+			logPath := filepath.Join(tmp, "argv.log")
+			mock := filepath.Join(tmp, "vm-harness")
+			script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " +
+				shellSingleQuote(logPath) + "\n"
+			if err := os.WriteFile(mock, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			b := &VMHarnessRunBackend{
+				VMHarnessPath: mock,
+				BackendID:     tc.backendID,
+				StateDir:      filepath.Join(tmp, "state"),
+			}
+			b.Sweep(context.Background())
+
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("mock vm-harness was not invoked: %v", err)
+			}
+			argv := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+			if len(argv) == 0 || argv[0] != "prune" {
+				t.Fatalf("expected first arg 'prune', got %v", argv)
+			}
+			assertFlag := func(flag, want string) {
+				for i, a := range argv {
+					if a == flag {
+						if i+1 < len(argv) && argv[i+1] == want {
+							return
+						}
+						t.Fatalf("%s: expected %s %q, got %v", tc.backendID, flag, want, argv)
+					}
+				}
+				t.Fatalf("%s: missing flag %s in %v", tc.backendID, flag, argv)
+			}
+			assertFlag("--ephemeral-prefix", tc.wantStem)
+			assertFlag("--backend", tc.wantBackend)
+			hasSweepTmp := false
+			for _, a := range argv {
+				if a == "--sweep-tmp" {
+					hasSweepTmp = true
+				}
+			}
+			if !hasSweepTmp {
+				t.Fatalf("%s: expected --sweep-tmp in %v", tc.backendID, argv)
+			}
+		})
+	}
+}
+
+// TestVMHarnessRunBackendSweepNoopForNonEphemeralBackend ensures Sweep does
+// nothing (and never shells out) for a backend with no vm-harness ephemerals.
+func TestVMHarnessRunBackendSweepNoopForNonEphemeralBackend(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "argv.log")
+	mock := filepath.Join(tmp, "vm-harness")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + shellSingleQuote(logPath) + "\n"
+	if err := os.WriteFile(mock, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b := &VMHarnessRunBackend{VMHarnessPath: mock, BackendID: "libvirt"}
+	b.Sweep(context.Background())
+	if _, err := os.Stat(logPath); err == nil {
+		t.Fatal("Sweep unexpectedly invoked vm-harness for a non-ephemeral backend")
+	}
+}

--- a/packages/garm-provider-vmharness/src/internal/provider/provider.go
+++ b/packages/garm-provider-vmharness/src/internal/provider/provider.go
@@ -928,6 +928,15 @@ func (p *Provider) CreateInstance(ctx context.Context, bootstrapParams commonPar
 // DeleteInstance destroys + undefines the domain. Idempotent: returns
 // garmErrors.ErrNotFound (=> exit 30) only when the harness should signal
 // not-found; a genuinely-absent domain is treated as success.
+// sweeper is implemented by backends that can reclaim ephemeral resources
+// leaked by hard-killed launchers (see VMHarnessRunBackend.Sweep). Delete is
+// per-instance and self-cleaning; the sweep opportunistically mops up orphans
+// from prior runs that crashed before their own Delete could fire, so leaks do
+// not accumulate across the fleet without needing a separate daemon.
+type sweeper interface {
+	Sweep(ctx context.Context)
+}
+
 func (p *Provider) DeleteInstance(ctx context.Context, instance string) error {
 	if err := p.backend.Delete(ctx, instance); err != nil {
 		if errors.Is(err, garmErrors.ErrNotFound) {
@@ -935,6 +944,11 @@ func (p *Provider) DeleteInstance(ctx context.Context, instance string) error {
 			return nil
 		}
 		return err
+	}
+	// After a successful delete, opportunistically reclaim any leaked orphans
+	// from previously crashed runs. Best-effort; never affects the delete result.
+	if s, ok := p.backend.(sweeper); ok {
+		s.Sweep(ctx)
 	}
 	return nil
 }


### PR DESCRIPTION
## Why
When a vm-harness launcher is hard-killed before its teardown — and before the provider's `Delete` — runs, it leaks orphans: qemu overlay dirs, stranded Tart clones (each instance uses a unique prefix, so a later run never reaps them), and stale SSH-password files in `/tmp`.

## What
`DeleteInstance` now opportunistically calls `vm-harness prune` after a successful delete (`VMHarnessRunBackend.Sweep`), scoped to the backend's shared ephemeral-prefix stem (`repro-vm-tart-macos` / `-linux` / `repro-vm-qemu-windows-arm`) with `--sweep-tmp`. Delete stays per-instance and self-cleaning; the sweep mops up orphans from prior crashed runs so leaks don't accumulate across the fleet without a separate daemon.

- `prune` is lock-guarded in vm-harness → never removes a live instance.
- Best-effort: sweep failures never affect the delete result.
- No-op for backends without vm-harness ephemerals (libvirt/incus).

Requires the `prune` subcommand from `metacraft-labs/vm-harness#13`.

## Tests
New `TestVMHarnessRunBackendSweepInvokesPrune` (asserts the prune argv/scope per backend via a fake vm-harness) and `...SweepNoopForNonEphemeralBackend`. Full `internal/backend` + `internal/provider` packages still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)