### PR TITLE
fix(terraform-ci): compose backend OIDC credentials

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -34,5 +34,6 @@
     ./pre-commit.nix
     ./secret-integration
     ./setup-nix-transfer-resilience.nix
+    ./terraform-ci-matrix.nix
   ];
 }

--- a/checks/terraform-ci-matrix.nix
+++ b/checks/terraform-ci-matrix.nix
@@ -1,0 +1,27 @@
+{ ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks.terraform-ci-matrix =
+        pkgs.runCommand "terraform-ci-matrix-test"
+          {
+            nativeBuildInputs = [
+              pkgs.bash
+              pkgs.coreutils
+              pkgs.findutils
+              pkgs.jq
+              pkgs.python3
+            ];
+          }
+          ''
+            export TERRAFORM_CI_MATRIX_SCRIPT=${../terraform/ci/terraform-ci-matrix}
+            export TERRAFORM_CI_MATRIX_SCHEMA=${../terraform/ci/metadata.schema.json}
+            export TERRAFORM_CI_MATRIX_BASH=${pkgs.bash}/bin/bash
+
+            ${pkgs.bash}/bin/bash ${../terraform/ci/tests/test-matrix.sh}
+            ${pkgs.bash}/bin/bash ${../terraform/ci/tests/test-matrix-mutations.sh}
+            touch "$out"
+          '';
+    };
+}

--- a/docs/Terraform-Root-Layering.md
+++ b/docs/Terraform-Root-Layering.md
@@ -21,11 +21,19 @@ Required fields:
 - `backend_config_file`: backend HCL file consumed by CI and operator commands.
 - `provider_allowlist`: exact provider sources allowed after Terranix render.
 - `credential_mode`: how CI obtains provider credentials.
+- `backend_uses_aws_oidc`: optional boolean, defaulting to `false`, that requests
+  the reviewed AWS OIDC role independently when the state backend needs it.
 - `enable_checkov`: whether the reusable CI workflow should run Checkov.
 - `split_boundary`: human-readable lifecycle and access-boundary rationale.
 
 The metadata is deliberately redundant with the backend file. The backend file
 drives OpenTofu; the metadata drives review and CI matrix generation.
+Provider and backend authentication are separate: for example, a Cloudflare
+root can use `credential_mode: "agenix-token"` for the provider and
+`backend_uses_aws_oidc: true` for S3 state. The generated `uses_aws_oidc` field
+is the combined workflow signal consumers use when selecting AWS plan, apply,
+and drift roles. If required provider credential material is absent, the root
+remains offline-only even when the backend would otherwise use AWS OIDC.
 
 ## State Classes
 

--- a/docs/Terraform-Shared-Infrastructure.status.org
+++ b/docs/Terraform-Shared-Infrastructure.status.org
@@ -43,3 +43,20 @@
   each module's README under =terraform/= and the bootstrap runbook for the
   end-to-end procedure. Deployment facts (accounts, owners, zones) live in the
   consumer's tracked Terraform/Nix files, never in this shared repo.
+
+* Terraform provider and backend credential composition
+
+  Terraform-root metadata models provider and backend authentication as
+  independent axes. =credential_mode= selects provider credentials;
+  =backend_uses_aws_oidc=true= additionally supplies the reviewed AWS OIDC role
+  to an AWS-backed state backend. This supports token-authenticated providers
+  such as Cloudflare, Stripe, or GitHub while retaining an S3 backend without
+  private consumer-side matrix logic. An =agenix-token= root whose encrypted
+  plan/apply key files are absent remains offline-only even when its backend
+  requires AWS OIDC.
+
+  The direct suite covers combined, provider-only, backend-only, legacy AWS
+  provider, credential-free, missing-secret, and malformed-metadata cases. The
+  flake check runs that suite in a Nix sandbox on every supported system and
+  also proves that mutations weakening backend composition, credential
+  readiness, defaulting, validation, or matrix publication are rejected.

