### PR TITLE
setup-nix: restore service utility paths portably

### DIFF
--- a/.github/setup-nix/tests/verify-nix-config-test.sh
+++ b/.github/setup-nix/tests/verify-nix-config-test.sh
@@ -23,6 +23,13 @@
 # The suite additionally asserts that action.yml actually INVOKES the guard, so
 # deleting the step from the action fails this test rather than quietly
 # restoring the original silent-success behaviour.
+#
+# The native-Darwin service-PATH regression uses real executables rather than
+# mocks: a temporary bin directory contains the real Nix and every external
+# utility the guard uses except grep. A mutation with the portability bootstrap
+# removed must reproduce the old false missing-feature report, then the real
+# guard must pass under that identical PATH. This proves both that the fixture
+# can trigger the defect and that the fix covers the service environment.
 
 set -euo pipefail
 
@@ -100,6 +107,177 @@ if NIX_CONFIG="experimental-features = $healthy_features" \
 else
   fail "guard rejected a correctly configured Nix — it would block healthy jobs"
 fi
+
+# ---------------------------------------------------------------------------
+# 2a. Native-Darwin runner services may omit /usr/bin from PATH.
+#
+# Retain the real Nix and every other external utility used by the guard, but
+# deliberately omit grep. This is the precise environment from the failing
+# native-Darwin jobs: Nix reports all requested features as effective, while the
+# guard used to turn `grep: command not found` into a false missing-feature
+# report. The vulnerable mutation proves this fixture kills the old code before
+# the fixed guard is allowed to establish the positive result.
+# ---------------------------------------------------------------------------
+portable_fixture_root="$(mktemp -d)"
+portable_fixture_bin="$portable_fixture_root/bin"
+vulnerable_guard="$portable_fixture_root/verify-nix-config-without-path-bootstrap.sh"
+no_system_path_guard="$portable_fixture_root/verify-nix-config-without-system-paths.sh"
+selected_nix_marker="$portable_fixture_root/selected-nix-used"
+selected_nix_real="$(command -v nix)"
+mkdir "$portable_fixture_bin"
+trap 'rm -rf "$portable_fixture_root"' EXIT
+
+for portable_fixture_utility in mktemp rm cat sed sort tr; do
+  portable_fixture_utility_path="$(command -v "$portable_fixture_utility")"
+  ln -s "$portable_fixture_utility_path" "$portable_fixture_bin/$portable_fixture_utility"
+done
+
+# Delegate to the real Nix, while leaving evidence that the guard preserved the
+# incoming PATH's selected Nix instead of replacing it with one from a profile.
+{
+  printf '#!%s\n' "$BASH"
+  cat <<'EOF'
+if [ -n "${SETUP_NIX_SELECTED_NIX_MARKER:-}" ]; then
+  printf 'used\n' >>"$SETUP_NIX_SELECTED_NIX_MARKER"
+fi
+exec "$SETUP_NIX_SELECTED_NIX_REAL" "$@"
+EOF
+} >"$portable_fixture_bin/nix"
+chmod +x "$portable_fixture_bin/nix"
+
+if (PATH="$portable_fixture_bin"; export PATH; command -v grep >/dev/null 2>&1); then
+  fail "FIXTURE BROKEN: grep is still available in the minimal service PATH"
+else
+  pass "fixture reproduces a service PATH with real Nix and utilities but no grep"
+fi
+
+if portable_nix_probe="$(
+  PATH="$portable_fixture_bin" \
+    NIX_CONFIG="experimental-features = $healthy_features" \
+    SETUP_NIX_SELECTED_NIX_REAL="$selected_nix_real" \
+    nix eval --raw --expr '"minimal-path-nix-ok"'
+)" && [ "$portable_nix_probe" = "minimal-path-nix-ok" ]; then
+  pass "fixture's real Nix has every requested feature in effect"
+else
+  fail "FIXTURE BROKEN: real Nix is not functional in the minimal service PATH"
+fi
+
+sed \
+  '/^# BEGIN portable system utility PATH bootstrap$/,/^# END portable system utility PATH bootstrap$/d' \
+  "$guard" >"$vulnerable_guard"
+
+set +e
+vulnerable_output="$(
+  PATH="$portable_fixture_bin" \
+    NIX_CONFIG="experimental-features = $healthy_features" \
+    SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+    SETUP_NIX_SELECTED_NIX_REAL="$selected_nix_real" \
+    "$BASH" "$vulnerable_guard" 2>&1
+)"
+vulnerable_exit_code=$?
+set -e
+
+if [ "$vulnerable_exit_code" -ne 0 ] &&
+  printf '%s' "$vulnerable_output" | grep -q 'grep: command not found' &&
+  printf '%s' "$vulnerable_output" | grep -q 'requested experimental features are not in effect'; then
+  pass "fixture reproduces the old grep failure and false missing-feature report"
+else
+  fail "FIXTURE BROKEN: guard without the PATH bootstrap did not reproduce the old failure: $vulnerable_output"
+fi
+
+rm -f "$selected_nix_marker"
+if PATH="$portable_fixture_bin" \
+  NIX_CONFIG="experimental-features = $healthy_features" \
+  SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+  SETUP_NIX_SELECTED_NIX_MARKER="$selected_nix_marker" \
+  SETUP_NIX_SELECTED_NIX_REAL="$selected_nix_real" \
+  "$BASH" "$guard" >/dev/null 2>&1; then
+  pass "guard restores platform utility paths and verifies real Nix from the minimal service PATH"
+else
+  fail "guard rejected healthy Nix when the incoming service PATH omitted grep"
+fi
+
+if [ -s "$selected_nix_marker" ]; then
+  pass "PATH repair preserves the incoming service's selected Nix executable"
+else
+  fail "PATH repair replaced the incoming service's selected Nix with a profile or system Nix"
+fi
+
+# Service temp roots can contain shell metacharacters. Cleanup must retain the
+# exact mktemp paths rather than interpolating them into a trap command string.
+quoted_tmp_dir="$portable_fixture_root/service'tmp"
+mkdir "$quoted_tmp_dir"
+if TMPDIR="$quoted_tmp_dir" \
+  NIX_CONFIG="experimental-features = $healthy_features" \
+  SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+  "$BASH" "$guard" >/dev/null 2>&1; then
+  pass "guard succeeds when the service temp path contains a quote"
+else
+  fail "guard mishandled a quoted service temp path"
+fi
+if rmdir "$quoted_tmp_dir"; then
+  pass "probe cleanup removes exact temp paths containing shell metacharacters"
+else
+  fail "probe cleanup leaked files from a quoted service temp path"
+fi
+
+# Remove only the conventional path entries, retaining the utility preflight.
+# This lets the suite verify that the inventory is complete and that each
+# helper has a direct diagnostic instead of being misreported as a Nix feature
+# failure. The generated guard still executes the real functional probes.
+sed '
+  /^setup_nix_system_paths=(/,/^)/ {
+    /^  \//d
+  }
+' "$guard" >"$no_system_path_guard"
+
+portable_utility_names="mktemp rm cat grep sed sort tr"
+complete_utility_bin="$portable_fixture_root/complete-utility-bin"
+mkdir "$complete_utility_bin"
+ln -s "$selected_nix_real" "$complete_utility_bin/nix"
+for portable_fixture_utility in $portable_utility_names; do
+  portable_fixture_utility_path="$(command -v "$portable_fixture_utility")"
+  ln -s "$portable_fixture_utility_path" "$complete_utility_bin/$portable_fixture_utility"
+done
+
+if PATH="$complete_utility_bin" \
+  NIX_CONFIG="experimental-features = $healthy_features" \
+  SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+  "$BASH" "$no_system_path_guard" >/dev/null 2>&1; then
+  pass "the declared utility inventory is sufficient for every functional probe"
+else
+  fail "the guard uses an external utility that its preflight does not declare"
+fi
+
+for missing_portable_utility in $portable_utility_names; do
+  missing_utility_bin="$portable_fixture_root/missing-$missing_portable_utility-bin"
+  mkdir "$missing_utility_bin"
+  ln -s "$selected_nix_real" "$missing_utility_bin/nix"
+  for portable_fixture_utility in $portable_utility_names; do
+    if [ "$portable_fixture_utility" != "$missing_portable_utility" ]; then
+      portable_fixture_utility_path="$(command -v "$portable_fixture_utility")"
+      ln -s "$portable_fixture_utility_path" "$missing_utility_bin/$portable_fixture_utility"
+    fi
+  done
+
+  set +e
+  missing_utility_output="$(
+    PATH="$missing_utility_bin" \
+      NIX_CONFIG="experimental-features = $healthy_features" \
+      SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+      "$BASH" "$no_system_path_guard" 2>&1
+  )"
+  missing_utility_exit_code=$?
+  set -e
+
+  if [ "$missing_utility_exit_code" -ne 0 ] &&
+    printf '%s' "$missing_utility_output" | grep -qF "required verification utilities are not on PATH: $missing_portable_utility" &&
+    ! printf '%s' "$missing_utility_output" | grep -qF 'requested experimental features are not in effect'; then
+    pass "missing $missing_portable_utility is diagnosed as a utility failure"
+  else
+    fail "missing $missing_portable_utility was not diagnosed precisely: $missing_utility_output"
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # 2b. The guard must not be fooled by Nix writing WARNINGS to stderr.

