### PR TITLE
feat(import-ci): human-focused plan differences summary (diffs_path)

### DIFF
--- a/terraform/github/github-governance-import-ci
+++ b/terraform/github/github-governance-import-ci
@@ -74,6 +74,7 @@ plan_text="$plan_dir/plan.txt"
 plan_stderr="$plan_dir/plan.stderr"
 plan_json="$plan_dir/plan.json"
 counts_file="$plan_dir/counts.env"
+plan_diffs="$plan_dir/diffs.md"
 
 plan_args=(
   -input=false
@@ -112,11 +113,11 @@ echo "text_plan_path=$(realpath --relative-to="$workspace" "$plan_text")" >> "$G
 echo "json_plan_path=$(realpath --relative-to="$workspace" "$plan_json")" >> "$GITHUB_OUTPUT"
 
 nix shell --accept-flake-config --inputs-from "$workspace" nixpkgs#python3 --command \
-  python3 - "$plan_json" "$GITHUB_OUTPUT" "$counts_file" <<'PY'
+  python3 - "$plan_json" "$GITHUB_OUTPUT" "$counts_file" "$plan_diffs" <<'PY'
 import json
 import sys
 
-plan_path, output_path, counts_path = sys.argv[1], sys.argv[2], sys.argv[3]
+plan_path, output_path, counts_path, diffs_path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 counts = {
     "to_import": 0,
     "to_add": 0,
@@ -151,7 +152,65 @@ with open(output_path, "a", encoding="utf-8") as output:
 with open(counts_path, "w", encoding="utf-8") as counts_file:
     for key, value in counts.items():
         print(f"{key}={value}", file=counts_file)
+
+
+def _trunc(text, limit=80):
+    return text if len(text) <= limit else text[: limit - 1] + "\u2026"
+
+
+def _fmt(value):
+    if value is None:
+        return "`null`"
+    rendered = value if isinstance(value, str) else json.dumps(value)
+    return "`" + _trunc(rendered) + "`"
+
+
+items = []
+for change in plan.get("resource_changes", []):
+    inner = change.get("change", {})
+    actions = inner.get("actions", [])
+    if actions == ["no-op"]:
+        continue
+    if set(actions) >= {"create", "delete"}:
+        kind = "replace"
+    elif actions == ["delete"]:
+        kind = "delete"
+    elif actions == ["create"]:
+        kind = "create"
+    elif "update" in actions:
+        kind = "update"
+    else:
+        continue
+    before = inner.get("before") or {}
+    after = inner.get("after") or {}
+    attrs = []
+    if kind in ("update", "replace"):
+        for key in sorted(set(before) | set(after)):
+            if before.get(key) != after.get(key):
+                attrs.append((key, before.get(key), after.get(key)))
+    items.append((kind, change.get("address", ""), attrs))
+
+lines = []
+if not items:
+    lines.append("_No differences \u2014 this plan is import-only (safe to apply)._")
+else:
+    lines.append(f"**{len(items)} action(s) need review** \u2014 imports omitted:")
+    for key, label in (("delete", "Destroy"), ("replace", "Replace"), ("update", "Update"), ("create", "Create")):
+        group = [entry for entry in items if entry[0] == key]
+        if not group:
+            continue
+        lines.append(f"\n#### {label} ({len(group)})")
+        for _kind, address, attrs in group:
+            lines.append(f"- `{address}`")
+            for attr, before_value, after_value in attrs:
+                lines.append(f"  - `{attr}`: {_fmt(before_value)} \u2192 {_fmt(after_value)}")
+
+with open(diffs_path, "w", encoding="utf-8") as diffs_file:
+    diffs_file.write("\n".join(lines) + "\n")
 PY
+
+# shellcheck disable=SC1090
+echo "diffs_path=$(realpath --relative-to="$workspace" "$plan_diffs")" >> "$GITHUB_OUTPUT"
 
 # shellcheck disable=SC1090
 source "$counts_file"


### PR DESCRIPTION
The governance import plan comment was dominated by thousands of import lines. This adds a shared `diffs.md` / `diffs_path` output to `github-governance-import-ci`: only the **non-import actions** (Destroy/Replace/Update/Create), grouped, with per-attribute **old→new** values (truncated). Per-repo workflows can include `steps.plan.outputs.diffs_path` instead of computing it inline, so agent-harbor / blocksense / metacraft all benefit from one source. Verified: bash -n, python compiles, output correct on a sample plan.