--- a/terraform/ci/README.md
+++ b/terraform/ci/README.md
@@ -31,7 +31,14 @@ Each managed root carries a `metadata.json` validated against
 `credential_mode` (`aws-oidc` | `agenix-token` | `none`), `enable_checkov`,
 `provider_allowlist`. `agenix-token` roots also require `credentials_env_name`
 and `agenix_{plan,apply}_secret_path`. Optional: `smoke_test_command`,
-`split_boundary` (prose; see the root-layering runbook).
+`split_boundary` (prose; see the root-layering runbook), and
+`backend_uses_aws_oidc` (default `false`). `credential_mode` describes provider
+authentication only. Set `backend_uses_aws_oidc` when the state backend also
+needs the caller's AWS OIDC role; this permits combinations such as a
+Cloudflare provider token from agenix with an S3 state backend. The generated
+`uses_aws_oidc` value is the combined workflow signal. If a required agenix
+plan/apply key file is absent, the root remains offline-only and the matrix
+emits neither provider credentials nor the AWS workflow switch.
 
 The one fixed rule: the state key must match its sensitivity —
 `terraform/<config>.tfstate` for `standard`, `terraform-sensitive/<config>.tfstate`
@@ -40,5 +47,8 @@ for `sensitive`, where `<config>` is the root path minus the leading
 
 ## Tests
 
-`tests/test-matrix.sh` covers discovery and negative validation offline (no
-credentials, no network).
+`tests/test-matrix.sh` covers the provider/backend credential matrix and
+negative validation directly, without credentials or network.
+`tests/test-matrix-mutations.sh` proves that the suite rejects semantic
+weakenings. The `terraform-ci-matrix` flake check runs both in a Nix sandbox on
+every supported system.

--- a/terraform/ci/metadata.schema.json
+++ b/terraform/ci/metadata.schema.json
@@ -9,7 +9,8 @@
     "state_key": { "type": "string", "description": "Backend state key. Must be terraform/<config>.tfstate (standard) or terraform-sensitive/<config>.tfstate (sensitive), where <config> is the root path minus the leading terraform/." },
     "state_sensitivity": { "enum": ["standard", "sensitive"] },
     "backend_config_file": { "type": "string", "description": "Path to the root's backends/*.hcl (state key only; never secrets)." },
-    "credential_mode": { "enum": ["aws-oidc", "agenix-token", "none"] },
+    "credential_mode": { "enum": ["aws-oidc", "agenix-token", "none"], "description": "Provider credential mode. Backend authentication is declared independently by backend_uses_aws_oidc." },
+    "backend_uses_aws_oidc": { "type": "boolean", "default": false, "description": "Whether the Terraform state backend also requires the caller's AWS OIDC role. This is independent of provider credential_mode so, for example, an agenix-token provider can use an S3 backend." },
     "credentials_env_name": { "type": "string", "description": "Required for agenix-token: env var the decrypted token is exported as (e.g. GITHUB_TOKEN, CLOUDFLARE_API_TOKEN)." },
     "agenix_plan_secret_path": { "type": "string", "description": "Required for agenix-token: repo-relative path to the read-only (plan) agenix secret." },
     "agenix_apply_secret_path": { "type": "string", "description": "Required for agenix-token: repo-relative path to the read-write (apply) agenix secret." },
@@ -17,5 +18,16 @@
     "provider_allowlist": { "type": "array", "minItems": 1, "items": { "type": "string" }, "description": "Exact terraform.required_providers source values permitted in this root." },
     "smoke_test_command": { "type": "string", "description": "Optional post-apply smoke test command." },
     "split_boundary": { "type": "object", "description": "Optional prose documenting why this root is a separate state boundary (see the root-layering runbook)." }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "credential_mode": { "const": "agenix-token" } },