--- a/.github/setup-nix/verify-nix-config.sh
+++ b/.github/setup-nix/verify-nix-config.sh
@@ -52,6 +52,46 @@
 
 set -euo pipefail
 
+# BEGIN portable system utility PATH bootstrap
+# GitHub runner services do not necessarily inherit the same PATH as an
+# interactive login shell. In particular, the native Darwin services expose
+# the Nix and Bash store paths but can omit /usr/bin, where macOS provides grep,
+# sed, and the other POSIX utilities used below. Preserve the runner's existing
+# PATH (and therefore its selected Nix), then add the conventional immutable or
+# operating-system profiles that can supply missing base utilities.
+setup_nix_system_paths=(
+  /usr/bin
+  /bin
+  /usr/sbin
+  /sbin
+  /run/current-system/sw/bin
+  /nix/var/nix/profiles/default/bin
+)
+for setup_nix_system_dir in "${setup_nix_system_paths[@]}"; do
+  if [ -d "$setup_nix_system_dir" ]; then
+    case ":${PATH:-}:" in
+      *":$setup_nix_system_dir:"*) ;;
+      *) PATH="${PATH:+$PATH:}$setup_nix_system_dir" ;;
+    esac
+  fi
+done
+export PATH
+
+# Check every non-shell utility this script assumes before a missing helper can
+# be misreported as a missing Nix feature. `nix` has its own check below so its
+# established diagnostics remain intact.
+missing_setup_nix_utilities=""
+for setup_nix_utility in mktemp rm cat grep sed sort tr; do
+  if ! command -v "$setup_nix_utility" >/dev/null 2>&1; then
+    missing_setup_nix_utilities="$missing_setup_nix_utilities $setup_nix_utility"
+  fi
+done
+if [ -n "$missing_setup_nix_utilities" ]; then
+  echo "setup-nix: FAIL: required verification utilities are not on PATH:${missing_setup_nix_utilities}" >&2
+  exit 1
+fi
+# END portable system utility PATH bootstrap
+
 # The feature list the caller asked for. `Configure Nix` passes the very same
 # value it wrote into nix.conf, so this asserts what was REQUESTED rather than
 # a second, independently drifting copy of the list.
