### PR TITLE
garm: let the libvirt provider emit a <currentMemory> balloon floor

### DIFF
--- a/modules/garm/README.md
+++ b/modules/garm/README.md
@@ -245,7 +245,15 @@ above + `/metrics` served + the declarative egress option.
 - **Provider** is a `[[provider]]` external block pointing at the
   `garm-provider-vmharness` binary + a secret-free provider `config.toml` carrying
   `virsh_path`/`qemu_img_path`/`libvirt_uri`/`network`/`pool_dir`/`uefi_*`/
-  `memory_mb`/`vcpus` + the golden `[images.*]` map (all from module options).
+  `memory_mb`/`vcpus` (plus `current_memory_mb` when a balloon floor is set) +
+  the golden `[images.*]` map (all from module options).
+- **Dynamic memory** (`providers.<name>.currentMemoryMb`, libvirt only): when set,
+  `memory_mb` becomes the guest's ceiling and `current_memory_mb` its virtio-balloon
+  boot target, emitted as `<currentMemory>` plus an explicit
+  `<memballoon model='virtio'/>`. It is a request the guest honours only while
+  running the balloon driver (on Windows: `balloon.sys` + `BLNSVR`) — check with
+  `virsh dommemstat <domain>`, which reports `unused`/`available` only when the
+  guest is really ballooning. The resource guard below still budgets the ceiling.
 
 ---
 

--- a/modules/garm/default.nix
+++ b/modules/garm/default.nix
@@ -116,18 +116,26 @@
           "VMH_QEMU_WINDOWS_ARM_SWTPM_CMD"
           "VM_HARNESS_DARWIN_ASUSER_UID"
         ];
-      mkLibvirtKeys = p: ''
-        virsh_path = "${p.virshPath}"
-        qemu_img_path = "${p.qemuImgPath}"
-        vm_harness_path = "${p.vmHarnessPath}"
-        libvirt_uri = "${p.libvirtURI}"
-        network = "${p.network}"
-        pool_dir = "${p.poolDir}"
-        uefi_loader = "${p.uefiLoader}"
-        uefi_nvram_template = "${p.uefiNvramTemplate}"
-        memory_mb = ${toString p.memoryMb}
-        vcpus = ${toString p.vcpus}
-      '';
+      mkLibvirtKeys =
+        p:
+        ''
+          virsh_path = "${p.virshPath}"
+          qemu_img_path = "${p.qemuImgPath}"
+          vm_harness_path = "${p.vmHarnessPath}"
+          libvirt_uri = "${p.libvirtURI}"
+          network = "${p.network}"
+          pool_dir = "${p.poolDir}"
+          uefi_loader = "${p.uefiLoader}"
+          uefi_nvram_template = "${p.uefiNvramTemplate}"
+          memory_mb = ${toString p.memoryMb}
+          vcpus = ${toString p.vcpus}
+        ''
+        # Only emitted when a balloon floor is actually requested, so providers
+        # that do not use one keep a byte-identical config.toml (and therefore a
+        # byte-identical domain XML) to before this option existed.
+        + optionalString (p.currentMemoryMb > 0) ''
+          current_memory_mb = ${toString p.currentMemoryMb}
+        '';
       mkIncusKeys = p: ''
         incus_path = "${p.incusPath}"
         incus_bridge = "${p.incusBridge}"
@@ -985,6 +993,46 @@
                 Per-job guest RAM (MiB), emitted as `memory_mb`. Also an input to
                 the eval-time resource-guard assertion
                 (`maxRunners * memoryMb <= hostBudget.memoryMb`).
