### PR TITLE
fix(ci): defer Nix cache key hashing

### DIFF
--- a/.github/setup-nix/action.yml
+++ b/.github/setup-nix/action.yml
@@ -58,9 +58,9 @@ inputs:
     required: false
     default: false
   nix-cache-key:
-    description: The primary key to use for the Nix GHA cache
+    description: The primary key to use for the Nix GHA cache; defaults to the current commit so disabled caching does not eagerly evaluate hashFiles()
     required: false
-    default: nix-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
+    default: nix-${{ runner.os }}-${{ github.sha }}
   nix-cache-restore-prefixes:
     description: The fallback restore prefixes for the Nix GHA cache
     required: false


### PR DESCRIPTION
## Summary

Stop the shared `setup-nix` composite action from evaluating `hashFiles()` while its optional GitHub Actions Nix-store cache is disabled.

Runner 2.336.0 still invokes its internal `hashFiles` helper through `externals/node20`, while current Nixpkgs packages only the supported Node 24 runtime. Because composite-action input defaults are evaluated eagerly, the old default prevented `setup-nix` from starting even when `use-nix-cache` was false.

## Exact expected behavior

- Change only the default `nix-cache-key` from a `hashFiles('**/flake.lock')` expression to `nix-${{ runner.os }}-${{ github.sha }}`.
- Keep caller-supplied `nix-cache-key` values unchanged.
- Keep opt-in cache restore prefixes unchanged, so a new commit can still restore the latest compatible OS cache.
- Avoid invoking the runner's internal `hashFiles` helper when callers use the default inputs and caching is disabled.
- Make no NixOS module, package, Terraform, secret, credential, host, runner, or cloud-resource change.

Current review head: `b2fae38c11dbd96e28d66862c228fa3a4c35c906`.

## Validation

- Changed-file `prek` checks pass.
- Prettier passes for `.github/setup-nix/action.yml`.
- `git diff --check` passes.
- The action contains no executable `${{ hashFiles(...) }}` input-default expression.
