### PR TITLE
fix(nix-cache): harden transfer and publication retries

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -199,6 +199,13 @@ runs:
           fallback = true
           download-attempts = 2
           connect-timeout = 5
+          # Persistent self-hosted runners have observed a group of multiplexed
+          # cache.nixos.org NAR transfers make no progress until the job ceiling.
+          # Bound silent transfers and prefer a smaller HTTP/1.1 pool so Nix can
+          # retry an individual object instead of wedging the whole substitution.
+          stalled-download-timeout = 30
+          http2 = false
+          http-connections = 8
           narinfo-cache-negative-ttl = 120
           allow-import-from-derivation = true
           experimental-features = nix-command flakes pipe-operators

--- a/checks/consumer-flake-attic.nix
+++ b/checks/consumer-flake-attic.nix
@@ -198,6 +198,9 @@
                   "nix build",
                   "--print-out-paths",
                   "attic push",
+                  "push_with_retry",
+                  "push-attempts",
+                  "push-retry-delay-seconds",
                   "missing required input",
               ]
               for needle in required:
@@ -227,6 +230,7 @@
                   fake_bin = temp_path / "bin"
                   fake_bin.mkdir()
                   fake_attic_log = temp_path / "attic.log"
+                  fake_attic_counter = temp_path / "attic-counter"
                   fake_nix_log = temp_path / "nix.log"
 
                   (fake_bin / "attic").write_text("""#!${pkgs.bash}/bin/bash
@@ -235,8 +239,16 @@
               if [ "''${FAKE_ATTIC_FAIL_PATH:-}" != "" ] && [ "$1" = "push" ]; then
                 last="''${!#}"
                 if [ "$last" = "$FAKE_ATTIC_FAIL_PATH" ]; then
-                  echo "fake attic push failed for $last" >&2
-                  exit 23
+                  count=0
+                  if [ -s "$FAKE_ATTIC_COUNTER" ]; then
+                    count=$(cat "$FAKE_ATTIC_COUNTER")
+                  fi
+                  if [ "$count" -lt "''${FAKE_ATTIC_FAIL_COUNT:-999}" ]; then
+                    count=$((count + 1))
+                    printf '%s\\n' "$count" > "$FAKE_ATTIC_COUNTER"
+                    echo "fake attic push failed for $last" >&2
+                    exit 23
+                  fi
                 fi
               fi
               """)
@@ -273,6 +285,7 @@
                   base_env.update({
                       "PATH": f"{fake_bin}:{base_env['PATH']}",
                       "FAKE_ATTIC_LOG": str(fake_attic_log),
+                      "FAKE_ATTIC_COUNTER": str(fake_attic_counter),
                       "FAKE_NIX_LOG": str(fake_nix_log),
                       "INPUT_ENDPOINT": "https://cache.metacraft-labs.test",
                       "INPUT_CACHE": "metacraft-private-infrastructure",
@@ -281,6 +294,8 @@
                       "INPUT_ATTRIBUTES": "packages.x86_64-linux.foo, checks.x86_64-linux.bar\ngithub:metacraft/example#prebuilt packages.x86_64-linux.foo",
                       "INPUT_EXTRA_NIX_ARGS": "",
                       "INPUT_EXTRA_ATTIC_PUSH_ARGS": "--jobs 2",
+                      "INPUT_PUSH_ATTEMPTS": "3",
+                      "INPUT_PUSH_RETRY_DELAY_SECONDS": "0",
                       "ATTIC_TOKEN": "test-token",
                   })
 
@@ -295,6 +310,17 @@
                   )
                   assert result.returncode == 64, result
                   assert "missing required input(s): token or ATTIC_TOKEN" in result.stderr, result.stderr
+
+                  invalid_attempts_env = base_env.copy()
+                  invalid_attempts_env["INPUT_PUSH_ATTEMPTS"] = "0"
+                  result = subprocess.run(
+                      ["${pkgs.bash}/bin/bash", str(script_paths[0])],
+                      env=invalid_attempts_env,
+                      text=True,
+                      capture_output=True,
+                  )
+                  assert result.returncode == 64, result
+                  assert "push-attempts must be a positive integer" in result.stderr, result.stderr
 
                   subprocess.run(["${pkgs.bash}/bin/bash", str(script_paths[0])], env=base_env, check=True)
                   subprocess.run(["${pkgs.bash}/bin/bash", str(script_paths[1])], env=base_env, check=True)