+              '';
+            };
+
+            currentMemoryMb = mkOption {
+              type = types.ints.unsigned;
+              default = 0;
+              example = 8192;
+              description = ''
+                Virtio-balloon BOOT TARGET (MiB) for the per-job libvirt domain,
+                emitted as `current_memory_mb` and rendered as
+                `<currentMemory>` directly below `<memory>` in the domain XML.
+                `0` (the default) omits it entirely.
+
+                What it does: `memoryMb` becomes the CEILING the guest may ever
+                reach, and this becomes the amount it is asked to hold at
+                power-on — the difference is parked in the virtio balloon until
+                the guest asks for it back. That is what makes a large ceiling
+                affordable: an idle job costs the floor, not the ceiling, so a
+                burst of runners cannot pin the host's whole RAM indefinitely.
+
+                Two caveats, both important:
+
+                - It is a REQUEST, not a cap. `<currentMemory>` is honoured only
+                  by a guest running the virtio-balloon driver; a guest without
+                  it silently ignores the target and boots with the full
+                  `memoryMb`. On Windows that means `balloon.sys` plus a running
+                  `BLNSVR` service. Setting this against a guest that lacks them
+                  is inert — it changes the XML and nothing else. Verify with
+                  `virsh dommemstat <domain>`: a guest that is actually
+                  ballooning reports `unused`/`available`, not just
+                  `actual`/`rss`.
+                - It does not relax the resource guard. The eval-time assertion
+                  still budgets `maxRunners * memoryMb`, i.e. the WORST case, on
+                  purpose: the floor is what the host usually pays, but the
+                  ceiling is what it must be able to survive if every runner
+                  fills up at once.
+
+                Must be strictly below `memoryMb` when set (a target at or above
+                the ceiling means an empty balloon); the provider drops such a
+                value and the module asserts against it.
               '';
             };
 
@@ -2182,6 +2230,19 @@
               assertion = cfg.providers ? ${ss.provider};
               message = "services.garm.scaleSets.${n}.provider = \"${ss.provider}\" does not name a declared services.garm.providers.<name> (have: ${lib.concatStringsSep ", " (lib.attrNames cfg.providers)}).";
             }) cfg.scaleSets
+            # W1: a balloon floor must sit strictly BELOW the ceiling it floors,
+            # and only the libvirt backend renders a domain XML to put it in.
+            # Both are eval-time failures rather than silent no-ops: the provider
+            # drops a degenerate value, which would otherwise look like a
+            # working memory floor while every VM quietly boots at its ceiling.
+            ++ lib.mapAttrsToList (n: p: {
+              assertion = p.currentMemoryMb == 0 || p.currentMemoryMb < p.memoryMb;
+              message = "services.garm.providers.${n}: currentMemoryMb (${toString p.currentMemoryMb}) must be strictly below memoryMb (${toString p.memoryMb}) — a balloon boot target at or above the ceiling leaves the balloon empty and is ignored by the provider. Use 0 to disable ballooning.";
+            }) cfg.providers
+            ++ lib.mapAttrsToList (n: p: {
+              assertion = p.currentMemoryMb == 0 || providerIsLibvirt p;
+              message = "services.garm.providers.${n}: currentMemoryMb is only honoured by the libvirt backend (this provider's backend = \"${p.backend}\"); it has no effect on incus containers or vm-harness-run VMs.";
+            }) cfg.providers
             # Resource-guard (eval time): the sum over all scale sets of
             # maxRunners * (its provider's per-VM RAM) must fit the declared host
             # RAM budget, and likewise vCPUs. A bad config FAILS TO EVAL instead

--- a/packages/garm-provider-vmharness/src/internal/backend/backend.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/backend.go
@@ -83,6 +83,13 @@ type CreateArgs struct {
 	// MemoryMB / VCPUs size the domain. Zero => defaults (4096 MiB / 2 vCPU).
 	MemoryMB int
 	VCPUs    int
+	// CurrentMemoryMB is the virtio-balloon BOOT TARGET (<currentMemory>): the
+	// amount the guest is asked to hold at power-on, with MemoryMB - this
+	// parked in the balloon. It is a request, not a cap — a guest without the
+	// balloon driver ignores it and boots with the full MemoryMB. Zero (or any
+	// value outside 0 < n < MemoryMB) means "no target": the domain XML is
+	// emitted exactly as it was before this field existed.
+	CurrentMemoryMB int
 }
 
 // Backend is the seam the provider shells to. Every method is a thin wrapper

--- a/packages/garm-provider-vmharness/src/internal/backend/domainxml.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/domainxml.go
@@ -52,6 +52,36 @@ func buildDomainXML(args CreateArgs, metaInner, configDriveISO string) string {
 		vcpus = 2
 	}
 
