### PR TITLE
mcl-s3-artifact-store: replace prior same-name keys on issue

### DIFF
--- a/modules/mcl-s3-artifact-store/default.nix
+++ b/modules/mcl-s3-artifact-store/default.nix
@@ -155,6 +155,20 @@
               owner) mcl-garage bucket allow "$bucket" --read --write --owner --key "$keyId" >&2 ;;
             esac
           done
+          # Prune older keys that share this name. Garage keys never expire, and
+          # every invocation mints a brand-new one, so without this each
+          # re-provisioning (and each boot, for the bootstrap key) would leak a
+          # permanent, still-valid credential under the same label. We delete
+          # AFTER creating + granting the new key, so the name is never left
+          # without a working credential. The just-minted keyId is preserved.
+          # ``key list`` columns vary across Garage versions, so match any line
+          # whose final field is exactly this name and pull the GK id from it.
+          mcl-garage key list 2>/dev/null \
+            | awk -v n="$name" '$NF == n { for (i = 1; i <= NF; i++) if ($i ~ /^GK[0-9a-f]+$/) print $i }' \
+            | while read -r oldKey; do
+                [[ "$oldKey" == "$keyId" ]] && continue
+                mcl-garage key delete "$oldKey" --yes >&2 || true
+              done
           jq -cn --arg k "$keyId" --arg s "$secret" '{keyId:$k, secretKey:$s}'
         '';
       };


### PR DESCRIPTION
## Why
Garage access keys **never expire** — they're valid until explicitly deleted. `mcl-garage-issue-key` mints a **new** key on every invocation, so:
- each re-provisioning of a repo (`configure-s3-artifact-store-github-repo`) left the previous, still-valid `ci-<owner>__<repo>` key behind, and
- the idempotent **boot-time bootstrap** minted a fresh `s3-artifact-store-bootstrap` key on every reboot.

Both accumulate permanent, write-scoped credentials on the `ci-artifacts` bucket. (The onboarding run across ~73 repos, re-run after a connectivity fix, already produced duplicates.)

## What
After minting **and granting** the new key, delete any other keys sharing the name — keeping only the one just created. Delete-**after**-create, so the label is never momentarily without a working credential. `key list` columns vary across Garage versions, so the prune matches any row whose final field is exactly the name and extracts the `GK…` id from it.

## Note
This only prevents *future* accumulation once high-mem-server is redeployed. The keys already accumulated need a one-off cleanup on the host (I can provide the `mcl-garage key list` + delete one-liner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)