### PR TITLE
eph-win-x64: provision git and Git Bash before the runner starts

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -20,6 +20,7 @@
     ./garm-incus-runner-host.nix
     ./garm-macos-runner-install-wrapper.nix
     ./garm-provider-vmharness-protocol.nix
+    ./garm-provider-vmharness-windows-toolchain.nix
     ./s3-artifact-store.nix
     ./repro-binary-cache-systemd.nix
     ./repro-binary-cache-cross-host.nix

--- a/checks/garm-provider-vmharness-windows-toolchain.nix
+++ b/checks/garm-provider-vmharness-windows-toolchain.nix
@@ -1,0 +1,33 @@
+{ ... }:
+{
+  # The Windows guest-provisioning tests in `internal/provider` were written to
+  # pin one thing that cannot be recovered later: `Initialize-RunnerToolchain`
+  # must run BEFORE `Runner.Listener` starts, because actions/checkout is the
+  # first step of a job and inherits whatever PATH the runner was launched with.
+  # Provisioning that happens afterwards satisfies every content assertion and
+  # still leaves checkout without git, silently degrading it to a REST-API zip
+  # download with no submodules, no history and no LFS.
+  #
+  # Nothing ran those tests. `packages/garm-provider-vmharness/default.nix` sets
+  # `doCheck = false`, and no workflow invokes `go test` for this package, so the
+  # suite existed without ever executing -- a check that cannot report anything
+  # is the same class of defect it was written to catch.
+  #
+  # This mirrors `garm-macos-runner-install-wrapper.nix`, which already enables
+  # `doCheck` on a sibling package for exactly this reason. The tests are pure
+  # template rendering: no network, no daemon, no guest.
+  perSystem =
+    { self', ... }:
+    {
+      checks.t_garm_provider_vmharness_windows_toolchain =
+        self'.packages.garm-provider-vmharness.overrideAttrs
+          (_old: {
+            doCheck = true;
+            checkPhase = ''
+              runHook preCheck
+              go test ./internal/provider
+              runHook postCheck
+            '';
+          });
+    };
+}

--- a/packages/garm-provider-vmharness/src/internal/provider/provider.go
+++ b/packages/garm-provider-vmharness/src/internal/provider/provider.go
@@ -610,6 +610,125 @@ function Send-SystemInfo {
 	}
 }
 
