### PR TITLE
ci: add reusable-recorder-ci reusable workflow

### DIFF
--- a/.github/workflows/reusable-recorder-ci.yml
+++ b/.github/workflows/reusable-recorder-ci.yml
@@ -1,0 +1,104 @@
+name: recorder-ci
+
+# Reusable CI for the CodeTracer recorder fleet. The recorders share one
+# lint-and-test shape — checkout, mint a CI token, setup-dev-env (nix), an
+# optional recorder-specific prep, then `just lint` / `just test`, then upload
+# logs to GitHub (short retention) AND mirror them to the in-house S3 artifact
+# store. Centralising it here means the S3 mirror (and every future CI change)
+# lives in ONE file instead of ~30 near-identical copies.
+#
+# A recorder adopts it by reducing its own `.github/workflows/ci.yml` to a
+# caller (see the codetracer-*-recorder repos) and moving any recorder-specific
+# CI prep (corelib fetch, sibling library build, …) out of inline YAML and into
+# a `just <prepare-recipe>` recipe — which also satisfies the
+# ci-workflow-standards.md "no complex CI scripts" rule. The prep recipe may
+# export variables to later steps by appending to "$GITHUB_ENV".
+#
+# See metacraft-dev-guidelines policies/ci-workflow-standards.md
+# (§ In-house artifact store, § Local Reproducibility).
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'runs-on value as a JSON array string.'
+        type: string
+        default: '["self-hosted", "nixos"]'
+      prepare-recipe:
+        description: >
+          Optional `just` recipe run after setup-dev-env, before lint/test, for
+          recorder-specific prep. Empty (default) skips it.
+        type: string
+        default: ''
+      log-path:
+        description: 'Path uploaded/mirrored as the failure log bundle.'
+        type: string
+        default: 'target/'
+      env-flavor:
+        description: 'setup-dev-env flavor.'
+        type: string
+        default: 'nix'
+    secrets:
+      CI_TOKEN_PROVIDER_APP_ID:
+        required: true
+      CI_TOKEN_PROVIDER_PRIVATE_KEY:
+        required: true
+      ATTIC_TOKEN:
+        required: false
+      MCL_S3_ARTIFACTS_ACCESS_KEY_ID:
+        required: false
+      MCL_S3_ARTIFACTS_SECRET_ACCESS_KEY:
+        required: false
+
+jobs:
+  lint-and-test:
+    name: Lint and test
+    runs-on: ${{ fromJSON(inputs.runner) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate CI token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
+          owner: metacraft-labs
+
+      - name: Setup dev env
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        with:
+          env-flavor: ${{ inputs.env-flavor }}
+          gh-token: ${{ steps.app-token.outputs.token }}
+          attic-token: ${{ secrets.ATTIC_TOKEN }}
+
+      - name: Prepare (recorder-specific)
+        if: inputs.prepare-recipe != ''
+        run: dev-exec just ${{ inputs.prepare-recipe }}
+
+      - name: Lint
+        run: dev-exec just lint
+
+      - name: Test
+        run: dev-exec just test
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: ${{ inputs.log-path }}
+          retention-days: 1
+
+      - name: Mirror test logs to S3 (non-blocking)
+        if: failure()
+        continue-on-error: true
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        with:
+          path: ${{ inputs.log-path }}
+          prefix: test-logs/${{ github.run_id }}
+          endpoint: ${{ vars.MCL_S3_ARTIFACTS_ENDPOINT }}
+          bucket: ${{ vars.MCL_S3_ARTIFACTS_BUCKET }}
+          region: ${{ vars.MCL_S3_ARTIFACTS_REGION }}
+          access-key-id: ${{ secrets.MCL_S3_ARTIFACTS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MCL_S3_ARTIFACTS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
The ~30 CodeTracer recorders each carry a near-identical lint-and-test `ci.yml`. This adds a shared reusable workflow (alongside the existing `reusable-*.yml`) capturing that spine — checkout → CI token → `setup-dev-env` → optional `just <prepare-recipe>` → lint → test → upload logs (`retention-days: 1`) → **mirror to the in-house S3 store** (`mirror-artifacts-s3`, metacraft-github-actions#4).

Centralising it means the S3 mirror (and every future recorder-CI change) lives in **one file** instead of ~30 copies. A recorder adopts it by reducing its `ci.yml` to a caller and moving inline CI prep (corelib fetch, sibling build) into a `just` recipe — which also fixes the current `ci-workflow-standards.md` "no complex CI scripts" violation. Reference conversion: `codetracer-cairo-recorder` (separate PR).

Additive — nothing calls it until a recorder opts in. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)