+        "required": ["credential_mode"]
+      },
+      "then": {
+        "required": ["credentials_env_name", "agenix_plan_secret_path", "agenix_apply_secret_path"]
+      }
+    }
+  ]
 }

--- a/terraform/ci/terraform-ci-matrix
+++ b/terraform/ci/terraform-ci-matrix
@@ -67,6 +67,10 @@ while IFS= read -r root; do
     and (.backend_config_file | nonempty_string)
     and (.state_sensitivity | IN("standard", "sensitive"))
     and (.credential_mode | IN("aws-oidc", "agenix-token", "none"))
+    and (
+      (has("backend_uses_aws_oidc") | not)
+      or (.backend_uses_aws_oidc | type == "boolean")
+    )
     and (.enable_checkov | type == "boolean")
     and (.provider_allowlist | string_array and length > 0)
     # agenix-token roots must declare their env name and plan/apply secret paths.
@@ -89,15 +93,16 @@ while IFS= read -r root; do
   fi
 
   credential_mode="$(jq -r '.credential_mode' "$metadata_file")"
+  backend_uses_aws_oidc="$(jq -r '.backend_uses_aws_oidc // false' "$metadata_file")"
   uses_aws_oidc=false
+  provider_credentials_ready=true
   credentials_env_name=""
   agenix_plan_secret_path=""
   agenix_apply_secret_path=""
   smoke_test_command="$(jq -r '.smoke_test_command // ""' "$metadata_file")"
 
   case "$credential_mode" in
-    aws-oidc)
-      uses_aws_oidc=true ;;
+    aws-oidc) : ;;
     agenix-token)
       credentials_env_name="$(jq -r '.credentials_env_name' "$metadata_file")"
       agenix_plan_secret_path="$(jq -r '.agenix_plan_secret_path' "$metadata_file")"
@@ -106,14 +111,24 @@ while IFS= read -r root; do
       # so a root can be added before its CI keys are provisioned.
       if [[ ! -f "${root_dir}/${agenix_plan_secret_path}" || ! -f "${root_dir}/${agenix_apply_secret_path}" ]]; then
         credentials_env_name=""; agenix_plan_secret_path=""; agenix_apply_secret_path=""
+        provider_credentials_ready=false
       fi ;;
     none) : ;;
   esac
+
+  # Provider and backend authentication are separate axes. Emit the one
+  # combined workflow switch only when every provider credential is ready, so
+  # an agenix-token root without provisioned key files remains offline-only.
+  if [[ "$provider_credentials_ready" == true \
+    && ( "$credential_mode" == "aws-oidc" || "$backend_uses_aws_oidc" == true ) ]]; then
+    uses_aws_oidc=true
+  fi
 
   row="$(jq -c -n \
     --arg root "$root" \
     --arg config "$config" \
     --argjson metadata "$(jq -c . "$metadata_file")" \
+    --argjson backend_uses_aws_oidc "$backend_uses_aws_oidc" \
     --argjson uses_aws_oidc "$uses_aws_oidc" \
     --arg credentials_env_name "$credentials_env_name" \
     --arg agenix_plan_secret_path "$agenix_plan_secret_path" \
@@ -128,6 +143,7 @@ while IFS= read -r root; do
       enable_checkov: $metadata.enable_checkov,
       state_sensitivity: $metadata.state_sensitivity,
       credential_mode: $metadata.credential_mode,
+      backend_uses_aws_oidc: $backend_uses_aws_oidc,
       uses_aws_oidc: $uses_aws_oidc,
       credentials_env_name: $credentials_env_name,
       agenix_plan_secret_path: $agenix_plan_secret_path,