+	// W1: dynamic memory. <memory> is the CEILING the domain may ever reach;
+	// <currentMemory> is the balloon's BOOT TARGET, i.e. how much the guest is
+	// asked to hold on to at power-on, with the difference parked in the balloon
+	// until the guest asks for it back. That makes a large ceiling affordable:
+	// the host only pays the floor while the job is idle.
+	//
+	// Two things this is NOT:
+	//   - it is not an enforcement. <currentMemory> is a REQUEST; a guest that
+	//     is not running the virtio-balloon driver simply ignores it and boots
+	//     with the full <memory>. Until the Windows golden ships balloon.sys +
+	//     BLNSVR (campaign milestone W0) this field is inert on Windows guests.
+	//   - it is not a way to overcommit past <memory>. A value at or above the
+	//     EFFECTIVE ceiling (mem, i.e. after the 4096 MiB default is applied) is
+	//     meaningless — the balloon would be empty — and <= 0 means "unset".
+	//
+	// Both of those degenerate cases are dropped, and when the field is unset
+	// the emitted XML is byte-identical to the pre-W1 template — that is the
+	// regression lock that lets W1 land before W0 without reshaping any running
+	// domain. We also declare <memballoon model='virtio'/> explicitly whenever
+	// we emit a target: libvirt adds one by default, but relying on a default
+	// for the device that makes the target achievable is not something the XML
+	// should leave implicit.
+	currentMemLine := ""
+	balloonLine := ""
+	if args.CurrentMemoryMB > 0 && args.CurrentMemoryMB < mem {
+		currentMemLine = fmt.Sprintf("  <currentMemory unit='MiB'>%d</currentMemory>\n",
+			args.CurrentMemoryMB)
+		balloonLine = "    <memballoon model='virtio'/>\n"
+	}
+
 	uefi := args.UEFILoader != ""
 
 	// <os> block: OVMF pflash loader + per-job nvram (UEFI/Windows 11) or a
@@ -122,7 +152,7 @@ func buildDomainXML(args CreateArgs, metaInner, configDriveISO string) string {
 %s
   </metadata>
   <memory unit='MiB'>%d</memory>
-  <vcpu>%d</vcpu>
+%s  <vcpu>%d</vcpu>
 %s%s%s%s  <devices>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
@@ -138,7 +168,7 @@ func buildDomainXML(args CreateArgs, metaInner, configDriveISO string) string {
       <model type='qxl'/>
     </video>
     <console type='pty'/>
-  </devices>
+%s  </devices>
 </domain>
-`, name, metaInner, mem, vcpus, osBlock, features, cpuBlock, clockBlock, source, configDrive, network)
+`, name, metaInner, mem, currentMemLine, vcpus, osBlock, features, cpuBlock, clockBlock, source, configDrive, network, balloonLine)
 }