+# The eph-win-x64 golden ships neither git nor bash. That breaks two
+# separate things, and only one of them can be fixed by a workflow step:
+#
+#   * every 'shell: bash' step dies with "bash: command not found";
+#   * actions/checkout finds no git and silently degrades to a REST-API zip
+#     download, which has no submodules, no history, and no LFS.
+#
+# The second is why this belongs HERE rather than in a workflow. actions/
+# checkout is normally the first step of a job, so no action of ours runs
+# before it -- but this template does. It executes in the guest during
+# provisioning, before Runner.Listener is started, so the PATH it sets is
+# inherited by the runner process and therefore by every step of the job,
+# including checkout.
+#
+# The image itself remains the right long-term home for these tools (see
+# guest-recipes/windows-x64-base/cloudbase-init-golden.md); this template
+# stays correct either way, because it installs only when the tools are
+# absent and otherwise just verifies. When a golden that ships git lands,
+# this becomes a cheap assertion rather than a download.
+#
+# The pin below is the same PortableGit the persistent win-ci-vm-001 runner
+# already uses (infra machines/server/_win-ci-vm-001/system_windows_runner.nim);
+# keeping one pin for both Windows runner classes means one thing to bump.
+# PortableGit rather than MinGit: MinGit satisfies actions/checkout and still
+# leaves every bash step dead, which is exactly the half-fix to avoid.
+$PortableGitVersion = '2.47.1'
+$PortableGitName = "PortableGit-$PortableGitVersion-64-bit.7z.exe"
+$PortableGitUrl = "https://github.com/git-for-windows/git/releases/download/v$PortableGitVersion.windows.1/$PortableGitName"
+$PortableGitSha256 = '4f3f21f4effcb659566883ee1ed3ae403e5b3d7a0699cee455f6cd765e1ac39c'
+$PortableGitInstallDir = 'C:\PortableGit'
+
+function Test-RunnerToolchain {
+	$git = Get-Command git -ErrorAction SilentlyContinue
+	if ($null -eq $git) {
+		return $false
+	}
+	$bash = Get-Command bash -ErrorAction SilentlyContinue
+	if ($null -eq $bash) {
+		return $false
+	}
+	# A bash.exe that is the WSL stub in System32 is worse than none: it is on
+	# PATH, it launches, and it fails only once a step tries to use it.
+	if ($bash.Source -like "$env:SystemRoot\System32\*") {
+		return $false
+	}
+	return $true
+}
+
+function Add-RunnerPathEntry {
+	param([string]$Entry)
+	if (-not (Test-Path -LiteralPath $Entry -PathType Container)) {
+		Fail-Install "refusing to add a non-directory to PATH: $Entry"
+	}
+	$machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+	$entries = @()
+	if (-not [string]::IsNullOrWhiteSpace($machinePath)) {
+		$entries = $machinePath.Split(';') | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+	}
+	if ($entries -notcontains $Entry) {
+		$updated = (@($Entry) + $entries) -join ';'
+		[Environment]::SetEnvironmentVariable('Path', $updated, 'Machine')
+	}
+	# The machine PATH alone does not reach this already-running process, and
+	# run.cmd inherits from this process. Set both.
+	$env:PATH = "$Entry;$env:PATH"
+}
+
+function Install-RunnerToolchain {
+	Send-Status -Status 'installing' -Message 'installing git and Git Bash'
+	$archive = Join-Path $env:TEMP $PortableGitName
+	Invoke-FileDownload -Uri $PortableGitUrl -Destination $archive
+	$actualHash = (Get-FileHash -Algorithm SHA256 -Path $archive).Hash.ToLowerInvariant()
+	if ($actualHash -ne $PortableGitSha256.ToLowerInvariant()) {
+		Remove-Item -Force $archive -ErrorAction SilentlyContinue
+		Fail-Install "PortableGit checksum mismatch: expected $PortableGitSha256 got $actualHash"
+	}
+	Remove-Item -Recurse -Force $PortableGitInstallDir -ErrorAction SilentlyContinue
+	# PortableGit ships as a 7-Zip self-extractor; -y -o<dir> extracts silently.
+	$process = Start-Process -FilePath $archive -ArgumentList '-y', "-o$PortableGitInstallDir" -Wait -PassThru -NoNewWindow
+	Remove-Item -Force $archive -ErrorAction SilentlyContinue
+	if ($process.ExitCode -ne 0) {
+		Fail-Install "PortableGit extraction failed with exit code $($process.ExitCode)"
+	}
+	foreach ($sub in @('cmd', 'bin')) {
+		Add-RunnerPathEntry (Join-Path $PortableGitInstallDir $sub)
+	}
+}
+
+function Initialize-RunnerToolchain {
+	if (-not (Test-RunnerToolchain)) {
+		Install-RunnerToolchain
+	}
+	# Verify what is actually present rather than trusting either branch above.
+	# An install that reported success but left the tools unusable is the same
+	# silent-no-op class this whole block exists to end, so prove both tools
+	# RUN -- Get-Command only proves a file was found.
+	if (-not (Test-RunnerToolchain)) {
+		Fail-Install 'git and Git Bash are still not on PATH after provisioning'
+	}
+	try {
+		$gitVersion = (& git --version 2>&1 | Out-String).Trim()
+	} catch {
+		Fail-Install "git is on PATH but not executable: $($_.Exception.Message)"
+	}
+	try {
+		$bashVersion = (& bash --version 2>&1 | Select-Object -First 1 | Out-String).Trim()
+	} catch {
+		Fail-Install "bash is on PATH but not executable: $($_.Exception.Message)"
+	}
+	if ([string]::IsNullOrWhiteSpace($gitVersion)) {
+		Fail-Install 'git --version produced no output'
+	}
+	if ([string]::IsNullOrWhiteSpace($bashVersion)) {
+		Fail-Install 'bash --version produced no output'
+	}
+	Write-Host "runner toolchain verified: $gitVersion"
+	Write-Host "runner toolchain verified: $bashVersion"
+}
+
 if ([string]::IsNullOrWhiteSpace($MetadataURL)) {
 	Fail-Install 'missing metadata URL'
 }