--- a/terraform/ci/tests/test-matrix-mutations.sh
+++ b/terraform/ci/tests/test-matrix-mutations.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Prove that the direct suite detects semantic weakenings of the independent
+# provider/backend credential contract.
+set -euo pipefail
+
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+matrix="${TERRAFORM_CI_MATRIX_SCRIPT:-${here}/../terraform-ci-matrix}"
+schema="${TERRAFORM_CI_MATRIX_SCHEMA:-${here}/../metadata.schema.json}"
+matrix_bash="${TERRAFORM_CI_MATRIX_BASH:-}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+expect_rejected() {
+  local name="$1"
+  local old="$2"
+  local new="$3"
+  local mutated="${tmp}/${name}"
+  local log="${tmp}/${name}.log"
+
+  python3 - "$matrix" "$mutated" "$old" "$new" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text()
+old = sys.argv[3]
+count = source.count(old)
+if count != 1:
+    raise SystemExit(f"mutation anchor occurs {count} times, expected exactly once: {old!r}")
+pathlib.Path(sys.argv[2]).write_text(source.replace(old, sys.argv[4], 1))
+PY
+  chmod +x "$mutated"
+
+  if TERRAFORM_CI_MATRIX_SCRIPT="$mutated" \
+    TERRAFORM_CI_MATRIX_SCHEMA="$schema" \
+    TERRAFORM_CI_MATRIX_BASH="$matrix_bash" \
+    bash "${here}/test-matrix.sh" >"$log" 2>&1; then
+    echo "FAIL: semantic mutation '${name}' escaped the direct suite" >&2
+    cat "$log" >&2
+    return 1
+  fi
+}
+
+expect_rejected \
+  remove-backend-composition \
+  '|| "$backend_uses_aws_oidc" == true' \
+  '|| false == true'
+expect_rejected \
+  bypass-provider-readiness \
+  '"$provider_credentials_ready" == true' \
+  'true == true'
+expect_rejected \
+  invert-backend-default \
+  ".backend_uses_aws_oidc // false" \
+  ".backend_uses_aws_oidc // true"
+expect_rejected \
+  weaken-backend-type-validation \
+  'or (.backend_uses_aws_oidc | type == "boolean")' \
+  'or true'
+expect_rejected \
+  omit-backend-axis-from-output \
+  'backend_uses_aws_oidc: $backend_uses_aws_oidc,' \
+  'backend_uses_aws_oidc: false,'
+
+echo "OK: terraform-ci-matrix semantic mutations were rejected"

--- a/terraform/ci/tests/test-matrix.sh
+++ b/terraform/ci/tests/test-matrix.sh
@@ -1,39 +1,301 @@
 #!/usr/bin/env bash
-# Self-contained tests for terraform-ci-matrix (positive discovery + negative
-# validation). No credentials or network required.
+# Direct contract tests for terraform-ci-matrix. No credentials or network are
+# required. Environment overrides let the Nix check and mutation suite exercise
+# the exact same assertions with sandboxed or deliberately altered inputs.
 set -euo pipefail
+
 here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-matrix="${here}/../terraform-ci-matrix"
+matrix="${TERRAFORM_CI_MATRIX_SCRIPT:-${here}/../terraform-ci-matrix}"
+schema="${TERRAFORM_CI_MATRIX_SCHEMA:-${here}/../metadata.schema.json}"
+matrix_bash="${TERRAFORM_CI_MATRIX_BASH:-}"
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
-fail=0
+badtmp=""
+github_output="${tmp}/github-output"
+failures=0
 
-mkroot() { mkdir -p "$tmp/$1"; cat > "$tmp/$1/metadata.json"; }
+cleanup() {
+  rm -rf "$tmp"
+  if [[ -n "$badtmp" ]]; then
+    rm -rf "$badtmp"
+  fi
+}
+trap cleanup EXIT
 
