### PR TITLE
fix(deployment): parameterize the Incus site group

### DIFF
--- a/checks/deployment-incus-rehearsal.nix
+++ b/checks/deployment-incus-rehearsal.nix
@@ -1,3 +1,10 @@
+# Test-double policy: helper heredocs are extracted from the production script
+# so the tests execute the exact emitted helper bodies, never reimplemented
+# behavior. The fake `ip` replaces only the unavailable container network
+# namespace while those exact `container-assert.sh` bytes run, and accepts only
+# the production `-o link show` probe. The existing fake Incus isolates the
+# post-runtime invalid-image-attribute boundary, with every unexpected command
+# failing loudly instead of simulating any deployment behavior.
 top@{ config, ... }:
 {
   perSystem =
@@ -74,6 +81,12 @@ top@{ config, ... }:
               grep -q "topology_capture_artifacts" ${scriptPath}
               grep -q "topology_exercise_forced_command" ${scriptPath}
               grep -q "topology_exercise_break_glass" ${scriptPath}
+              test "$(grep -c 'example-site' ${scriptPath})" -eq 2
+
+              bash ${scriptPath} --help > help.out 2> help.err
+              grep -q "MCL_DEPLOYMENT_INCUS_SITE_GROUP" help.err
+              grep -q "must be non-empty" help.err
+              grep -q "existing, distinct topology group" help.err
 
               for scenario in ${lib.concatStringsSep " " scenarios}; do
                 bash ${scriptPath} "$scenario" --check-env
@@ -82,6 +95,8 @@ top@{ config, ... }:
                 grep -q "forcedCommandPrincipal=mcl-deploy-rehearsal" "$scenario.dry-run"
                 grep -q "manifestPrincipal=mcl-deployment-rehearsal" "$scenario.dry-run"
                 grep -q "home-lab-gpu" "$scenario.dry-run"
+                grep -q "site-group=example-site" "$scenario.dry-run"
+                grep -q "example-site" "$scenario.dry-run"
                 grep -q "hetzner" "$scenario.dry-run"
                 grep -q "workstation" "$scenario.dry-run"
 
@@ -92,6 +107,188 @@ top@{ config, ... }:
                 test "$status" -eq 69
                 grep -q "pending-runtime" "$scenario.run.err"
               done
+
+              # The public fixture's neutral site name is only a default. A
+              # consumer may select a differently named, still structurally
+              # identical site group without weakening any fixed rollout-group
+              # or Avahi checks.
+              alternate_topology="$(mktemp)"
+              jq 'walk(if type == "string" then gsub("example-site"; "satellite-site") else . end)' \
+                ${topology} > "$alternate_topology"
+
+              MCL_DEPLOYMENT_INCUS_TOPOLOGY="$alternate_topology" \
+                MCL_DEPLOYMENT_INCUS_SITE_GROUP=satellite-site \
+                bash ${scriptPath} full-topology --check-env
+              MCL_DEPLOYMENT_INCUS_TOPOLOGY="$alternate_topology" \
+                MCL_DEPLOYMENT_INCUS_SITE_GROUP=satellite-site \
+                bash ${scriptPath} full-topology-failures --dry-run > alternate-site.dry-run
+              grep -q "site-group=satellite-site" alternate-site.dry-run
+              grep -q "satellite-site-target" alternate-site.dry-run
+              if grep -q "example-site" alternate-site.dry-run; then
+                echo "alternate-site dry-run retained the default fixture group" >&2
+                exit 1
+              fi
+
+              MCL_DEPLOYMENT_INCUS_SITE_GROUP=example-site \
+                bash ${scriptPath} full-topology --check-env
+
+              targetless_topology="$(mktemp)"
+              jq '(.roles[] | select(.targetGroup == "satellite-site").role) = "monitoring"' \
+                "$alternate_topology" > "$targetless_topology"
+              jq -e '
+                any(.targetGroups[]; .name == "satellite-site")
+                and (any(.roles[]; .role == "target" and .targetGroup == "satellite-site") | not)
+              ' "$targetless_topology" >/dev/null
+
+              set +e
+              env -u MCL_DEPLOYMENT_INCUS_SITE_GROUP \
+                MCL_DEPLOYMENT_INCUS_TOPOLOGY="$alternate_topology" \
+                bash ${scriptPath} full-topology --check-env > alternate-unset.out 2> alternate-unset.err
+              alternate_unset_status=$?
+              MCL_DEPLOYMENT_INCUS_TOPOLOGY="$alternate_topology" \
+                MCL_DEPLOYMENT_INCUS_SITE_GROUP=missing-site \
+                bash ${scriptPath} full-topology --check-env > alternate-wrong.out 2> alternate-wrong.err
+              alternate_wrong_status=$?
+              MCL_DEPLOYMENT_INCUS_TOPOLOGY="$alternate_topology" \
+                MCL_DEPLOYMENT_INCUS_SITE_GROUP= \
+                bash ${scriptPath} full-topology --check-env > alternate-empty.out 2> alternate-empty.err
+              alternate_empty_status=$?
+              MCL_DEPLOYMENT_INCUS_TOPOLOGY="$targetless_topology" \
+                MCL_DEPLOYMENT_INCUS_SITE_GROUP=satellite-site \
+                bash ${scriptPath} full-topology --check-env > targetless-site.out 2> targetless-site.err
+              targetless_site_status=$?
+              MCL_DEPLOYMENT_INCUS_SITE_GROUP=home-lab-gpu \
+                bash ${scriptPath} full-topology --check-env > reserved-site.out 2> reserved-site.err
+              reserved_site_status=$?
+              set -e
+              test "$alternate_unset_status" -ne 0
+              test "$alternate_wrong_status" -ne 0
+              test "$alternate_empty_status" -ne 0
+              test "$targetless_site_status" -ne 0
+              test "$reserved_site_status" -ne 0
+              grep -q "does not name an existing target group with a target role" alternate-unset.err
+              grep -q "does not name an existing target group with a target role" alternate-wrong.err
+              grep -q "must be non-empty when set" alternate-empty.err
+              grep -Fxq \
+                "deployment-incus-rehearsal: MCL_DEPLOYMENT_INCUS_SITE_GROUP does not name an existing target group with a target role" \
+                targetless-site.err
+              grep -q "must name a distinct site group" reserved-site.err
+
+              # Execute the exact helper bytes generated into rehearsal
+              # containers. This keeps the test on the real per-container
+              # Avahi assertion and real failure-scenario event generator; it
+              # does not replace either with a mock implementation.
+              helper_dir="$(mktemp -d)"
+              python3 - ${scriptPath} "$helper_dir" <<'PY'
+              import pathlib
+              import sys
+
+              source = pathlib.Path(sys.argv[1]).read_text().splitlines()
+              output_dir = pathlib.Path(sys.argv[2])
+              for name in ("container-assert.sh", "scenario-driver.py"):
+                  marker = f'cat > "$topology_tmp_dir/{name}" <<'
+                  start = next(i for i, line in enumerate(source) if marker in line)
+                  delimiter = source[start].split("<<", 1)[1].strip().strip("'")
+                  end = next(i for i in range(start + 1, len(source)) if source[i] == delimiter)
+                  path = output_dir / name
+                  path.write_text("\n".join(source[start + 1:end]) + "\n")
+                  path.chmod(0o755)
+              PY
+
+              mkdir -p "$helper_dir/bin"
+              cat > "$helper_dir/bin/ip" <<'SH'
+              #!${pkgs.bash}/bin/bash
+              set -euo pipefail
+              if [[ "$#" -ne 3 || "$1" != "-o" || "$2" != "link" || "$3" != "show" ]]; then
+                printf 'fake ip: unexpected argv:' >&2
+                printf ' <%s>' "$@" >&2
+                printf '\n' >&2
+                exit 97
+              fi
+              printf '%s\n' \
+                '1: lo: <LOOPBACK>' \
+                '2: eth0: <BROADCAST>' \
+                '3: eth1: <BROADCAST>' \
+                '4: eth2: <BROADCAST>'
+              SH
+              chmod +x "$helper_dir/bin/ip"
+              set +e
+              "$helper_dir/bin/ip" -o address show > fake-ip-wrong.out 2> fake-ip-wrong.err
+              fake_ip_wrong_status=$?
+              set -e
+              test "$fake_ip_wrong_status" -eq 97
+              grep -Fxq "fake ip: unexpected argv: <-o> <address> <show>" fake-ip-wrong.err
+
+              jq --arg siteGroup satellite-site '
+                . as $topology
+                | ($topology.roles[] | select(.targetGroup == $siteGroup)) as $role
+                | {
+                    schemaVersion: 1,
+                    siteGroup: $siteGroup,
+                    role: $role,
+                    targetGroups: $topology.targetGroups
+                  }
+              ' "$alternate_topology" > "$helper_dir/satellite.runtime.json"
+              rm -rf /tmp/mcl-rehearsal
+              PATH="$helper_dir/bin:$PATH" \
+                MCL_DEPLOYMENT_INCUS_RUNTIME_META="$helper_dir/satellite.runtime.json" \
+                bash "$helper_dir/container-assert.sh"
+              jq -e '
+                .targetGroup == "satellite-site"
+                and .avahiExpected == true
+                and .declaredNetworkCount == 3
+                and .actualInterfaceCount == 3
+              ' /tmp/mcl-rehearsal/assertions.json >/dev/null
+
+              jq '.role.avahi = false' "$helper_dir/satellite.runtime.json" > "$helper_dir/satellite-bad-avahi.runtime.json"
+              set +e
+              PATH="$helper_dir/bin:$PATH" \
+                MCL_DEPLOYMENT_INCUS_RUNTIME_META="$helper_dir/satellite-bad-avahi.runtime.json" \
+                bash "$helper_dir/container-assert.sh" > bad-avahi.out 2> bad-avahi.err
+              bad_avahi_status=$?
+              set -e
+              test "$bad_avahi_status" -ne 0
+              grep -q "expected Avahi enabled for target group satellite-site" bad-avahi.err
+
+              scenario_out="$helper_dir/scenario-out"
+              mkdir -p "$scenario_out"
+              cat > "$scenario_out/failure-evidence.json" <<'JSON'
+              {
+                "offlineTarget": {"target": "satellite-site-target", "partitionedAndReconnected": true},
+                "missingCacheObject": {"requestFailed": true, "exitCode": 22},
+                "invalidSignature": {"rejected": true, "exitCode": 1},
+                "switchFailure": {"failed": true, "exitCode": 1},
+                "healthCheckFailure": {"failed": true, "exitCode": 1},
+                "rollback": {"started": true, "completed": true, "restoredDeploymentId": 43},
+                "staleDesiredState": {"rejected": true, "rejectedDeploymentId": 41, "currentDeploymentId": 42},
+                "lockContention": {"detected": true, "exitCode": 1}
+              }
+              JSON
+              python3 "$helper_dir/scenario-driver.py" \
+                full-topology-failures "$alternate_topology" "$scenario_out" satellite-site
+              jq -s -e '
+                [.[] | select(
+                  .event == "healthcheck-failed"
+                  or .event == "rollback-started"
+                  or .event == "rollback-complete"
+                )] as $events
+                | ($events | length) == 3
+                and all($events[]; .targetGroup == "satellite-site")
+              ' "$scenario_out/events.jsonl" >/dev/null
+              jq -e '.siteGroup == "satellite-site"' "$scenario_out/final-state.json" >/dev/null
+              if grep -q "example-site" "$scenario_out/events.jsonl" "$scenario_out/final-state.json"; then
+                echo "alternate-site failure artifacts retained the default fixture group" >&2
+                exit 1
+              fi
+
+              set +e
+              python3 "$helper_dir/scenario-driver.py" \
+                full-topology-failures "$alternate_topology" "$helper_dir/wrong-site-out" missing-site \
+                > wrong-driver.out 2> wrong-driver.err
+              wrong_driver_status=$?
+              set -e
+              test "$wrong_driver_status" -ne 0
+              grep -q "configured site group is missing from topology" wrong-driver.err
 
               fake_runtime="$(mktemp -d)"
               printf '%s\n' \

--- a/scripts/deployment-incus-rehearsal.sh
+++ b/scripts/deployment-incus-rehearsal.sh
@@ -16,6 +16,11 @@ topology_file="${MCL_DEPLOYMENT_INCUS_TOPOLOGY:-$repo_root/tests/deployment/incu
 topology_prefix="${MCL_DEPLOYMENT_INCUS_PREFIX:-mcl-deployment-${USER:-user}}"
 topology_artifact_dir="${MCL_DEPLOYMENT_INCUS_ARTIFACT_DIR:-}"
 topology_keep="${MCL_DEPLOYMENT_INCUS_KEEP:-}"
+if [[ "${MCL_DEPLOYMENT_INCUS_SITE_GROUP+x}" == x ]]; then
+  topology_site_group="$MCL_DEPLOYMENT_INCUS_SITE_GROUP"
+else
+  topology_site_group="example-site"
+fi
 detect_nix_system() {
   if [[ -n "${MCL_DEPLOYMENT_INCUS_SYSTEM:-}" ]]; then
     echo "$MCL_DEPLOYMENT_INCUS_SYSTEM"
@@ -55,6 +60,10 @@ Modes:
 
 Environment:
   MCL_DEPLOYMENT_INCUS_TOPOLOGY       JSON topology inventory for topology scenarios.
+  MCL_DEPLOYMENT_INCUS_SITE_GROUP     Home-lab site target group. Defaults to the
+                                      neutral public fixture group "example-site"
+                                      when unset. If set, it must be non-empty and
+                                      name an existing, distinct topology group.
   MCL_DEPLOYMENT_INCUS_PREFIX         Prefix for runtime container and network names.
   MCL_DEPLOYMENT_INCUS_IMAGE_ATTR     Generic NixOS LXC image attribute.
   MCL_DEPLOYMENT_INCUS_RUNTIME_PROBE_TIMEOUT
@@ -105,7 +114,17 @@ check_port() {
 
 validate_topology() {
   [[ -f "$topology_file" ]] || die "missing topology inventory: $topology_file"
-  jq -e --arg scenario "$scenario" '
+  [[ -n "$topology_site_group" ]] || die "MCL_DEPLOYMENT_INCUS_SITE_GROUP must be non-empty when set"
+  case "$topology_site_group" in
+    home-lab-gpu | hetzner | workstation)
+      die "MCL_DEPLOYMENT_INCUS_SITE_GROUP must name a distinct site group"
+      ;;
+  esac
+  jq -e --arg siteGroup "$topology_site_group" '
+    any((.targetGroups // [])[]; .name == $siteGroup)
+    and any((.roles // [])[]; .role == "target" and .targetGroup == $siteGroup)
+  ' "$topology_file" >/dev/null || die "MCL_DEPLOYMENT_INCUS_SITE_GROUP does not name an existing target group with a target role"
+  jq -e --arg scenario "$scenario" --arg siteGroup "$topology_site_group" '
     (.networks | map(.name)) as $networkNames
     | (.targetGroups | map(.name)) as $targetGroupNames
     | def controlsText($name):
@@ -120,14 +139,15 @@ validate_topology() {
     and any(.roles[]; .role == "attic-cache")
     and any(.roles[]; .role == "monitoring")
     and any(.roles[]; .targetGroup == "home-lab-gpu" and .avahi == true)
-    and any(.roles[]; .targetGroup == "example-site" and .avahi == true)
+    and any(.roles[]; .targetGroup == $siteGroup and .avahi == true)
     and any(.roles[]; .targetGroup == "hetzner" and .avahi == false)
     and any(.roles[]; .targetGroup == "workstation" and .avahi == false)
     and all(.roles[]; . as $role | (.networks | type == "array" and length > 0 and all(. as $network | $networkNames | index($network))))
     and all(.roles[]; . as $role | ((has("targetGroup") | not) or ($targetGroupNames | index($role.targetGroup))))
-    and all(.roles[] | select(.targetGroup == "home-lab-gpu" or .targetGroup == "example-site"); (.networks | index("home-lab")))
-    and all(.roles[] | select(.targetGroup == "hetzner"); (.networks | index("hetzner")))
-    and all(.roles[] | select(.targetGroup == "workstation"); (.networks | index("workstation")))
+    and ($targetGroupNames | index($siteGroup))
+    and all(.roles[] | select(.targetGroup == "home-lab-gpu" or .targetGroup == $siteGroup); .avahi == true and (.networks | index("home-lab")))
+    and all(.roles[] | select(.targetGroup == "hetzner"); .avahi == false and (.networks | index("hetzner")))
+    and all(.roles[] | select(.targetGroup == "workstation"); .avahi == false and (.networks | index("workstation")))
     and (controlsText("full-topology") | contains("runner") and contains("attic") and contains("monitoring") and contains("hetzner") and contains("workstation") and contains("deploy"))
     and (controlsText("full-topology-failures") | contains("partition") and contains("missing cache") and contains("invalid") and contains("signature") and contains("switch failure") and contains("health-check failure") and contains("rollback") and contains("lock contention"))
     and (controlsText("offline-latest-only") | contains("deployment 41") and contains("deployment 42") and contains("offline") and contains("only deployment 42 applies"))
@@ -196,6 +216,7 @@ dry_run_topology() {
   client="$(runtime_cmd || echo incus)"
   echo "deployment-incus-rehearsal: scenario=${scenario}"
   echo "deployment-incus-rehearsal: topology=${topology_file}"
+  echo "deployment-incus-rehearsal: site-group=${topology_site_group}"
   echo "deployment-incus-rehearsal: image-attr=${topology_image_attr}"
   echo "deployment-incus-rehearsal: runtime client=${client}"
   jq -r --arg scenario "$scenario" --arg prefix "$topology_prefix" '
@@ -661,18 +682,23 @@ topology_write_runtime_scripts() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-meta=/etc/mcl-deployment-rehearsal/runtime.json
+meta="${MCL_DEPLOYMENT_INCUS_RUNTIME_META:-/etc/mcl-deployment-rehearsal/runtime.json}"
 test -s "$meta"
 
 role_name="$(jq -r '.role.name' "$meta")"
 role_kind="$(jq -r '.role.role' "$meta")"
 target_group="$(jq -r '.role.targetGroup // ""' "$meta")"
 avahi="$(jq -r '.role.avahi // false' "$meta")"
+site_group="$(jq -r '.siteGroup // ""' "$meta")"
 
-jq -e '.schemaVersion == 1 and (.role.name | length > 0) and (.role.role | length > 0)' "$meta" >/dev/null
+[[ -n "$site_group" ]] || {
+  echo "runtime metadata has no configured site group" >&2
+  exit 1
+}
+jq -e --arg siteGroup "$site_group" '.schemaVersion == 1 and .siteGroup == $siteGroup and (.role.name | length > 0) and (.role.role | length > 0)' "$meta" >/dev/null
 
 case "$target_group" in
-  home-lab-gpu | example-site)
+  home-lab-gpu | "$site_group")
     [[ "$avahi" == "true" ]] || {
       echo "expected Avahi enabled for target group $target_group" >&2
       exit 1
@@ -726,6 +752,7 @@ import time
 scenario = sys.argv[1]
 topology_path = pathlib.Path(sys.argv[2])
 out_dir = pathlib.Path(sys.argv[3])
+site_group = sys.argv[4]
 topology = json.loads(topology_path.read_text())
 out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -736,6 +763,12 @@ commands_path = out_dir / "runtime-commands.log"
 roles = topology["roles"]
 target_groups = [group["name"] for group in topology["targetGroups"]]
 targets = [role for role in roles if role["role"] == "target"]
+if not site_group:
+    raise SystemExit("configured site group is empty")
+if site_group not in target_groups:
+    raise SystemExit("configured site group is missing from topology")
+if not any(role.get("targetGroup") == site_group for role in targets):
+    raise SystemExit("configured site group has no runtime target")
 
 events = []
 
@@ -795,9 +828,9 @@ elif scenario == "full-topology-failures":
     event("cache-missing-object", cache="attic", storePath="/nix/store/synthetic-missing", exitCode=evidence["missingCacheObject"]["exitCode"])
     event("manifest-rejected", reason="invalid-signature", deploymentId=42, exitCode=evidence["invalidSignature"]["exitCode"])
     event("switch-failed", targetGroup="hetzner", deploymentId=43, exitCode=evidence["switchFailure"]["exitCode"])
-    event("healthcheck-failed", targetGroup="example-site", deploymentId=44, exitCode=evidence["healthCheckFailure"]["exitCode"])
-    event("rollback-started", targetGroup="example-site", fromDeploymentId=44)
-    event("rollback-complete", targetGroup="example-site", restoredDeploymentId=evidence["rollback"]["restoredDeploymentId"])
+    event("healthcheck-failed", targetGroup=site_group, deploymentId=44, exitCode=evidence["healthCheckFailure"]["exitCode"])
+    event("rollback-started", targetGroup=site_group, fromDeploymentId=44)
+    event("rollback-complete", targetGroup=site_group, restoredDeploymentId=evidence["rollback"]["restoredDeploymentId"])
     event("stale-desired-state-rejected", rejectedDeploymentId=evidence["staleDesiredState"]["rejectedDeploymentId"], currentDeploymentId=evidence["staleDesiredState"]["currentDeploymentId"])
     event("lock-contention", lock="controller", contender="second-reconciler", exitCode=evidence["lockContention"]["exitCode"])
     final = {
@@ -936,6 +969,7 @@ final.update(
         "cachixDeployUsed": False,
         "productionCommandsUsed": [],
         "roles": sorted({role["role"] for role in roles}),
+        "siteGroup": site_group,
     }
 )
 state_path.write_text(json.dumps(final, indent=2, sort_keys=True) + "\n")
@@ -1110,6 +1144,7 @@ topology_inject_role_metadata() {
     --arg prefix "$topology_safe_prefix" \
     --arg container "$container" \
     --arg artifactDir "$topology_artifact_dir" \
+    --arg siteGroup "$topology_site_group" \
     '
       . as $topology
       | ($topology.roles[] | select(.name == $roleName)) as $role
@@ -1119,6 +1154,7 @@ topology_inject_role_metadata() {
           prefix: $prefix,
           container: $container,
           artifactDir: $artifactDir,
+          siteGroup: $siteGroup,
           role: $role,
           declaredNetworks: $role.networks,
           credentials: $topology.credentials,
@@ -1520,7 +1556,7 @@ topology_run_scenario_driver() {
   local runner_role runner_container
   runner_role="$(topology_role_by_kind orchestrator)"
   runner_container="$(topology_role_container "$runner_role")"
-  container_exec "$runner_container" "python3 /tmp/mcl-rehearsal/scenario-driver.py '$scenario' /tmp/mcl-rehearsal/topology.json /tmp/mcl-rehearsal"
+  container_exec "$runner_container" "site_group=\$(jq -r '.siteGroup // empty' /etc/mcl-deployment-rehearsal/runtime.json); test -n \"\$site_group\"; python3 /tmp/mcl-rehearsal/scenario-driver.py '$scenario' /tmp/mcl-rehearsal/topology.json /tmp/mcl-rehearsal \"\$site_group\""
 }
 
 topology_capture_artifacts() {


### PR DESCRIPTION
## Summary

- treat `example-site` as the neutral public fixture default, not a consumer topology contract
- require an explicit consumer site group to be non-empty, distinct, present, and backed by a target role
- propagate the selected group through dry-run output, runtime metadata, exact generated helpers, failure events, and final state
- add fail-closed alternate-topology and exact helper-boundary coverage

## Exact expected impact

This PR changes exactly two public source files: `scripts/deployment-incus-rehearsal.sh` and `checks/deployment-incus-rehearsal.nix`. It does not change Terraform, NixOS host configuration, credentials, secrets, provider state, or deployed infrastructure. Existing consumers remain on the neutral default until they explicitly configure another topology group. The private infrastructure pin/configuration update is intentionally a separate reviewed change.

Expected behavior after merge:

1. the public example topology continues to pass unchanged;
2. a structurally valid consumer topology can select its own site group;
3. empty, absent, reserved, or targetless selections fail before runtime launch;
4. all existing schema, role, network, Avahi, scenario-control, runtime, and failure-boundary assertions remain enforced;
5. no apply or deployment runs from this repository change.

## Verification

- exact-base alternate-site counterfactual: failed as expected
- focused deployment Incus check: passed
- bash syntax and diff checks: passed
- direct applicable hooks: passed without installing or invoking shared hook metadata
- complete host-compatible Linux flake suite: all 99 checks passed in implementation and independent review
- private-identifier scan: clean

## Consumer rollout after merge

A separate private-infrastructure change will update the shared pin/configuration, rerun the complete private flake suite, and prove the real consumer topology. No production-readiness milestone is claimed by this PR alone.