@@ -317,6 +343,24 @@
                       assert f"--print-out-paths {attr}" in nix_log.replace("\n", " "), nix_log
 
                   fake_attic_log.write_text("")
+                  fake_attic_counter.write_text("")
+                  fake_nix_log.write_text("")
+                  transient_env = base_env.copy()
+                  transient_env["INPUT_ATTRIBUTES"] = "packages.x86_64-linux.foo"
+                  transient_env["FAKE_ATTIC_FAIL_PATH"] = "/nix/store/foo-two"
+                  transient_env["FAKE_ATTIC_FAIL_COUNT"] = "2"
+                  subprocess.run(
+                      ["${pkgs.bash}/bin/bash", str(script_paths[1])],
+                      env=transient_env,
+                      check=True,
+                  )
+                  transient_log = fake_attic_log.read_text().splitlines()
+                  assert transient_log.count(
+                      "push --jobs 2 metacraft-private-infrastructure /nix/store/foo-two"
+                  ) == 3, transient_log
+
+                  fake_attic_log.write_text("")
+                  fake_attic_counter.write_text("")
                   fake_nix_log.write_text("")
                   fail_env = base_env.copy()
                   fail_env["INPUT_ATTRIBUTES"] = "packages.x86_64-linux.foo"
@@ -329,6 +373,11 @@
                   )
                   assert result.returncode == 23, result
                   assert "fake attic push failed for /nix/store/foo-two" in result.stderr, result.stderr
+                  fail_log = fake_attic_log.read_text().splitlines()
+                  assert fail_log.count(
+                      "push --jobs 2 metacraft-private-infrastructure /nix/store/foo-two"
+                  ) == 3, fail_log
+                  assert "after 3 attempts" in result.stdout, result.stdout
               PY
 
               touch "$out"

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -29,5 +29,6 @@
     ./packages-ci-matrix.nix
     ./pre-commit.nix
     ./secret-integration
+    ./setup-nix-transfer-resilience.nix
   ];
 }

--- a/checks/setup-nix-transfer-resilience.nix
+++ b/checks/setup-nix-transfer-resilience.nix
@@ -1,0 +1,26 @@
+{ ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks.setup-nix-transfer-resilience =
+        pkgs.runCommand "setup-nix-transfer-resilience"
+          {
+            nativeBuildInputs = [ pkgs.python3 ];
+          }
+          ''
+            python3 - <<'PY'
+            from pathlib import Path
+
+            action = Path("${../.github/setup-nix/action.yml}").read_text()
+
+            assert "stalled-download-timeout = 30" in action
+            assert "http2 = false" in action
+            assert "http-connections = 8" in action
+            assert action.index("connect-timeout = 5") < action.index("stalled-download-timeout = 30")
+            assert action.index("stalled-download-timeout = 30") < action.index("substituters = ")
+            PY
+            touch "$out"
+          '';
+    };
+}

--- a/modules/attic-push-flake-outputs/action.yml
+++ b/modules/attic-push-flake-outputs/action.yml
@@ -27,6 +27,14 @@ inputs:
     description: Extra arguments appended to attic push.
     required: false
     default: ''
+  push-attempts:
+    description: Maximum attempts for each Attic output push.
+    required: false
+    default: '3'
+  push-retry-delay-seconds:
+    description: Base delay in seconds between Attic push attempts. The delay is multiplied by the failed attempt number.
+    required: false
+    default: '5'
 
 runs:
   using: composite
@@ -38,6 +46,8 @@ runs:
         INPUT_CACHE: ${{ inputs.cache }}
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_ATTRIBUTES: ${{ inputs.attributes }}
+        INPUT_PUSH_ATTEMPTS: ${{ inputs.push-attempts }}
+        INPUT_PUSH_RETRY_DELAY_SECONDS: ${{ inputs.push-retry-delay-seconds }}
       run: |
         set -euo pipefail
 
@@ -62,6 +72,24 @@ runs:
           exit 127
         }
 
+        case "$INPUT_PUSH_ATTEMPTS" in
+          '' | *[!0-9]*)
+            echo "attic-push-flake-outputs: push-attempts must be a positive integer" >&2
+            exit 64
+            ;;
+        esac
+        if [ "$INPUT_PUSH_ATTEMPTS" -lt 1 ]; then
+          echo "attic-push-flake-outputs: push-attempts must be a positive integer" >&2
+          exit 64
+        fi
+
+        case "$INPUT_PUSH_RETRY_DELAY_SECONDS" in
+          '' | *[!0-9]*)
+            echo "attic-push-flake-outputs: push-retry-delay-seconds must be a non-negative integer" >&2
+            exit 64
+            ;;
+        esac
+
     - name: Push flake outputs to Attic
       shell: bash
       env:
@@ -72,6 +100,8 @@ runs:
         INPUT_ATTRIBUTES: ${{ inputs.attributes }}
         INPUT_EXTRA_NIX_ARGS: ${{ inputs.extra-nix-args }}
         INPUT_EXTRA_ATTIC_PUSH_ARGS: ${{ inputs.extra-attic-push-args }}
+        INPUT_PUSH_ATTEMPTS: ${{ inputs.push-attempts }}
+        INPUT_PUSH_RETRY_DELAY_SECONDS: ${{ inputs.push-retry-delay-seconds }}
       run: |
         set -euo pipefail
 
@@ -90,6 +120,35 @@ runs:
         fi
 
         attic login --set-default attic-push-flake-outputs "$INPUT_ENDPOINT" "$token"
+
+        push_with_retry() {
+          local output_path="$1"
+          local attempt=1
+          local status
+          local delay
+
+          while true; do
+            set +e
+            attic push ${INPUT_EXTRA_ATTIC_PUSH_ARGS} "$INPUT_CACHE" "$output_path"
+            status=$?
+            set -e
+
+            if [ "$status" -eq 0 ]; then
+              return 0
+            fi
+            if [ "$attempt" -ge "$INPUT_PUSH_ATTEMPTS" ]; then
+              echo "::error::Attic push failed for ${output_path} after ${attempt} attempts"
+              return "$status"
+            fi
+
+            delay=$((10#$INPUT_PUSH_RETRY_DELAY_SECONDS * attempt))
+            echo "::warning::Attic push failed for ${output_path} (attempt ${attempt}/${INPUT_PUSH_ATTEMPTS}); retrying in ${delay}s"
+            if [ "$delay" -gt 0 ]; then
+              sleep "$delay"
+            fi
+            attempt=$((attempt + 1))
+          done
+        }
 
         while IFS= read -r attr; do
           case "$attr" in
@@ -118,7 +177,7 @@ runs:
           echo "::group::Push ${flake_attr} outputs to ${INPUT_CACHE}"
           while IFS= read -r output_path; do
             [ -n "$output_path" ] || continue
-            attic push ${INPUT_EXTRA_ATTIC_PUSH_ARGS} "$INPUT_CACHE" "$output_path"
+            push_with_retry "$output_path"
           done < "$workdir/outputs"
           echo "::endgroup::"
         done < "$workdir/attributes"


### PR DESCRIPTION
## What changed

- disable Nix HTTP/2 multiplexing in the shared setup-nix action
- reduce the substitution pool from the Nix default to eight HTTP connections
- bound no-progress downloads at 30 seconds so Nix can retry individual NARs
- add bounded, linearly backed-off retry to the shared Attic flake-output publication action
- validate retry inputs and executable-test transient success plus exhausted failure behavior
- add flake checks that preserve both transfer-resilience contracts

## Why

Production-readiness runs exposed both sides of the shared cache boundary. A persistent aarch64-darwin runner previously wedged indefinitely while substituting a multiplexed NAR group. After Agent Harbor adopted the shared blocking Attic publication action, the cache accepted most of an ah-agents closure but returned HTTP 504 for three large paths. Runner cleanup cannot be allowed to truncate publication, and a single transient reverse-proxy timeout must not invalidate an otherwise successful build.

This is reusable Nix workflow behavior for Agent Harbor, metacraft, and blocksense consumers, so it remains centralized in nixos-modules.

## Impact

Consumers retain the same substituters, trusted keys, retry count, and fallback behavior for Nix downloads. Cache downloads use fewer concurrent HTTP/1.1 connections and retry after 30 seconds without progress. Explicit Attic output pushes now make up to three attempts per realized output with five-second linear backoff by default; both settings are configurable. Permanent failures still return the original failing status after exhaustion.

## Validation

- nix build --no-link .#checks.x86_64-linux.setup-nix-transfer-resilience -L
- nix build --no-link .#checks.x86_64-linux.attic-push-flake-outputs-action -L
- nixfmt --check checks/consumer-flake-attic.nix checks/setup-nix-transfer-resilience.nix
- prettier --check .github/setup-nix/action.yml modules/attic-push-flake-outputs/action.yml
- pre-commit hooks passed on commit 42c917273bab2b22ffcee3940f23d59dd1a9677f
- git diff --check