-# Two valid roots.
-mkroot terraform/github/governance <<'J'
-{ "state_key":"terraform/github/governance.tfstate","state_sensitivity":"standard",
-  "backend_config_file":"backends/gh.hcl","credential_mode":"agenix-token",
-  "credentials_env_name":"GITHUB_TOKEN","agenix_plan_secret_path":"a.age","agenix_apply_secret_path":"b.age",
-  "enable_checkov":false,"provider_allowlist":["integrations/github"] }
-J
-mkroot terraform/aws/prod <<'J'
-{ "state_key":"terraform/aws/prod.tfstate","state_sensitivity":"standard","backend_config_file":"backends/aws.hcl",
-  "credential_mode":"aws-oidc","enable_checkov":true,"provider_allowlist":["hashicorp/aws"] }
-J
-out="$("$matrix" --root-dir "$tmp")"
-n="$(jq '.include | length' <<<"$out")"
-[[ "$n" == "2" ]] || { echo "FAIL: expected 2 roots, got $n"; fail=1; }
-jq -e '.include[] | select(.root=="terraform/aws/prod") | .uses_aws_oidc == true' <<<"$out" >/dev/null \
-  || { echo "FAIL: aws root should set uses_aws_oidc"; fail=1; }
+fail() {
+  echo "FAIL: $*" >&2
+  failures=$((failures + 1))
+}
 