@@ -619,6 +738,11 @@ if ([string]::IsNullOrWhiteSpace($CallbackURL)) {
 
 New-Item -ItemType Directory -Force -Path $RunHome | Out-Null
 Set-Location $RunHome
+
+# Before the runner exists, and therefore before any job step -- including
+# actions/checkout, which runs before any action of ours and is the reason this
+# cannot be solved by a workflow step.
+Initialize-RunnerToolchain
 
 if (-not (Test-Path (Join-Path $RunHome 'run.cmd'))) {
 	Send-Status -Status 'installing' -Message "downloading tools from {{ .DownloadURL }}"

--- a/packages/garm-provider-vmharness/src/internal/provider/provider_macos_test.go
+++ b/packages/garm-provider-vmharness/src/internal/provider/provider_macos_test.go
@@ -18,6 +18,32 @@ import (
 
 func strptr(v string) *string { return &v }
 
+// assertNothingDetached enforces what the old blanket ban on the substring
+// "Start-Process" was standing in for: nothing in a FOREGROUND bootstrap
+// template may be launched and left running.
+//
+// The blanket ban was a proxy, and it became a false positive the moment the
+// template legitimately needed to run a synchronous helper process (extracting
+// the pinned PortableGit self-extractor, which PowerShell's call operator does
+// not wait for because the extractor is a GUI subsystem binary). Banning a
+// cmdlet name is not the same as forbidding detachment, so assert the actual
+// property: every Start-Process is waited on.
+//
+// The runner's own foreground launch stays pinned independently, by the
+// positive assertions on the ComSpec/run.cmd line, $LASTEXITCODE capture, and
+// the non-zero-exit Fail-Install, all of which remain unchanged.
+func assertNothingDetached(t *testing.T, text string) {
+	t.Helper()
+	for _, line := range strings.Split(text, "\n") {
+		if !strings.Contains(line, "Start-Process") {
+			continue
+		}
+		if !strings.Contains(line, "-Wait") {
+			t.Fatalf("bootstrap starts a process without -Wait (detached):\n%s", line)
+		}
+	}
+}
+
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
@@ -145,7 +171,6 @@ func TestQemuWindowsArmBootstrapUsesWindowsPath(t *testing.T) {
 		"New-Service",
 		"RunnerService.exe",
 		"Get-MetadataFile -Path 'credentials/credentials_rsaparams'",
-		"Start-Process",
 		"$encodedBytes",
 		"[Text.Encoding]::UTF8.GetBytes($rsaResponse.Content)",
 		"[System.Text.Encoding]::UTF8.GetBytes($rsaResponse.Content)",
@@ -222,9 +247,7 @@ func TestQemuWindowsArmBootstrapUsesGuestURLOverrides(t *testing.T) {
 			t.Fatalf("qemu Windows ARM bootstrap missing override %q:\n%s", want, text)
 		}
 	}
-	if strings.Contains(text, "Start-Process") {
-		t.Fatalf("qemu Windows ARM bootstrap detaches runner instead of running it in foreground:\n%s", text)
-	}
+	assertNothingDetached(t, text)
 	if strings.Contains(text, "/metadata/install-script/") {
 		t.Fatalf("qemu Windows ARM bootstrap still relies on GARM second-stage install script:\n%s", text)
 	}
@@ -392,9 +415,7 @@ powershell.exe -Sta -NonInteractive -ExecutionPolicy RemoteSigned -File $install
 			t.Fatalf("CreateInstance bootstrap missing override %q:\n%s", want, text)
 		}
 	}
-	if strings.Contains(text, "Start-Process") {
-		t.Fatalf("CreateInstance bootstrap detaches runner instead of running it in foreground:\n%s", text)
-	}
+	assertNothingDetached(t, text)
 	if strings.Contains(text, "/metadata/install-script/") {
 		t.Fatalf("CreateInstance bootstrap still relies on GARM second-stage install script:\n%s", text)
 	}

--- a/packages/garm-provider-vmharness/src/internal/provider/provider_windows_toolchain_test.go
+++ b/packages/garm-provider-vmharness/src/internal/provider/provider_windows_toolchain_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Metacraft Labs
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	commonParams "github.com/cloudbase/garm-provider-common/params"
+)
+
+// The eph-win-x64 golden ships neither git nor bash. Two distinct things break:
+//
+//   - every `shell: bash` step dies with "bash: command not found";
+//   - actions/checkout finds no git and silently degrades to a REST-API zip
+//     download -- no submodules, no history, no LFS -- while still reporting
+//     success, so the lane looks green until something downstream needs what
+//     the zip did not contain.
+//
+// The second is why the fix lives in this template rather than in a workflow:
+// actions/checkout is the first step of a job, so no action of ours runs before
+// it. This template does -- it executes in the guest during provisioning,
+// before Runner.Listener starts -- so the PATH it establishes is inherited by
+// the runner and by every step, checkout included.
+//
+// These tests pin that behaviour. The ordering assertion is the load-bearing
+// one: provisioning that happened AFTER the runner started would satisfy every
+// content check here and still leave checkout without git.
+
+func windowsBootstrapText(t *testing.T) string {
+	t.Helper()
+	params := commonParams.BootstrapInstance{
+		Name:             "garm-win-x64-1",
+		RepoURL:          "https://github.com/example-org/example-repo",
+		CallbackURL:      "http://192.168.122.1:9997/api/v1/callbacks",
+		MetadataURL:      "http://192.168.122.1:9997/api/v1/metadata",
+		InstanceToken:    "instance-token",
+		OSType:           commonParams.Windows,
+		OSArch:           commonParams.Amd64,
+		Labels:           []string{"self-hosted", "windows", "x64", "eph-win-x64"},
+		JitConfigEnabled: true,
+		Tools: []commonParams.RunnerApplicationDownload{
+			{
+				OS:           strptr("win"),
+				Architecture: strptr("x64"),
+				DownloadURL:  strptr("https://example.invalid/actions-runner-win-x64.zip"),
+				Filename:     strptr("actions-runner-win-x64.zip"),
+			},
+		},
+	}
+	tools, err := pickTools(params)
+	if err != nil {
+		t.Fatalf("pickTools: %v", err)
+	}
+	rendered, err := renderRunnerInstallTemplate(
+		"windows-foreground",
+		windowsForegroundRunnerInstallTemplate,
+		runnerInstallTemplateDataFrom(params, tools, params.Name),
+	)
+	if err != nil {
+		t.Fatalf("renderRunnerInstallTemplate: %v", err)
+	}
+	return string(rendered)
+}
+
+// TestWindowsBootstrapProvisionsGitAndBash pins the content of the toolchain
+// provisioning: what is installed, that it is pinned and digest-verified, and
+// that both PATH entries are established.
+func TestWindowsBootstrapProvisionsGitAndBash(t *testing.T) {
+	text := windowsBootstrapText(t)
+
+	for _, want := range []string{
+		// Pinned version + digest. An unpinned or unverified download into a
+		// CI runner's SYSTEM PATH is remote code execution with extra steps.
+		"$PortableGitVersion = '2.47.1'",
+		"$PortableGitSha256 = '4f3f21f4effcb659566883ee1ed3ae403e5b3d7a0699cee455f6cd765e1ac39c'",
+		"https://github.com/git-for-windows/git/releases/download/v$PortableGitVersion.windows.1/$PortableGitName",
+		// The digest must be checked and must abort on mismatch.
+		"$actualHash = (Get-FileHash -Algorithm SHA256 -Path $archive).Hash.ToLowerInvariant()",
+		"Fail-Install \"PortableGit checksum mismatch: expected $PortableGitSha256 got $actualHash\"",
+		// Both directories: cmd/ carries git.exe, bin/ carries bash.exe. One
+		// without the other is the half-fix this exists to avoid.
+		"foreach ($sub in @('cmd', 'bin')) {",
+		"Add-RunnerPathEntry (Join-Path $PortableGitInstallDir $sub)",
+		// The machine PATH does not reach the already-running process that
+		// launches run.cmd, so the process PATH must be set too.
+		"$env:PATH = \"$Entry;$env:PATH\"",
+		"[Environment]::SetEnvironmentVariable('Path', $updated, 'Machine')",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("windows bootstrap missing %q:\n%s", want, text)
+		}
+	}
+
+	// MinGit satisfies actions/checkout and still leaves every bash step dead.
+	// Pinning PortableGit explicitly keeps a future "smaller download" refactor
+	// from reintroducing exactly that half-fix.
+	//
+	// Scoped to executable lines: the template's own PowerShell comments explain
+	// why MinGit is rejected, and a substring search over the whole rendered
+	// text would fire on that explanation. Checking the comment rather than the
+	// code is the failure mode these tests exist to avoid, so check the code.
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(trimmed, "MinGit") {
+			t.Fatalf("windows bootstrap uses MinGit, which ships no Git Bash:\n%s", line)
+		}
+	}
+}
+
+// TestWindowsBootstrapVerifiesToolchainRatherThanAssumingIt is the guard
+// against this provisioning becoming the same silent no-op it fixes: an
+// install that "succeeded" but left the tools unusable must fail the runner,
+// not proceed into a job that will fail confusingly much later.
+func TestWindowsBootstrapVerifiesToolchainRatherThanAssumingIt(t *testing.T) {
+	text := windowsBootstrapText(t)
+
+	for _, want := range []string{
+		// Re-check after provisioning, whichever branch was taken.
+		"Fail-Install 'git and Git Bash are still not on PATH after provisioning'",
+		// Presence on PATH is not usability: both tools must actually run.
+		"$gitVersion = (& git --version 2>&1 | Out-String).Trim()",
+		"$bashVersion = (& bash --version 2>&1 | Select-Object -First 1 | Out-String).Trim()",
+		"Fail-Install 'git --version produced no output'",
+		"Fail-Install 'bash --version produced no output'",
+		// A System32 bash.exe is the WSL launcher stub: on PATH, launches, and
+		// fails only once a step tries to use it. Worse than absent.
+		"if ($bash.Source -like \"$env:SystemRoot\\System32\\*\") {",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("windows bootstrap missing verification %q:\n%s", want, text)
+		}
+	}
+}
+
+// TestWindowsBootstrapProvisionsToolchainBeforeRunnerStarts is the assertion
+// that actually makes actions/checkout work. Content alone is not enough: the
+// toolchain must be on PATH before Runner.Listener is launched, because the
+// runner inherits this process's environment and checkout runs before any
+// action of ours could intervene.
+func TestWindowsBootstrapProvisionsToolchainBeforeRunnerStarts(t *testing.T) {
+	text := windowsBootstrapText(t)
+
+	const invocation = "\nInitialize-RunnerToolchain\n"
+	invocationAt := strings.Index(text, invocation)
+	if invocationAt < 0 {
+		t.Fatalf("windows bootstrap never CALLS Initialize-RunnerToolchain; "+
+			"defining it is not running it, and an uncalled function leaves "+
+			"checkout without git:\n%s", text)
+	}
+
+	runnerAt := strings.Index(text, `& "$env:ComSpec" /d /c run.cmd`)
+	if runnerAt < 0 {
+		t.Fatalf("windows bootstrap does not launch run.cmd in the foreground:\n%s", text)
+	}
+
+	if invocationAt > runnerAt {
+		t.Fatalf("Initialize-RunnerToolchain runs at offset %d, after the runner "+
+			"starts at offset %d; every job step, including actions/checkout, "+
+			"would already have been handed a PATH without git", invocationAt, runnerAt)
+	}
+
+	// It must also precede the runner *download*, so a broken toolchain fails
+	// fast rather than after a multi-hundred-MB fetch.
+	if downloadAt := strings.Index(text, "downloading tools from"); downloadAt >= 0 && invocationAt > downloadAt {
+		t.Fatalf("Initialize-RunnerToolchain runs after the runner download; "+
+			"a guest that cannot be provisioned should fail before that work "+
+			"(toolchain at %d, download at %d)", invocationAt, downloadAt)
+	}
+}
+
+// TestLinuxBootstrapUnaffectedByWindowsToolchain keeps the change scoped: the
+// Linux template must not have grown Windows provisioning.
+func TestLinuxBootstrapUnaffectedByWindowsToolchain(t *testing.T) {
+	if strings.Contains(linuxForegroundRunnerInstallTemplate, "PortableGit") {
+		t.Fatal("the Linux bootstrap template references PortableGit")
+	}
+}