--- a/packages/garm-provider-vmharness/src/internal/backend/domainxml_test.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/domainxml_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Metacraft Labs
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+// Gate t_domainxml_currentmemory (campaign milestone W1).
+//
+// buildDomainXML is a pure function over CreateArgs, so this gate is fully
+// hermetic: no libvirt, no virsh (not even the mock), no filesystem. It uses no
+// mock objects at all — the unit under test IS the real string builder that
+// feeds `virsh define`.
+//
+// The load-bearing assertion is TestBuildDomainXMLCurrentMemoryUnsetIsByteIdentical:
+// it pins the ENTIRE pre-W1 rendering as a literal, so adding the
+// <currentMemory>/<memballoon> lines cannot perturb the XML of any domain that
+// does not ask for a balloon target. That is what lets W1 land before W0
+// (the guest-side balloon driver) without reshaping running VMs.
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+// baseArgs is the plainest domain the builder can render: no UEFI, no
+// config-drive, no explicit disk overlay. Kept minimal so the byte-identical
+// golden below stays readable.
+func baseArgs() CreateArgs {
+	return CreateArgs{
+		Name:        "garm-win-0001",
+		SourceImage: "/var/lib/libvirt/images/win11-golden.qcow2",
+		Network:     "garmnet",
+		MemoryMB:    8192,
+		VCPUs:       4,
+	}
+}
+
+// wantPreW1 is the EXACT XML buildDomainXML emitted before W1 for baseArgs()
+// with metaInner "<meta/>" and no config-drive. Transcribed from the pre-W1
+// template; any drift here is a real change in the shape of every domain the
+// provider defines.
+const wantPreW1 = `<domain type='kvm'>
+  <name>garm-win-0001</name>
+  <metadata>
+<meta/>
+  </metadata>
+  <memory unit='MiB'>8192</memory>
+  <vcpu>4</vcpu>
+  <os>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <devices>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/win11-golden.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <interface type='network'>
+      <source network='garmnet'/>
+      <model type='virtio'/>
+    </interface>
+    <graphics type='vnc' port='-1'/>
+    <video>
+      <model type='qxl'/>
+    </video>
+    <console type='pty'/>
+  </devices>
+</domain>
+`
+
+// TestBuildDomainXMLCurrentMemoryUnsetIsByteIdentical is the regression lock:
+// with CurrentMemoryMB left at its zero value the output must equal the pre-W1
+// rendering byte for byte.
+func TestBuildDomainXMLCurrentMemoryUnsetIsByteIdentical(t *testing.T) {
+	got := buildDomainXML(baseArgs(), "<meta/>", "")
+	if got != wantPreW1 {
+		t.Errorf("domain XML changed shape with CurrentMemoryMB unset.\n--- got ---\n%s\n--- want ---\n%s",
+			got, wantPreW1)
+	}
+}
+
+// TestBuildDomainXMLCurrentMemorySet checks the whole-document rendering when a
+// balloon target below the ceiling is requested: <currentMemory> immediately
+// after <memory>, and an explicit <memballoon model='virtio'/> in <devices>.
+// Asserted as a full-document comparison (not a substring probe) so a target
+// emitted in the wrong place fails.
+func TestBuildDomainXMLCurrentMemorySet(t *testing.T) {
+	args := baseArgs()
+	args.CurrentMemoryMB = 2048
+
+	want := strings.Replace(wantPreW1,
+		"  <memory unit='MiB'>8192</memory>\n",
+		"  <memory unit='MiB'>8192</memory>\n  <currentMemory unit='MiB'>2048</currentMemory>\n",
+		1)
+	want = strings.Replace(want,
+		"    <console type='pty'/>\n",
+		"    <console type='pty'/>\n    <memballoon model='virtio'/>\n",
+		1)
+
+	got := buildDomainXML(args, "<meta/>", "")
+	if got != want {
+		t.Errorf("domain XML with CurrentMemoryMB=2048 mismatch.\n--- got ---\n%s\n--- want ---\n%s",
+			got, want)
+	}
+}
+
+// TestBuildDomainXMLCurrentMemoryDegenerate covers every value that must NOT
+// produce a balloon target: unset, negative, exactly the ceiling, and above the
+// ceiling (a target >= <memory> would mean an empty balloon, so it is dropped
+// rather than emitted as a no-op). All must render the pre-W1 XML.
+func TestBuildDomainXMLCurrentMemoryDegenerate(t *testing.T) {
+	cases := []struct {
+		name    string
+		current int
+	}{
+		{"unset", 0},
+		{"negative", -1},
+		{"equal to ceiling", 8192},
+		{"above ceiling", 16384},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := baseArgs()
+			args.CurrentMemoryMB = tc.current
+			got := buildDomainXML(args, "<meta/>", "")
+			if strings.Contains(got, "currentMemory") {
+				t.Errorf("CurrentMemoryMB=%d emitted <currentMemory>, want it omitted:\n%s",
+					tc.current, got)
+			}
+			if strings.Contains(got, "memballoon") {
+				t.Errorf("CurrentMemoryMB=%d emitted <memballoon>, want it omitted:\n%s",
+					tc.current, got)
+			}
+			if got != wantPreW1 {
+				t.Errorf("CurrentMemoryMB=%d changed the XML.\n--- got ---\n%s\n--- want ---\n%s",
+					tc.current, got, wantPreW1)
+			}
+		})
+	}
+}
+
+// TestBuildDomainXMLCurrentMemoryAgainstDefaultCeiling pins the interaction
+// with the builder's own MemoryMB default: when MemoryMB is unset the ceiling
+// is 4096, so a target must be compared against the EFFECTIVE ceiling, not
+// against the zero the caller passed. 2048 is below it (emitted); 4096 is not
+// (dropped).
+func TestBuildDomainXMLCurrentMemoryAgainstDefaultCeiling(t *testing.T) {
+	args := baseArgs()
+	args.MemoryMB = 0
+	args.CurrentMemoryMB = 2048
+	got := buildDomainXML(args, "<meta/>", "")
+	if !strings.Contains(got, "  <memory unit='MiB'>4096</memory>\n  <currentMemory unit='MiB'>2048</currentMemory>\n") {
+		t.Errorf("target below the DEFAULT ceiling was not emitted:\n%s", got)
+	}
+
+	args.CurrentMemoryMB = 4096
+	got = buildDomainXML(args, "<meta/>", "")
+	if strings.Contains(got, "currentMemory") {
+		t.Errorf("target equal to the DEFAULT ceiling should be dropped:\n%s", got)
+	}
+}
+
+// TestBuildDomainXMLCurrentMemoryUEFIPath checks the target survives the other
+// major rendering path (OVMF pflash + hyperv + config-drive), where several
+// optional blocks sit between <memory> and <devices>. This is the path the real
+// Windows runners take.
+func TestBuildDomainXMLCurrentMemoryUEFIPath(t *testing.T) {
+	args := baseArgs()
+	args.DiskSource = "/var/lib/libvirt/images/garm-win-0001.overlay.qcow2"
+	args.UEFILoader = "/run/libvirt/nix-ovmf/edk2-x86_64-code.fd"
+	args.UEFINVRAM = "/var/lib/libvirt/images/garm-win-0001.nvram.fd"
+	args.UEFINVRAMTemplate = "/run/libvirt/nix-ovmf/edk2-i386-vars.fd"
+	args.CurrentMemoryMB = 8192
+	args.MemoryMB = 65536
+
+	got := buildDomainXML(args, "<meta/>", "/var/lib/libvirt/images/garm-win-0001.iso")
+
+	if !strings.Contains(got, "  <memory unit='MiB'>65536</memory>\n  <currentMemory unit='MiB'>8192</currentMemory>\n  <vcpu>4</vcpu>\n") {
+		t.Errorf("UEFI path: <currentMemory> not emitted between <memory> and <vcpu>:\n%s", got)
+	}
+	if !strings.Contains(got, "    <memballoon model='virtio'/>\n  </devices>\n") {
+		t.Errorf("UEFI path: <memballoon> not emitted inside <devices>:\n%s", got)
+	}
+	// The balloon must not have displaced the UEFI/config-drive rendering.
+	if !strings.Contains(got, "<loader readonly='yes' type='pflash' format='raw'>") ||
+		!strings.Contains(got, "<smm state='on'/>") ||
+		!strings.Contains(got, "device='cdrom'") {
+		t.Errorf("UEFI path: expected blocks missing:\n%s", got)
+	}
+}