-# Invalid: state_key does not match sensitivity naming rule.
-badtmp="$(mktemp -d)"; mkdir -p "$badtmp/terraform/x/y"
-cat > "$badtmp/terraform/x/y/metadata.json" <<'J'
-{ "state_key":"wrong.tfstate","state_sensitivity":"standard","backend_config_file":"b.hcl",
-  "credential_mode":"none","enable_checkov":false,"provider_allowlist":["hashicorp/aws"] }
-J
-if "$matrix" --root-dir "$badtmp" >/dev/null 2>&1; then echo "FAIL: bad state_key should exit non-zero"; fail=1; fi
+mkroot() {
+  mkdir -p "$tmp/$1"
+  cat > "$tmp/$1/metadata.json"
+}
+
+run_matrix() {
+  if [[ -n "$matrix_bash" ]]; then
+    "$matrix_bash" "$matrix" "$@"
+  else
+    "$matrix" "$@"
+  fi
+}
+
+expect_row() {
+  local root="$1"
+  local expression="$2"
+  if ! jq -e --arg root "$root" \
+    ".include[] | select(.root == \$root) | ${expression}" <<<"$out" >/dev/null; then
+    fail "unexpected matrix contract for ${root}: ${expression}"
+  fi
+}
+
+expect_invalid_backend_flag() {
+  local invalid_backend_flag="$1"
+  badtmp="$(mktemp -d)"
+  mkdir -p "$badtmp/terraform/x/y"
+  jq -n --argjson backend_flag "$invalid_backend_flag" '{
+    state_key: "terraform/x/y.tfstate",
+    state_sensitivity: "standard",
+    backend_config_file: "b.hcl",
+    credential_mode: "none",
+    backend_uses_aws_oidc: $backend_flag,
+    enable_checkov: false,
+    provider_allowlist: ["hashicorp/archive"]
+  }' > "$badtmp/terraform/x/y/metadata.json"
+  if run_matrix --root-dir "$badtmp" >/dev/null 2>&1; then
+    fail "non-boolean backend_uses_aws_oidc=${invalid_backend_flag} was accepted"
+  fi
+  rm -rf "$badtmp"
+  badtmp=""
+}
+
+# The published JSON Schema must expose the optional, false-defaulted backend
+# axis and retain the agenix provider requirements.
+if ! jq -e '
+  .properties.backend_uses_aws_oidc.type == "boolean"
+  and .properties.backend_uses_aws_oidc.default == false
+  and ((.required | index("backend_uses_aws_oidc")) == null)
+  and any(.allOf[];
+    .if.properties.credential_mode.const == "agenix-token"
+    and (.then.required | sort) == ([
+      "agenix_apply_secret_path",
+      "agenix_plan_secret_path",
+      "credentials_env_name"
+    ] | sort)
+  )
+' "$schema" >/dev/null; then
+  fail "metadata schema does not publish the independent backend credential axis"
+fi
+
+mkdir -p "$tmp/secrets"
+touch \
+  "$tmp/secrets/github-plan.age" \
+  "$tmp/secrets/github-apply.age" \
+  "$tmp/secrets/cloudflare-plan.age" \
+  "$tmp/secrets/cloudflare-apply.age" \
+  "$tmp/secrets/partial-plan.age"
+
+# Mixed provider/backend credentials.
+mkroot terraform/github/governance <<'JSON'
+{
+  "state_key": "terraform/github/governance.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "backends/github.hcl",
+  "credential_mode": "agenix-token",
+  "backend_uses_aws_oidc": true,
+  "credentials_env_name": "GITHUB_TOKEN",
+  "agenix_plan_secret_path": "secrets/github-plan.age",
+  "agenix_apply_secret_path": "secrets/github-apply.age",
+  "enable_checkov": false,
+  "provider_allowlist": ["integrations/github"]
+}
+JSON
+
+# Provider credentials without AWS backend credentials; omission proves the
+# compatibility default rather than relying only on an explicit false value.
+mkroot terraform/cloudflare/prod <<'JSON'
+{
+  "state_key": "terraform/cloudflare/prod.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "backends/cloudflare.hcl",
+  "credential_mode": "agenix-token",
+  "credentials_env_name": "CLOUDFLARE_API_TOKEN",
+  "agenix_plan_secret_path": "secrets/cloudflare-plan.age",
+  "agenix_apply_secret_path": "secrets/cloudflare-apply.age",
+  "enable_checkov": false,
+  "provider_allowlist": ["cloudflare/cloudflare"]
+}
+JSON
+
+# Legacy AWS provider behavior remains valid without the new backend field.
+mkroot terraform/aws/prod <<'JSON'
+{
+  "state_key": "terraform/aws/prod.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "backends/aws.hcl",
+  "credential_mode": "aws-oidc",
+  "enable_checkov": true,
+  "provider_allowlist": ["hashicorp/aws"]
+}
+JSON
+
+# Backend-only and wholly credential-free roots prove both sides of the new
+# axis for providers that need no runtime credential material.
+mkroot terraform/archive/state-backed <<'JSON'
+{
+  "state_key": "terraform/archive/state-backed.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "backends/archive.hcl",
+  "credential_mode": "none",
+  "backend_uses_aws_oidc": true,
+  "enable_checkov": false,
+  "provider_allowlist": ["hashicorp/archive"]
+}
+JSON
+mkroot terraform/archive/local <<'JSON'
+{
+  "state_key": "terraform/archive/local.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "backends/local.hcl",
+  "credential_mode": "none",
+  "backend_uses_aws_oidc": false,
+  "enable_checkov": false,
+  "provider_allowlist": ["hashicorp/archive"]
+}
+JSON
+
+# Missing either or both agenix files must suppress provider fields and the
+# combined workflow switch, including when the backend requests AWS OIDC.
+mkroot terraform/github/pending <<'JSON'
+{
+  "state_key": "terraform/github/pending.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "backends/pending.hcl",
+  "credential_mode": "agenix-token",
+  "backend_uses_aws_oidc": true,
+  "credentials_env_name": "GITHUB_TOKEN",
+  "agenix_plan_secret_path": "secrets/missing-plan.age",
+  "agenix_apply_secret_path": "secrets/missing-apply.age",
+  "enable_checkov": false,
+  "provider_allowlist": ["integrations/github"]
+}
+JSON
+mkroot terraform/github/partial <<'JSON'
+{
+  "state_key": "terraform/github/partial.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "backends/partial.hcl",
+  "credential_mode": "agenix-token",
+  "backend_uses_aws_oidc": true,
+  "credentials_env_name": "GITHUB_TOKEN",
+  "agenix_plan_secret_path": "secrets/partial-plan.age",
+  "agenix_apply_secret_path": "secrets/missing-apply.age",
+  "enable_checkov": false,
+  "provider_allowlist": ["integrations/github"]
+}
+JSON
+
+out="$(run_matrix --root-dir "$tmp")"
+if [[ "$(jq '.include | length' <<<"$out")" != 7 ]]; then
+  fail "expected seven credential-axis roots"
+fi
+
+expect_row terraform/github/governance '
+  .credential_mode == "agenix-token"
+  and .backend_uses_aws_oidc == true
+  and .uses_aws_oidc == true
+  and .credentials_env_name == "GITHUB_TOKEN"
+  and .agenix_plan_secret_path == "secrets/github-plan.age"
+  and .agenix_apply_secret_path == "secrets/github-apply.age"'
+expect_row terraform/cloudflare/prod '
+  .credential_mode == "agenix-token"
+  and .backend_uses_aws_oidc == false
+  and .uses_aws_oidc == false
+  and .credentials_env_name == "CLOUDFLARE_API_TOKEN"
+  and .agenix_plan_secret_path == "secrets/cloudflare-plan.age"
+  and .agenix_apply_secret_path == "secrets/cloudflare-apply.age"'
+expect_row terraform/aws/prod '
+  .credential_mode == "aws-oidc"
+  and .backend_uses_aws_oidc == false
+  and .uses_aws_oidc == true
+  and .credentials_env_name == ""'
+expect_row terraform/archive/state-backed '
+  .credential_mode == "none"
+  and .backend_uses_aws_oidc == true
+  and .uses_aws_oidc == true
+  and .credentials_env_name == ""'
+expect_row terraform/archive/local '
+  .credential_mode == "none"
+  and .backend_uses_aws_oidc == false
+  and .uses_aws_oidc == false
+  and .credentials_env_name == ""'
+for pending_root in terraform/github/pending terraform/github/partial; do
+  expect_row "$pending_root" '
+    .credential_mode == "agenix-token"
+    and .backend_uses_aws_oidc == true
+    and .uses_aws_oidc == false
+    and .credentials_env_name == ""
+    and .agenix_plan_secret_path == ""
+    and .agenix_apply_secret_path == ""'
+done
+
+# GitHub-output and pretty modes must preserve the exact matrix contract.
+run_matrix --root-dir "$tmp" --github-output "$github_output" >/dev/null
+if ! jq -Rse --argjson expected "$out" '
+  (sub("^matrix="; "") | fromjson) == $expected
+' "$github_output" >/dev/null; then
+  fail "GitHub output did not preserve the matrix"
+fi
+if ! run_matrix --root-dir "$tmp" --pretty | jq -e . >/dev/null; then
+  fail "pretty output was not valid JSON"
+fi
+
+# The new field is strictly boolean. Explicit null is rejected rather than
+# silently inheriting the default.
+for invalid_backend_flag in '"true"' null 0 '[]' '{}'; do
+  expect_invalid_backend_flag "$invalid_backend_flag"
+done
+
+# Existing fail-closed validation remains part of the contract.
+badtmp="$(mktemp -d)"
+mkdir -p "$badtmp/terraform/x/y"
+cat > "$badtmp/terraform/x/y/metadata.json" <<'JSON'
+{
+  "state_key": "wrong.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "b.hcl",
+  "credential_mode": "none",
+  "enable_checkov": false,
+  "provider_allowlist": ["hashicorp/archive"]
+}
+JSON
+if run_matrix --root-dir "$badtmp" >/dev/null 2>&1; then
+  fail "invalid state key was accepted"
+fi
 rm -rf "$badtmp"
