### PR TITLE
feat(tf-bootstrap): optional cost-allocation management for member-account bootstraps

### DIFF
--- a/checks/repro-lease-reaper-eval.nix
+++ b/checks/repro-lease-reaper-eval.nix
@@ -56,8 +56,7 @@ top@{ inputs, ... }:
       # so the assertions below are transport-agnostic.
       toExecStr = v: if builtins.isList v then lib.concatStringsSep " " (map toString v) else toString v;
 
-      systemReaperExec = toExecStr
-        nixosEval.config.systemd.services.repro-lease-reaper.serviceConfig.ExecStart;
+      systemReaperExec = toExecStr nixosEval.config.systemd.services.repro-lease-reaper.serviceConfig.ExecStart;
 
       # ---- Evaluate the home-manager class (user daemon). home-manager is a
       # flake input; its `lib.homeManagerConfiguration` renders a standalone HM
@@ -66,25 +65,26 @@ top@{ inputs, ... }:
       hmLib = (inputs.home-manager or { }).lib or null;
       userDaemonExec =
         if hmLib != null && hmLib ? homeManagerConfiguration then
-          toExecStr (hmLib.homeManagerConfiguration {
-            inherit pkgs;
-            modules = [
-              flake.modules.homeManager.mcl-reprobuild
-              (
-                { ... }:
-                {
-                  home.username = "reprotest";
-                  home.homeDirectory = "/home/reprotest";
-                  home.stateVersion = "24.05";
-                  programs.reprobuild = {
-                    enable = true;
-                    package = reproPkg;
-                    enableUserDaemon = true;
-                  };
-                }
-              )
-            ];
-          }).config.systemd.user.services.repro-daemon.Service.ExecStart
+          toExecStr
+            (hmLib.homeManagerConfiguration {
+              inherit pkgs;
+              modules = [
+                flake.modules.homeManager.mcl-reprobuild
+                (
+                  { ... }:
+                  {
+                    home.username = "reprotest";
+                    home.homeDirectory = "/home/reprotest";
+                    home.stateVersion = "24.05";
+                    programs.reprobuild = {
+                      enable = true;
+                      package = reproPkg;
+                      enableUserDaemon = true;
+                    };
+                  }
+                )
+              ];
+            }).config.systemd.user.services.repro-daemon.Service.ExecStart
         else
           "";
     in

--- a/terraform/aws/tf-bootstrap.nix
+++ b/terraform/aws/tf-bootstrap.nix
@@ -9,6 +9,10 @@
   lockTableName,
   namePrefix,
   orgLabel,
+  # Cost-allocation tags and Cost Categories can only be managed from the AWS
+  # Organizations management/payer account. Set false for member-account
+  # bootstraps (e.g. a dedicated per-org prod account) to skip them.
+  manageCostAllocation ? true,
   ...
 }:
 let
@@ -413,19 +417,25 @@ in
         }
       ];
     };
+  }
+  // (
+    if manageCostAllocation then
+      {
+        aws_ce_cost_allocation_tag = builtins.mapAttrs (_name: tagKey: {
+          tag_key = tagKey;
+          status = "Active";
+        }) costAllocationTags;
 
-    aws_ce_cost_allocation_tag = builtins.mapAttrs (_name: tagKey: {
-      tag_key = tagKey;
-      status = "Active";
-    }) costAllocationTags;
-
-    aws_ce_cost_category = {
-      agent_harbor_cost_layer = mkInheritedCostCategory "${orgLabel}CostLayer" "CostLayer";
-      agent_harbor_workload = mkInheritedCostCategory "${orgLabel}Workload" "Workload";
-      agent_harbor_platform_layer = mkInheritedCostCategory "${orgLabel}PlatformLayer" "PlatformLayer";
-      agent_harbor_component = mkInheritedCostCategory "${orgLabel}Component" "Component";
-    };
-  };
+        aws_ce_cost_category = {
+          agent_harbor_cost_layer = mkInheritedCostCategory "${orgLabel}CostLayer" "CostLayer";
+          agent_harbor_workload = mkInheritedCostCategory "${orgLabel}Workload" "Workload";
+          agent_harbor_platform_layer = mkInheritedCostCategory "${orgLabel}PlatformLayer" "PlatformLayer";
+          agent_harbor_component = mkInheritedCostCategory "${orgLabel}Component" "Component";
+        };
+      }
+    else
+      { }
+  );
 
   data.aws_iam_policy_document = {
     state_bucket_tls.statement = [
@@ -656,17 +666,21 @@ in
     };
 
     cost_allocation_tag_keys = {
-      value = costAllocationTags;
+      value = if manageCostAllocation then costAllocationTags else { };
       description = "User-defined AWS cost allocation tag keys activated by the bootstrap root.";
     };
 
     cost_category_names = {
-      value = [
-        "\${aws_ce_cost_category.agent_harbor_cost_layer.name}"
-        "\${aws_ce_cost_category.agent_harbor_workload.name}"
-        "\${aws_ce_cost_category.agent_harbor_platform_layer.name}"
-        "\${aws_ce_cost_category.agent_harbor_component.name}"
-      ];
+      value =
+        if manageCostAllocation then
+          [
+            "\${aws_ce_cost_category.agent_harbor_cost_layer.name}"
+            "\${aws_ce_cost_category.agent_harbor_workload.name}"
+            "\${aws_ce_cost_category.agent_harbor_platform_layer.name}"
+            "\${aws_ce_cost_category.agent_harbor_component.name}"
+          ]
+        else
+          [ ];
       description = "AWS Cost Categories managed by the bootstrap root for Agent Harbor cost reporting.";
     };
 


### PR DESCRIPTION
## Problem
Cost Explorer **cost-allocation tags** and **cost categories** can only be managed from the AWS Organizations **management/payer** account. A dedicated per-org **member (linked)** account bootstrap — e.g. `metacraft-prod` — fails apply with:

> `AccessDeniedException: Failed to update Cost Allocation Tag: Linked account doesn't have access to cost allocation tags.`

for all 13 `aws_ce_cost_allocation_tag` / `aws_ce_cost_category` resources.

## Change
Add a `manageCostAllocation` flag (default `true`). When `false`, the bootstrap skips the `aws_ce_*` resources and empties the `cost_allocation_tag_keys` / `cost_category_names` outputs — everything else (S3 state bucket, DynamoDB lock, GitHub OIDC provider, plan/apply/drift/break-glass roles, budget) is unchanged.

## Verified
- `manageCostAllocation = true` renders **byte-identical** to the previous module (`nix eval --json | jq -S` diff empty) — existing agent-harbor / blocksense management-account bootstraps are unaffected.
- `manageCostAllocation = false` drops all `aws_ce_*` resources and empties the two cost outputs; bucket/lock/roles/budget remain.