### PR DESCRIPTION
## The problem

The `eph-win-x64` golden ships **neither git nor bash**. Two different things break:

1. Every `shell: bash` step dies with `bash: command not found`. `metacraft-github-actions/setup-dev-env` opens with unconditional `shell: bash` steps, so every Windows job in the org dies at its first one.
2. **`actions/checkout` finds no git and silently degrades** to a REST-API zip download — no submodules, no history, no LFS — while still reporting success.

## Correcting one assumption

The brief for this work said *"a bootstrap step cannot help `actions/checkout`, which runs before any action of ours."* That is true of a **workflow step**, and it is why `codetracer`'s `ci/ensure-git-for-checkout.ps1` has to be the literal first step of every Windows job, pinned in place by a static contract test.

It is **not** true of this template. `windowsForegroundRunnerInstallTemplate` runs **in the guest, during provisioning, before `Runner.Listener` starts**. The runner inherits this process's environment, so the PATH established here reaches every step of every job — `actions/checkout` included. That is why the fix belongs here and not in a workflow.

## Where this belongs long-term

The **image** is still the right home for these tools. But there is no in-repo recipe for it: `eph-win-x64` boots from `/storage/iso/golden-win11-cloudbase.qcow2`, an opaque artifact on high-mem-server produced by a manual operator procedure documented in prose (`vm-harness guest-recipes/windows-x64-base/cloudbase-init-golden.md`). Rebuilding it needs host access this PR does not have.

