### PR TITLE
fix(terraform): keep drift notifications actionable

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -984,14 +984,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           PLAN_OUTPUT="$(cat /tmp/drift-plan.txt)"
-          gh issue create \
-            --title "Infrastructure drift detected in ${{ inputs.working_directory }}" \
+          issue_args=(
+            --title "Infrastructure drift detected in ${{ inputs.working_directory }}"
             --body "Scheduled drift detection found changes. Review the plan output and reconcile.
 
           \`\`\`
           $PLAN_OUTPUT
-          \`\`\`" \
-            --label "drift"
+          \`\`\`"
+          )
+
+          if gh label view drift >/dev/null 2>&1 \
+            || gh label create drift --color d73a4a --description "Automated Terraform drift detection" \
+            || gh label view drift >/dev/null 2>&1; then
+            issue_args+=(--label drift)
+          else
+            echo "::warning::Unable to create the drift label; opening the drift issue without it"
+          fi
+
+          gh issue create "${issue_args[@]}"
 
       - name: Cleanup credentials
         if: always()

--- a/checks/ci-workflows.nix
+++ b/checks/ci-workflows.nix
@@ -356,6 +356,27 @@
                 script_path = Path(temp) / "detect-drift.sh"
                 script_path.write_text(script)
                 subprocess.run(["${pkgs.bash}/bin/bash", "-n", str(script_path)], check=True)
+
+            issue_script = extract_run_script(drift_job, "Open drift issue")
+            label_view = issue_script.find("gh label view drift")
+            label_create = issue_script.find("gh label create drift")
+            issue_create = issue_script.find(
+                'gh issue create "' + "$" + '{issue_args[@]}"'
+            )
+            assert label_view != -1, "drift notification must probe for its label"
+            assert label_create != -1, "drift notification must create a missing label"
+            assert issue_create != -1, "drift notification issue creation disappeared"
+            assert label_view < label_create < issue_create, (
+                "the reusable workflow must ensure its optional label before opening the issue"
+            )
+            assert "opening the drift issue without it" in issue_script, (
+                "label failure must not suppress the drift issue"
+            )
+
+            with tempfile.TemporaryDirectory() as temp:
+                script_path = Path(temp) / "open-drift-issue.sh"
+                script_path.write_text(issue_script)
+                subprocess.run(["${pkgs.bash}/bin/bash", "-n", str(script_path)], check=True)
             PY
 
             touch "$out"


### PR DESCRIPTION
## Summary

- create the reusable Terraform workflow's `drift` label when a consumer repository does not have it yet
- tolerate label creation failure and still open the drift issue without a label
- lock the label-before-issue ordering and fallback behavior in the reusable workflow regression check

## Why

Agent Harbor infra scheduled run `30241196261` correctly detected an AWS drift plan, but its notification step failed because the consumer repository did not already contain a `drift` label. A reusable workflow should not lose the issue merely because optional classification metadata is absent.

## Impact

This changes notification behavior only. It does not change Terranix generation, OpenTofu plans, applies, credentials, or cloud resources.

## Validation

- `nix build --accept-flake-config --no-link .#checks.x86_64-linux.reusable-terraform-drift-workflow`
- `nix develop --accept-flake-config .#pre-commit -c prek run --files .github/workflows/reusable-terraform-ci.yml checks/ci-workflows.nix`
- `git diff --check`
