### PR TITLE
fix(secret tooling): auto-discover SSH identity + fix intake TTY/file-fill

### DIFF
--- a/terraform/github/github-governance-secrets-render
+++ b/terraform/github/github-governance-secrets-render
@@ -293,9 +293,31 @@ if [[ ${#secret_selectors[@]} -eq 0 && ${#group_selectors[@]} -eq 0 && ${#set_se
   select_all=1
 fi
 
+discover_identity() {
+  # Print a local SSH private key whose public key is a recipient in the rules
+  # file, so decrypts work without an explicit --identity. First match wins.
+  local rules_file="$1" ssh_dir="${SSH_DIR:-$HOME/.ssh}"
+  local bodies pub body priv
+  bodies="$(grep -oE 'ssh-(rsa|ed25519|dss) [A-Za-z0-9+/=]+' "$rules_file" 2>/dev/null | awk '{ print $2 }' | sort -u)"
+  [[ -n "$bodies" ]] || return 0
+  for pub in "$ssh_dir"/*.pub; do
+    [[ -f "$pub" ]] || continue
+    body="$(awk '{ print $2 }' "$pub" 2>/dev/null)"
+    [[ -n "$body" ]] || continue
+    if grep -qxF "$body" <<<"$bodies"; then
+      priv="${pub%.pub}"
+      [[ -f "$priv" ]] && { printf '%s\n' "$priv"; return 0; }
+    fi
+  done
+  return 0
+}
+
 if [[ -n "$identity" ]]; then
   identity="$(eval echo "$identity")"
   [[ -f "$identity" ]] || fail "identity not found: $identity"
+else
+  identity="$(discover_identity "$rules")"
+  [[ -n "$identity" ]] && echo "auto-selected identity: ${identity}" >&2
 fi
 
 need jq

--- a/terraform/github/github-secret-rotation-intake
+++ b/terraform/github/github-secret-rotation-intake
@@ -99,12 +99,34 @@ while (($# > 0)); do
   esac
 done
 
+discover_identity() {
+  # Print a local SSH private key whose public key is a recipient in the rules
+  # file, so decrypts work without an explicit --identity. First match wins.
+  local rules_file="$1" ssh_dir="${SSH_DIR:-$HOME/.ssh}"
+  local bodies pub body priv
+  bodies="$(grep -oE 'ssh-(rsa|ed25519|dss) [A-Za-z0-9+/=]+' "$rules_file" 2>/dev/null | awk '{ print $2 }' | sort -u)"
+  [[ -n "$bodies" ]] || return 0
+  for pub in "$ssh_dir"/*.pub; do
+    [[ -f "$pub" ]] || continue
+    body="$(awk '{ print $2 }' "$pub" 2>/dev/null)"
+    [[ -n "$body" ]] || continue
+    if grep -qxF "$body" <<<"$bodies"; then
+      priv="${pub%.pub}"
+      [[ -f "$priv" ]] && { printf '%s\n' "$priv"; return 0; }
+    fi
+  done
+  return 0
+}
+
 if [[ -n "$identity" ]]; then
   identity="$(eval echo "$identity")"
   if [[ ! -f "$identity" ]]; then
     echo "identity not found: $identity" >&2
     exit 1
   fi
+else
+  identity="$(discover_identity "$rules")"
+  [[ -n "$identity" ]] && echo "auto-selected identity: ${identity}"
 fi
 
 json="$(nix eval --json --file "$manifest")"
@@ -249,7 +271,8 @@ echo "Selected ${selected_count} GitHub secret(s). Values will be edited with ag
 echo "Rules: ${rules}"
 echo
 
-jq -r '.[] | @base64' <<<"$selected" | while IFS= read -r encoded; do
+mapfile -t _intake_entries < <(jq -r '.[] | @base64' <<<"$selected")
+for encoded in "${_intake_entries[@]}"; do
   secret_json="$(printf '%s' "$encoded" | base64 -d)"
   rotation_group="$(jq -r '.rotationGroup' <<<"$secret_json")"
   target="$(target_for_secret <<<"$secret_json")"
@@ -272,7 +295,7 @@ jq -r '.[] | @base64' <<<"$selected" | while IFS= read -r encoded; do
   use_file=""
   reply=""
   candidate=""
-  if [[ -e /dev/tty ]]; then
+  if [[ -e /dev/tty && "$name" =~ (PRIVATE_KEY|_KEY|PEM|CERT|CERTIFICATE|SIGNING_KEY) ]]; then
     candidate="$(newest_download)"
   fi
   if [[ -n "$candidate" ]]; then


### PR DESCRIPTION
Two fixes prompted by bringing up metacraft's governance App key.

**Auto-discover the decrypt identity (render + intake):** when `--identity` isn't given, scan `~/.ssh/*.pub` for a public key that is a recipient in `secrets.nix` and use its private key automatically (first match; `--identity` still overrides). No more hand-specifying e.g. `~/.ssh/metacraft_strong`. Verified it resolves the metacraft recipient.

**intake TTY/file-fill:** the edit loop was `jq | while`, so agenix inherited the pipe as stdin, hit ryantm-agenix's non-TTY `cp /dev/stdin` path and failed. Switched to `mapfile`+`for` so agenix keeps the TTY (editor + `EDITOR=cp <file>` fill both work). The `~/Downloads` auto-suggest now only offers for key-shaped names (never a scalar App ID).

`bash -n` clean, editorconfig-clean.