--- a/packages/garm-provider-vmharness/src/internal/backend/virsh.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/virsh.go
@@ -72,6 +72,9 @@ type VirshBackend struct {
 	// MemoryMB / VCPUs size the per-job domain (0 => builder defaults).
 	MemoryMB int
 	VCPUs    int
+	// CurrentMemoryMB is the balloon boot target handed to buildDomainXML (0 =>
+	// no <currentMemory>, and the domain XML keeps its pre-W1 shape).
+	CurrentMemoryMB int
 }
 
 // overlayPath is the per-job CoW overlay file (next to the config-drive so
@@ -167,6 +170,9 @@ func (v *VirshBackend) Create(ctx context.Context, args CreateArgs) (Instance, e
 		}
 		if args.VCPUs == 0 {
 			args.VCPUs = v.VCPUs
+		}
+		if args.CurrentMemoryMB == 0 {
+			args.CurrentMemoryMB = v.CurrentMemoryMB
 		}
 	}
 

--- a/packages/garm-provider-vmharness/src/internal/config/config.go
+++ b/packages/garm-provider-vmharness/src/internal/config/config.go
@@ -108,6 +108,15 @@ type Config struct {
 	MemoryMB int `toml:"memory_mb"`
 	VCPUs    int `toml:"vcpus"`
 
+	// CurrentMemoryMB is the virtio-balloon boot target (<currentMemory>) for
+	// the per-job domain: MemoryMB becomes a ceiling and this the floor the
+	// guest starts at, the rest parked in the balloon. Zero (the default, and
+	// anything not strictly between 0 and MemoryMB) omits <currentMemory>
+	// entirely, leaving the domain XML exactly as it was before. Note this is a
+	// request the guest must honour via the virtio-balloon driver, not an
+	// enforced cap.
+	CurrentMemoryMB int `toml:"current_memory_mb"`
+
 	// LibvirtURI is the libvirt connection URI (eg: "qemu:///system"). Passed
 	// to virsh as `-c`.
 	LibvirtURI string `toml:"libvirt_uri"`

--- a/packages/garm-provider-vmharness/src/internal/provider/provider.go
+++ b/packages/garm-provider-vmharness/src/internal/provider/provider.go
@@ -70,6 +70,7 @@ func NewWithConfig(cfg *config.Config) (*Provider, error) {
 			UEFINVRAMTemplate: cfg.UEFINVRAMTemplate,
 			MemoryMB:          cfg.MemoryMB,
 			VCPUs:             cfg.VCPUs,
+			CurrentMemoryMB:   cfg.CurrentMemoryMB,
 		}
 	case config.BackendIncus:
 		b = &backend.IncusBackend{


### PR DESCRIPTION
Milestone **W1** of [Windows-Runner-Memory-And-Org-Coverage](https://github.com/metacraft-labs/reprobuild-specs).

Adds `services.garm.providers.<name>.currentMemoryMb`, so a libvirt provider can declare a **boot target below its ceiling** — the floor half of dynamic memory.

## Why

The ephemeral Windows runners are pinned at a hard 8 GiB (`memoryMb = 8192`, unchanged since 2026-07-06). Measured host RSS on a live job VM was 8.1 GiB against that 8 GiB allocation, so the cap is genuinely binding. The goal is a 64 GiB ceiling made affordable by ballooning rather than a static raise — a static raise would swap a hard cap for two VMs that drift to 64 GiB each and never give memory back.

`<currentMemory>` is a **request**, not a cap. It is inert until the guest runs the virtio-balloon driver, which is milestone W0. Today `virsh dommemstat` on a running job VM returns only `actual`/`rss` with no `unused`, confirming the device is attached and unused.

## Safety

**No caller sets it.** Default 0 ⇒ nothing emitted ⇒ no running VM changes shape. `memoryMb` is not raised anywhere in this PR (that is W2, and it stays blocked on W0).

Two eval-time assertions reject `currentMemoryMb >= memoryMb` and `currentMemoryMb` on a non-libvirt backend. The Go side silently *drops* a degenerate value, which would read as a working floor while every VM booted at its ceiling — failing at eval is preferable.

## Verification

Gate `t_domainxml_currentmemory` — hermetic, no mocks (`buildDomainXML` is pure). 5 tests / 8 cases, no skips.

The regression lock is the important half: with the option unset the emitted XML must be **byte-identical** to pre-W1 output. That was verified by rendering the same args through `git archive HEAD` (pre-change) and the patched tree and `cmp`-ing — identical across the plain (727 bytes), UEFI + config-drive, and default-ceiling paths. The test's golden literal was then itself compared against the old renderer's real output, so it is pinned to old behaviour rather than transcribed from new code.

A review agent mutation-tested the implementation four ways — dropping the `0 < n < mem` guard, `<` → `<=`, removing `<memballoon>`, and comparing against `args.MemoryMB` instead of the effective ceiling. Every mutation was caught by the gate.

`go test ./...`, `go vet ./...`, `gofmt -l` and `nixfmt --check` clean; `nix build .#garm-provider-vmharness` succeeds; high-mem-server evaluates. The Nix side was checked by rendering the provider `config.toml` before and after — `garm-provider-win.toml` still reads `memory_mb = 8192` with no `current_memory_mb`, and the `writeText` store hashes are unchanged.

## Known gap (pre-existing, not introduced here)

The gate is **not** wired into `nix flake check` — the package sets `doCheck = false`, and the four sibling `_test.go` files in `internal/backend` are equally unwired. The regression lock therefore only holds if someone runs `go test ./...`. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)