@@ -125,7 +165,14 @@ fi
 # healthy runner. That mistake turns this guard into the false-alarm half of
 # the very problem it exists to solve.
 probe_stderr="$(mktemp)"
-trap 'rm -f "$probe_stderr"' EXIT
+probe_dir=""
+cleanup_setup_nix_probes() {
+  if [ -n "$probe_dir" ]; then
+    rm -rf "$probe_dir"
+  fi
+  rm -f "$probe_stderr"
+}
+trap cleanup_setup_nix_probes EXIT
 
 probe_output=""
 if ! probe_output="$(nix eval --raw --expr '"setup-nix-probe-ok"' 2>"$probe_stderr")"; then
@@ -146,8 +193,6 @@ fi
 # ---------------------------------------------------------------------------
 if printf '%s' "$required_features" | grep -qw flakes; then
   probe_dir="$(mktemp -d)"
-  # shellcheck disable=SC2064 # expand both paths now, at trap-set time
-  trap "rm -rf '$probe_dir'; rm -f '$probe_stderr'" EXIT
   printf '{ outputs = _: { probe = "setup-nix-flake-ok"; }; }\n' >"$probe_dir/flake.nix"
 
   flake_output=""


### PR DESCRIPTION
## Root cause

The native Darwin runner service can expose the store-selected Bash and Nix while omitting `/usr/bin` from `PATH`. In [metacraft-labs/infra run 32358686843, job 96393847612](https://github.com/metacraft-labs/infra/actions/runs/32358686843/job/96393847612), Nix reported the complete effective feature set (`fetch-tree flakes nix-command pipe-operators`), but every `grep` call failed with `grep: command not found`. The verification guard then falsely reported all requested features as missing.

That job consumed `metacraft-labs/nixos-modules/.github/setup-nix@main` at `08ac66a36417abf4f683158622a931e8d3c527b8`.

## Change

- Preserve the incoming runner-service `PATH` and therefore its selected Nix, then append existing conventional Darwin, Linux, NixOS, and default-profile utility directories.
- Preflight every external utility used by the guard and report missing helpers as utility failures, never as missing Nix features.
- Retain the original functional Nix probes without command-line feature overrides and retain secret-safe diagnostics.
- Replace interpolated trap commands with variable-safe cleanup so quoted service temp paths are removed exactly.
- Add mutation-sensitive coverage that reproduces the original false alarm, rejects prepending/replacing the selected Nix, proves the helper inventory complete, removes each helper independently, and verifies quoted-temp cleanup.

## Expected effect

This PR changes only the reusable `setup-nix` action guard and its contract test. Merging to `dev` does not deploy a machine, change Terraform, alter secrets, or change infrastructure topology. Consumers pinned to `@main` remain unchanged until promotion.

After this PR is merged to `dev`, the exact integrated revision must be promoted to `main`: reusable workflows and composite-action consumers resolve `metacraft-labs/nixos-modules/...@main`, so a dev-only merge is intentionally inert for those consumers.

## Verification

Exact base: `0bddbe3b9acc44ab40c20a38214de2c53c9c5ca3`

- `bash -n .github/setup-nix/verify-nix-config.sh .github/setup-nix/tests/verify-nix-config-test.sh`
- `bash .github/setup-nix/tests/verify-nix-config-test.sh` — 25 assertions, 0 failures
- `nix shell --accept-flake-config nixpkgs#shellcheck --command shellcheck .github/setup-nix/verify-nix-config.sh .github/setup-nix/tests/verify-nix-config-test.sh`
- prepend-PATH mutation — rejected because it replaces the incoming selected Nix
- utility-preflight removal mutation — rejected for all seven declared utilities
- complete bootstrap removal mutation — rejected while reproducing the original `grep`/false-feature failure
- `nix develop --accept-flake-config .#pre-commit -c prek run --files .github/setup-nix/verify-nix-config.sh .github/setup-nix/tests/verify-nix-config-test.sh --show-diff-on-failure --color never`
- `nix build --no-link .#checks.x86_64-linux.setup-nix-transfer-resilience`
- `nix flake check --no-build --all-systems`
- `git diff --check`

The repository-wide pre-commit invocation has three unrelated baseline formatting failures, reproduced unchanged on the exact base: `terraform/github/governance.nix`, `upstream-patches/CLAUDE.md`, and the terminal blank line in `upstream-patches/garm-listinstances-inverted-error-check/fix.patch`. The two changed files pass every configured pre-commit hook.