+badtmp=""
 
-[[ "$fail" == "0" ]] && echo "OK: terraform-ci-matrix tests passed" || exit 1
+badtmp="$(mktemp -d)"
+mkdir -p "$badtmp/terraform/x/y"
+cat > "$badtmp/terraform/x/y/metadata.json" <<'JSON'
+{
+  "state_key": "terraform/x/y.tfstate",
+  "state_sensitivity": "standard",
+  "backend_config_file": "b.hcl",
+  "credential_mode": "agenix-token",
+  "backend_uses_aws_oidc": true,
+  "enable_checkov": false,
+  "provider_allowlist": ["integrations/github"]
+}
+JSON
+if run_matrix --root-dir "$badtmp" >/dev/null 2>&1; then
+  fail "agenix mode without provider metadata was accepted"
+fi
+rm -rf "$badtmp"
+badtmp=""
+
+if ((failures > 0)); then
+  echo "${failures} terraform-ci-matrix contract assertion(s) failed." >&2
+  exit 1
+fi
+
+echo "OK: terraform-ci-matrix direct contract tests passed"


### PR DESCRIPTION
## Summary

- model Terraform provider credentials and AWS-backed state credentials as independent metadata axes
- preserve fail-closed offline-only behavior until every required agenix provider secret exists
- publish the false-defaulted backend axis in the JSON schema and generated matrix while preserving legacy AWS-provider behavior
- add direct, sandboxed, schema, GitHub-output, and semantic-mutation coverage for mixed, provider-only, backend-only, credential-free, missing/partial-secret, and malformed-input cases
- update the shared consumer contract and status document

