### PR TITLE
feat(secret-intake): auto-suggest a Downloads file for a secret value

### DIFF
--- a/terraform/github/github-secret-rotation-intake
+++ b/terraform/github/github-secret-rotation-intake
@@ -234,6 +234,17 @@ if ((verify_only)); then
   exit "$failures"
 fi
 
+downloads_dir="${SECRET_INTAKE_DOWNLOADS_DIR:-${HOME}/Downloads}"
+downloads_glob="${SECRET_INTAKE_DOWNLOADS_GLOB:-*.pem}"
+
+newest_download() {
+  # Newest file in downloads_dir matching downloads_glob (e.g. a freshly
+  # downloaded GitHub App *.pem key), or empty if none / dir missing.
+  [[ -d "$downloads_dir" ]] || return 0
+  find "$downloads_dir" -maxdepth 1 -type f -name "$downloads_glob" -print0 2>/dev/null \
+    | xargs -0 ls -t 2>/dev/null | head -n 1
+}
+
 echo "Selected ${selected_count} GitHub secret(s). Values will be edited with agenix."
 echo "Rules: ${rules}"
 echo
@@ -258,14 +269,35 @@ jq -r '.[] | @base64' <<<"$selected" | while IFS= read -r encoded; do
 
   mkdir -p "$(dirname "$absolute")"
 
+  use_file=""
   reply=""
-  if [[ -t 0 ]]; then
-    read -r -p "Press Enter to edit this value, or type 'skip': " reply
+  candidate=""
+  if [[ -e /dev/tty ]]; then
+    candidate="$(newest_download)"
   fi
-  if [[ "$reply" == "skip" ]]; then
-    echo "skipped"
-    echo
-    continue
+  if [[ -n "$candidate" ]]; then
+    mtime="$(stat -c '%y' "$candidate" 2>/dev/null || stat -f '%Sm' "$candidate" 2>/dev/null || echo '?')"
+    printf 'Found in %s: %s (modified %s)\n' "$downloads_dir" "$(basename "$candidate")" "$mtime"
+    read -r -p "Use this file as the value? [y = use file / Enter = edit manually / skip]: " reply </dev/tty
+    case "$reply" in
+    skip)
+      echo "skipped"
+      echo
+      continue
+      ;;
+    y | Y)
+      use_file="$candidate"
+      ;;
+    esac
+  else
+    if [[ -t 0 ]]; then
+      read -r -p "Press Enter to edit this value, or type 'skip': " reply
+    fi
+    if [[ "$reply" == "skip" ]]; then
+      echo "skipped"
+      echo
+      continue
+    fi
   fi
 
   args=(-e "$relative")
@@ -273,10 +305,21 @@ jq -r '.[] | @base64' <<<"$selected" | while IFS= read -r encoded; do
     args+=(-i "$identity")
   fi
 
-  (
-    cd "$secrets_dir"
-    RULES="$rules" agenix "${args[@]}"
-  )
+  if [[ -n "$use_file" ]]; then
+    fill_editor="$(mktemp)"
+    printf '#!/usr/bin/env bash\ncp -- "$INTAKE_FILL_SOURCE" "$1"\n' >"$fill_editor"
+    chmod +x "$fill_editor"
+    (
+      cd "$secrets_dir"
+      RULES="$rules" EDITOR="$fill_editor" INTAKE_FILL_SOURCE="$use_file" agenix "${args[@]}"
+    )
+    rm -f "$fill_editor"
+  else
+    (
+      cd "$secrets_dir"
+      RULES="$rules" agenix "${args[@]}"
+    )
+  fi
 
   if [[ ! -s "$absolute" ]]; then
     echo "agenix did not create a non-empty file: ${age_file}" >&2
@@ -289,6 +332,18 @@ jq -r '.[] | @base64' <<<"$selected" | while IFS= read -r encoded; do
     else
       echo "decrypt check failed for ${age_file}" >&2
       exit 1
+    fi
+  fi
+
+  if [[ -n "$use_file" && -e /dev/tty ]]; then
+    read -r -p "Securely delete the downloaded source ${use_file}? [y/N]: " del </dev/tty
+    if [[ "$del" == "y" || "$del" == "Y" ]]; then
+      if command -v shred >/dev/null 2>&1; then
+        shred -u -- "$use_file"
+      else
+        rm -f -- "$use_file"
+      fi
+      echo "removed ${use_file}"
     fi
   fi
   echo


### PR DESCRIPTION
When entering a value interactively, `github-secret-rotation-intake` now scans your Downloads for a matching file and offers to use it directly — no manual paste. Built for **GitHub App private keys** (`*.pem`), which are painful to paste into `$EDITOR`.

- Newest file in `SECRET_INTAKE_DOWNLOADS_DIR` (default `~/Downloads`) matching `SECRET_INTAKE_DOWNLOADS_GLOB` (default `*.pem`) is suggested per secret.
- On `y`, its contents are piped straight into the `.age` file (agenix with a copy-editor); `Enter` falls back to manual `$EDITOR`; `skip` skips.
- After a successful fill, offers to `shred`/`rm` the downloaded source (private key left in Downloads = bad).
- Reads prompts from `/dev/tty` so it works inside the piped selection loop; non-interactive/no-tty behavior is unchanged.

Enables, e.g. for the governance App key:
```
just github-secret-rotation-intake --group github-governance-app
```