This template is correct **either way**: it installs only when the tools are absent and otherwise just verifies. The day a golden that ships git lands, this becomes a cheap assertion rather than a download — the same shape as the macOS template's existing `command -v git-lfs || fail "Git LFS is missing from the macOS image"`.

## What it does

- Pinned **PortableGit 2.47.1**, the same pin the persistent `win-ci-vm-001` runner already uses (`infra .../system_windows_runner.nim`), so both Windows classes bump together. Digest independently re-verified against the published asset while writing this.
- **PortableGit, not MinGit.** MinGit satisfies `actions/checkout` and still leaves every bash step dead — precisely the half-fix to avoid. A test forbids reintroducing it.
- **Digest-verified before extraction.** An unverified download onto a CI runner's SYSTEM PATH is remote code execution with extra steps.
- **Verify unconditionally, whichever branch ran.** Presence on PATH is not usability, so both tools must actually execute. A `bash.exe` resolving into `System32` is rejected — that is the WSL launcher stub, which is on PATH and launches, so an existence check passes while every step still fails.

## Tests

`provider_windows_toolchain_test.go` pins content, verification, and — the load-bearing one — **ordering**: provisioning that ran *after* the runner started would satisfy every content assertion and still leave checkout without git.

Mutation-verified:

| Mutation | Result |
| --- | --- |
| Call site dropped (function defined, never called) | `TestWindowsBootstrapProvisionsToolchainBeforeRunnerStarts` fails |
| Checksum check replaced with a warning | `TestWindowsBootstrapProvisionsGitAndBash` fails |
| Unmutated | full `internal/provider` suite green |

The first mutation is not hypothetical — it is a mistake actually made while writing this PR, which the test caught.

## One existing assertion narrowed — please review this specifically

Three tests banned the **substring** `Start-Process` as a proxy for *"the runner is launched detached"*. Extracting the pinned self-extractor needs a synchronous child process (PowerShell's call operator does not wait for a GUI-subsystem binary), so that proxy became a false positive.

Rather than deleting it, the property is now asserted directly: **every `Start-Process` must be `-Wait`-ed**. The runner's own foreground launch stays pinned independently by the unchanged positive assertions on the `ComSpec`/`run.cmd` line, the `$LASTEXITCODE` capture, and the non-zero-exit `Fail-Install`.

## Consumer-side verification

Companion PR on `infra` adds git/bash assertions to the `eph-win-x64` fleet self-test, which currently checks neither — which is why it stayed green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)