## Scope and expected impact

This is a repository-only reusable Terraform CI contract change. It does not change a consumer Terraform root, invoke a credentialed plan or apply, deploy software, or mutate cloud infrastructure.

Expected cloud resource plan: **0 add, 0 change, 0 destroy**.

Consumers must explicitly set `backend_uses_aws_oidc` and pin the landed nixos-modules revision before their behavior changes.

## Current reconstruction

- exact base: `db6c57be3009cbbadbddb659ed76f564bc88b120` (synchronized `main` and `dev`)
- exact head: `cd723461de78082a728121042437809cf9c6790c`
- signed commit: verified locally and by GitHub
- changed scope: exactly nine Terraform matrix/schema/test/docs registration files

The prior PR head and all its CI evidence are superseded. In particular, unrelated historical commits `3642ba3` (governance formatting), `aeb99b4` (S3 key-issuer runtime), and `982f8c6` (deployment-event race handling) are intentionally excluded. Their paths are unchanged from the current base, so this reconstruction does not revive old fixes or overwrite newer GARM, Darwin setup-nix, or shared-infrastructure work.

## Local validation

- `bash terraform/ci/tests/test-matrix.sh`: pass
- `bash terraform/ci/tests/test-matrix-mutations.sh`: pass
- `nix build .#checks.x86_64-linux.terraform-ci-matrix --no-link --print-build-logs --accept-flake-config`: pass
- `nix develop --accept-flake-config .#pre-commit -c prek run --all-files --show-diff-on-failure --color always`: pass; all applicable hooks pass, Terraform formatter has no files in scope
- `nix flake check --no-build --accept-flake-config`: pass; full native flake graph evaluates
- `nix eval --raw --accept-flake-config .#checks.x86_64-linux.terraform-ci-matrix.drvPath`: pass
- `nix eval --raw --accept-flake-config .#checks.aarch64-darwin.terraform-ci-matrix.drvPath`: pass
- `nix eval --raw --accept-flake-config .#checks.x86_64-darwin.terraform-ci-matrix.drvPath`: pass
- `git diff --check` / committed diff check: pass

No test is weakened, ignored, skipped, quarantined, filtered, or masked. The test suite deliberately fails semantic mutations that remove backend composition, bypass provider readiness, invert the compatibility default, weaken boolean validation, or omit the backend axis from matrix publication.

## Merge gate

Do not merge on historical #584 results. A fresh complete CI graph for `cd723461de78082a728121042437809cf9c6790c` is required, including a real `aarch64-darwin` `terraform-ci-matrix` job on a native Darwin runner. This PR does not authorize a deployment or main/dev synchronization.