### PR TITLE
sync: promote current dev fixes to main

### DIFF
--- a/.github/setup-nix/tests/verify-nix-config-test.sh
+++ b/.github/setup-nix/tests/verify-nix-config-test.sh
@@ -23,6 +23,13 @@
 # The suite additionally asserts that action.yml actually INVOKES the guard, so
 # deleting the step from the action fails this test rather than quietly
 # restoring the original silent-success behaviour.
+#
+# The native-Darwin service-PATH regression uses real executables rather than
+# mocks: a temporary bin directory contains the real Nix and every external
+# utility the guard uses except grep. A mutation with the portability bootstrap
+# removed must reproduce the old false missing-feature report, then the real
+# guard must pass under that identical PATH. This proves both that the fixture
+# can trigger the defect and that the fix covers the service environment.
 
 set -euo pipefail
 
@@ -100,6 +107,177 @@ if NIX_CONFIG="experimental-features = $healthy_features" \
 else
   fail "guard rejected a correctly configured Nix — it would block healthy jobs"
 fi
+
+# ---------------------------------------------------------------------------
+# 2a. Native-Darwin runner services may omit /usr/bin from PATH.
+#
+# Retain the real Nix and every other external utility used by the guard, but
+# deliberately omit grep. This is the precise environment from the failing
+# native-Darwin jobs: Nix reports all requested features as effective, while the
+# guard used to turn `grep: command not found` into a false missing-feature
+# report. The vulnerable mutation proves this fixture kills the old code before
+# the fixed guard is allowed to establish the positive result.
+# ---------------------------------------------------------------------------
+portable_fixture_root="$(mktemp -d)"
+portable_fixture_bin="$portable_fixture_root/bin"
+vulnerable_guard="$portable_fixture_root/verify-nix-config-without-path-bootstrap.sh"
+no_system_path_guard="$portable_fixture_root/verify-nix-config-without-system-paths.sh"
+selected_nix_marker="$portable_fixture_root/selected-nix-used"
+selected_nix_real="$(command -v nix)"
+mkdir "$portable_fixture_bin"
+trap 'rm -rf "$portable_fixture_root"' EXIT
+
+for portable_fixture_utility in mktemp rm cat sed sort tr; do
+  portable_fixture_utility_path="$(command -v "$portable_fixture_utility")"
+  ln -s "$portable_fixture_utility_path" "$portable_fixture_bin/$portable_fixture_utility"
+done
+
+# Delegate to the real Nix, while leaving evidence that the guard preserved the
+# incoming PATH's selected Nix instead of replacing it with one from a profile.
+{
+  printf '#!%s\n' "$BASH"
+  cat <<'EOF'
+if [ -n "${SETUP_NIX_SELECTED_NIX_MARKER:-}" ]; then
+  printf 'used\n' >>"$SETUP_NIX_SELECTED_NIX_MARKER"
+fi
+exec "$SETUP_NIX_SELECTED_NIX_REAL" "$@"
+EOF
+} >"$portable_fixture_bin/nix"
+chmod +x "$portable_fixture_bin/nix"
+
+if (PATH="$portable_fixture_bin"; export PATH; command -v grep >/dev/null 2>&1); then
+  fail "FIXTURE BROKEN: grep is still available in the minimal service PATH"
+else
+  pass "fixture reproduces a service PATH with real Nix and utilities but no grep"
+fi
+
+if portable_nix_probe="$(
+  PATH="$portable_fixture_bin" \
+    NIX_CONFIG="experimental-features = $healthy_features" \
+    SETUP_NIX_SELECTED_NIX_REAL="$selected_nix_real" \
+    nix eval --raw --expr '"minimal-path-nix-ok"'
+)" && [ "$portable_nix_probe" = "minimal-path-nix-ok" ]; then
+  pass "fixture's real Nix has every requested feature in effect"
+else
+  fail "FIXTURE BROKEN: real Nix is not functional in the minimal service PATH"
+fi
+
+sed \
+  '/^# BEGIN portable system utility PATH bootstrap$/,/^# END portable system utility PATH bootstrap$/d' \
+  "$guard" >"$vulnerable_guard"
+
+set +e
+vulnerable_output="$(
+  PATH="$portable_fixture_bin" \
+    NIX_CONFIG="experimental-features = $healthy_features" \
+    SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+    SETUP_NIX_SELECTED_NIX_REAL="$selected_nix_real" \
+    "$BASH" "$vulnerable_guard" 2>&1
+)"
+vulnerable_exit_code=$?
+set -e
+
+if [ "$vulnerable_exit_code" -ne 0 ] &&
+  printf '%s' "$vulnerable_output" | grep -q 'grep: command not found' &&
+  printf '%s' "$vulnerable_output" | grep -q 'requested experimental features are not in effect'; then
+  pass "fixture reproduces the old grep failure and false missing-feature report"
+else
+  fail "FIXTURE BROKEN: guard without the PATH bootstrap did not reproduce the old failure: $vulnerable_output"
+fi
+
+rm -f "$selected_nix_marker"
+if PATH="$portable_fixture_bin" \
+  NIX_CONFIG="experimental-features = $healthy_features" \
+  SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+  SETUP_NIX_SELECTED_NIX_MARKER="$selected_nix_marker" \
+  SETUP_NIX_SELECTED_NIX_REAL="$selected_nix_real" \
+  "$BASH" "$guard" >/dev/null 2>&1; then
+  pass "guard restores platform utility paths and verifies real Nix from the minimal service PATH"
+else
+  fail "guard rejected healthy Nix when the incoming service PATH omitted grep"
+fi
+
+if [ -s "$selected_nix_marker" ]; then
+  pass "PATH repair preserves the incoming service's selected Nix executable"
+else
+  fail "PATH repair replaced the incoming service's selected Nix with a profile or system Nix"
+fi
+
+# Service temp roots can contain shell metacharacters. Cleanup must retain the
+# exact mktemp paths rather than interpolating them into a trap command string.
+quoted_tmp_dir="$portable_fixture_root/service'tmp"
+mkdir "$quoted_tmp_dir"
+if TMPDIR="$quoted_tmp_dir" \
+  NIX_CONFIG="experimental-features = $healthy_features" \
+  SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+  "$BASH" "$guard" >/dev/null 2>&1; then
+  pass "guard succeeds when the service temp path contains a quote"
+else
+  fail "guard mishandled a quoted service temp path"
+fi
+if rmdir "$quoted_tmp_dir"; then
+  pass "probe cleanup removes exact temp paths containing shell metacharacters"
+else
+  fail "probe cleanup leaked files from a quoted service temp path"
+fi
+
+# Remove only the conventional path entries, retaining the utility preflight.
+# This lets the suite verify that the inventory is complete and that each
+# helper has a direct diagnostic instead of being misreported as a Nix feature
+# failure. The generated guard still executes the real functional probes.
+sed '
+  /^setup_nix_system_paths=(/,/^)/ {
+    /^  \//d
+  }
+' "$guard" >"$no_system_path_guard"
+
+portable_utility_names="mktemp rm cat grep sed sort tr"
+complete_utility_bin="$portable_fixture_root/complete-utility-bin"
+mkdir "$complete_utility_bin"
+ln -s "$selected_nix_real" "$complete_utility_bin/nix"
+for portable_fixture_utility in $portable_utility_names; do
+  portable_fixture_utility_path="$(command -v "$portable_fixture_utility")"
+  ln -s "$portable_fixture_utility_path" "$complete_utility_bin/$portable_fixture_utility"
+done
+
+if PATH="$complete_utility_bin" \
+  NIX_CONFIG="experimental-features = $healthy_features" \
+  SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+  "$BASH" "$no_system_path_guard" >/dev/null 2>&1; then
+  pass "the declared utility inventory is sufficient for every functional probe"
+else
+  fail "the guard uses an external utility that its preflight does not declare"
+fi
+
+for missing_portable_utility in $portable_utility_names; do
+  missing_utility_bin="$portable_fixture_root/missing-$missing_portable_utility-bin"
+  mkdir "$missing_utility_bin"
+  ln -s "$selected_nix_real" "$missing_utility_bin/nix"
+  for portable_fixture_utility in $portable_utility_names; do
+    if [ "$portable_fixture_utility" != "$missing_portable_utility" ]; then
+      portable_fixture_utility_path="$(command -v "$portable_fixture_utility")"
+      ln -s "$portable_fixture_utility_path" "$missing_utility_bin/$portable_fixture_utility"
+    fi
+  done
+
+  set +e
+  missing_utility_output="$(
+    PATH="$missing_utility_bin" \
+      NIX_CONFIG="experimental-features = $healthy_features" \
+      SETUP_NIX_REQUIRED_EXPERIMENTAL_FEATURES="$healthy_features" \
+      "$BASH" "$no_system_path_guard" 2>&1
+  )"
+  missing_utility_exit_code=$?
+  set -e
+
+  if [ "$missing_utility_exit_code" -ne 0 ] &&
+    printf '%s' "$missing_utility_output" | grep -qF "required verification utilities are not on PATH: $missing_portable_utility" &&
+    ! printf '%s' "$missing_utility_output" | grep -qF 'requested experimental features are not in effect'; then
+    pass "missing $missing_portable_utility is diagnosed as a utility failure"
+  else
+    fail "missing $missing_portable_utility was not diagnosed precisely: $missing_utility_output"
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # 2b. The guard must not be fooled by Nix writing WARNINGS to stderr.

--- a/.github/setup-nix/verify-nix-config.sh
+++ b/.github/setup-nix/verify-nix-config.sh
@@ -193,6 +193,12 @@ fi
 # ---------------------------------------------------------------------------
 if printf '%s' "$required_features" | grep -qw flakes; then
   probe_dir="$(mktemp -d)"
+  # On Darwin, mktemp commonly returns /var/folders/... even though /var is a
+  # symlink to /private/var. Nix 2.31 rejects local path-flake references that
+  # traverse a symlink, so canonicalize the directory before constructing the
+  # path: URL. `cd` and `pwd` are Bash builtins, keeping the utility inventory
+  # above complete.
+  probe_dir="$(cd -- "$probe_dir" && pwd -P)"
   printf '{ outputs = _: { probe = "setup-nix-flake-ok"; }; }\n' >"$probe_dir/flake.nix"
 
   flake_output=""

--- a/.github/setup-nix/verify-nix-config.sh
+++ b/.github/setup-nix/verify-nix-config.sh
@@ -52,6 +52,46 @@
 
 set -euo pipefail
 
+# BEGIN portable system utility PATH bootstrap
+# GitHub runner services do not necessarily inherit the same PATH as an
+# interactive login shell. In particular, the native Darwin services expose
+# the Nix and Bash store paths but can omit /usr/bin, where macOS provides grep,
+# sed, and the other POSIX utilities used below. Preserve the runner's existing
+# PATH (and therefore its selected Nix), then add the conventional immutable or
+# operating-system profiles that can supply missing base utilities.
+setup_nix_system_paths=(
+  /usr/bin
+  /bin
+  /usr/sbin
+  /sbin
+  /run/current-system/sw/bin
+  /nix/var/nix/profiles/default/bin
+)
+for setup_nix_system_dir in "${setup_nix_system_paths[@]}"; do
+  if [ -d "$setup_nix_system_dir" ]; then
+    case ":${PATH:-}:" in
+      *":$setup_nix_system_dir:"*) ;;
+      *) PATH="${PATH:+$PATH:}$setup_nix_system_dir" ;;
+    esac
+  fi
+done
+export PATH
+
+# Check every non-shell utility this script assumes before a missing helper can
+# be misreported as a missing Nix feature. `nix` has its own check below so its
+# established diagnostics remain intact.
+missing_setup_nix_utilities=""
+for setup_nix_utility in mktemp rm cat grep sed sort tr; do
+  if ! command -v "$setup_nix_utility" >/dev/null 2>&1; then
+    missing_setup_nix_utilities="$missing_setup_nix_utilities $setup_nix_utility"
+  fi
+done
+if [ -n "$missing_setup_nix_utilities" ]; then
+  echo "setup-nix: FAIL: required verification utilities are not on PATH:${missing_setup_nix_utilities}" >&2
+  exit 1
+fi
+# END portable system utility PATH bootstrap
+
 # The feature list the caller asked for. `Configure Nix` passes the very same
 # value it wrote into nix.conf, so this asserts what was REQUESTED rather than
 # a second, independently drifting copy of the list.
@@ -125,7 +165,14 @@ fi
 # healthy runner. That mistake turns this guard into the false-alarm half of
 # the very problem it exists to solve.
 probe_stderr="$(mktemp)"
-trap 'rm -f "$probe_stderr"' EXIT
+probe_dir=""
+cleanup_setup_nix_probes() {
+  if [ -n "$probe_dir" ]; then
+    rm -rf "$probe_dir"
+  fi
+  rm -f "$probe_stderr"
+}
+trap cleanup_setup_nix_probes EXIT
 
 probe_output=""
 if ! probe_output="$(nix eval --raw --expr '"setup-nix-probe-ok"' 2>"$probe_stderr")"; then
@@ -146,8 +193,6 @@ fi
 # ---------------------------------------------------------------------------
 if printf '%s' "$required_features" | grep -qw flakes; then
   probe_dir="$(mktemp -d)"
-  # shellcheck disable=SC2064 # expand both paths now, at trap-set time
-  trap "rm -rf '$probe_dir'; rm -f '$probe_stderr'" EXIT
   printf '{ outputs = _: { probe = "setup-nix-flake-ok"; }; }\n' >"$probe_dir/flake.nix"
 
   flake_output=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,23 @@ jobs:
   # `extra_nix_config`, so the job dies later in an unrelated step with
   # "nix-command is disabled".
   #
-  # This job runs on `eph-linux-x64` deliberately: that runner IS the
-  # pre-installed-Nix case, so the `Setup Nix` step below exercises the exact
-  # environment where the upstream action no-ops. If our guard were wrong in
-  # either direction — too strict, or not checking at all — this job says so.
+  # The Linux case is deliberately retained because that runner IS the
+  # pre-installed-Nix case where the upstream action no-ops. Native Darwin is
+  # equally deliberate: it exercises macOS's symlinked /var temp root and the
+  # service PATH that originally omitted system utilities. If our guard were
+  # wrong in either direction — too strict, or not checking at all — one of
+  # these real platform contracts says so.
   test-setup-nix-verification:
-    name: Validate setup-nix verifies its own experimental-features
-    runs-on: eph-linux-x64
+    name: Validate setup-nix verification (${{ matrix.system }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: eph-linux-x64
+          - system: aarch64-darwin
+            runner: eph-macos-arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout first to use locally defined actions
         uses: actions/checkout@v6.0.2

--- a/modules/garm/README.md
+++ b/modules/garm/README.md
@@ -245,7 +245,15 @@ above + `/metrics` served + the declarative egress option.
 - **Provider** is a `[[provider]]` external block pointing at the
   `garm-provider-vmharness` binary + a secret-free provider `config.toml` carrying
   `virsh_path`/`qemu_img_path`/`libvirt_uri`/`network`/`pool_dir`/`uefi_*`/
-  `memory_mb`/`vcpus` + the golden `[images.*]` map (all from module options).
+  `memory_mb`/`vcpus` (plus `current_memory_mb` when a balloon floor is set) +
+  the golden `[images.*]` map (all from module options).
+- **Dynamic memory** (`providers.<name>.currentMemoryMb`, libvirt only): when set,
+  `memory_mb` becomes the guest's ceiling and `current_memory_mb` its virtio-balloon
+  boot target, emitted as `<currentMemory>` plus an explicit
+  `<memballoon model='virtio'/>`. It is a request the guest honours only while
+  running the balloon driver (on Windows: `balloon.sys` + `BLNSVR`) — check with
+  `virsh dommemstat <domain>`, which reports `unused`/`available` only when the
+  guest is really ballooning. The resource guard below still budgets the ceiling.
 
 ---
 

--- a/modules/garm/default.nix
+++ b/modules/garm/default.nix
@@ -116,18 +116,26 @@
           "VMH_QEMU_WINDOWS_ARM_SWTPM_CMD"
           "VM_HARNESS_DARWIN_ASUSER_UID"
         ];
-      mkLibvirtKeys = p: ''
-        virsh_path = "${p.virshPath}"
-        qemu_img_path = "${p.qemuImgPath}"
-        vm_harness_path = "${p.vmHarnessPath}"
-        libvirt_uri = "${p.libvirtURI}"
-        network = "${p.network}"
-        pool_dir = "${p.poolDir}"
-        uefi_loader = "${p.uefiLoader}"
-        uefi_nvram_template = "${p.uefiNvramTemplate}"
-        memory_mb = ${toString p.memoryMb}
-        vcpus = ${toString p.vcpus}
-      '';
+      mkLibvirtKeys =
+        p:
+        ''
+          virsh_path = "${p.virshPath}"
+          qemu_img_path = "${p.qemuImgPath}"
+          vm_harness_path = "${p.vmHarnessPath}"
+          libvirt_uri = "${p.libvirtURI}"
+          network = "${p.network}"
+          pool_dir = "${p.poolDir}"
+          uefi_loader = "${p.uefiLoader}"
+          uefi_nvram_template = "${p.uefiNvramTemplate}"
+          memory_mb = ${toString p.memoryMb}
+          vcpus = ${toString p.vcpus}
+        ''
+        # Only emitted when a balloon floor is actually requested, so providers
+        # that do not use one keep a byte-identical config.toml (and therefore a
+        # byte-identical domain XML) to before this option existed.
+        + optionalString (p.currentMemoryMb > 0) ''
+          current_memory_mb = ${toString p.currentMemoryMb}
+        '';
       mkIncusKeys = p: ''
         incus_path = "${p.incusPath}"
         incus_bridge = "${p.incusBridge}"
@@ -985,6 +993,46 @@
                 Per-job guest RAM (MiB), emitted as `memory_mb`. Also an input to
                 the eval-time resource-guard assertion
                 (`maxRunners * memoryMb <= hostBudget.memoryMb`).
+              '';
+            };
+
+            currentMemoryMb = mkOption {
+              type = types.ints.unsigned;
+              default = 0;
+              example = 8192;
+              description = ''
+                Virtio-balloon BOOT TARGET (MiB) for the per-job libvirt domain,
+                emitted as `current_memory_mb` and rendered as
+                `<currentMemory>` directly below `<memory>` in the domain XML.
+                `0` (the default) omits it entirely.
+
+                What it does: `memoryMb` becomes the CEILING the guest may ever
+                reach, and this becomes the amount it is asked to hold at
+                power-on — the difference is parked in the virtio balloon until
+                the guest asks for it back. That is what makes a large ceiling
+                affordable: an idle job costs the floor, not the ceiling, so a
+                burst of runners cannot pin the host's whole RAM indefinitely.
+
+                Two caveats, both important:
+
+                - It is a REQUEST, not a cap. `<currentMemory>` is honoured only
+                  by a guest running the virtio-balloon driver; a guest without
+                  it silently ignores the target and boots with the full
+                  `memoryMb`. On Windows that means `balloon.sys` plus a running
+                  `BLNSVR` service. Setting this against a guest that lacks them
+                  is inert — it changes the XML and nothing else. Verify with
+                  `virsh dommemstat <domain>`: a guest that is actually
+                  ballooning reports `unused`/`available`, not just
+                  `actual`/`rss`.
+                - It does not relax the resource guard. The eval-time assertion
+                  still budgets `maxRunners * memoryMb`, i.e. the WORST case, on
+                  purpose: the floor is what the host usually pays, but the
+                  ceiling is what it must be able to survive if every runner
+                  fills up at once.
+
+                Must be strictly below `memoryMb` when set (a target at or above
+                the ceiling means an empty balloon); the provider drops such a
+                value and the module asserts against it.
               '';
             };
 
@@ -2182,6 +2230,19 @@
               assertion = cfg.providers ? ${ss.provider};
               message = "services.garm.scaleSets.${n}.provider = \"${ss.provider}\" does not name a declared services.garm.providers.<name> (have: ${lib.concatStringsSep ", " (lib.attrNames cfg.providers)}).";
             }) cfg.scaleSets
+            # W1: a balloon floor must sit strictly BELOW the ceiling it floors,
+            # and only the libvirt backend renders a domain XML to put it in.
+            # Both are eval-time failures rather than silent no-ops: the provider
+            # drops a degenerate value, which would otherwise look like a
+            # working memory floor while every VM quietly boots at its ceiling.
+            ++ lib.mapAttrsToList (n: p: {
+              assertion = p.currentMemoryMb == 0 || p.currentMemoryMb < p.memoryMb;
+              message = "services.garm.providers.${n}: currentMemoryMb (${toString p.currentMemoryMb}) must be strictly below memoryMb (${toString p.memoryMb}) — a balloon boot target at or above the ceiling leaves the balloon empty and is ignored by the provider. Use 0 to disable ballooning.";
+            }) cfg.providers
+            ++ lib.mapAttrsToList (n: p: {
+              assertion = p.currentMemoryMb == 0 || providerIsLibvirt p;
+              message = "services.garm.providers.${n}: currentMemoryMb is only honoured by the libvirt backend (this provider's backend = \"${p.backend}\"); it has no effect on incus containers or vm-harness-run VMs.";
+            }) cfg.providers
             # Resource-guard (eval time): the sum over all scale sets of
             # maxRunners * (its provider's per-VM RAM) must fit the declared host
             # RAM budget, and likewise vCPUs. A bad config FAILS TO EVAL instead

--- a/packages/garm-provider-vmharness/src/internal/backend/backend.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/backend.go
@@ -83,6 +83,13 @@ type CreateArgs struct {
 	// MemoryMB / VCPUs size the domain. Zero => defaults (4096 MiB / 2 vCPU).
 	MemoryMB int
 	VCPUs    int
+	// CurrentMemoryMB is the virtio-balloon BOOT TARGET (<currentMemory>): the
+	// amount the guest is asked to hold at power-on, with MemoryMB - this
+	// parked in the balloon. It is a request, not a cap — a guest without the
+	// balloon driver ignores it and boots with the full MemoryMB. Zero (or any
+	// value outside 0 < n < MemoryMB) means "no target": the domain XML is
+	// emitted exactly as it was before this field existed.
+	CurrentMemoryMB int
 }
 
 // Backend is the seam the provider shells to. Every method is a thin wrapper

--- a/packages/garm-provider-vmharness/src/internal/backend/domainxml.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/domainxml.go
@@ -52,6 +52,36 @@ func buildDomainXML(args CreateArgs, metaInner, configDriveISO string) string {
 		vcpus = 2
 	}
 
+	// W1: dynamic memory. <memory> is the CEILING the domain may ever reach;
+	// <currentMemory> is the balloon's BOOT TARGET, i.e. how much the guest is
+	// asked to hold on to at power-on, with the difference parked in the balloon
+	// until the guest asks for it back. That makes a large ceiling affordable:
+	// the host only pays the floor while the job is idle.
+	//
+	// Two things this is NOT:
+	//   - it is not an enforcement. <currentMemory> is a REQUEST; a guest that
+	//     is not running the virtio-balloon driver simply ignores it and boots
+	//     with the full <memory>. Until the Windows golden ships balloon.sys +
+	//     BLNSVR (campaign milestone W0) this field is inert on Windows guests.
+	//   - it is not a way to overcommit past <memory>. A value at or above the
+	//     EFFECTIVE ceiling (mem, i.e. after the 4096 MiB default is applied) is
+	//     meaningless — the balloon would be empty — and <= 0 means "unset".
+	//
+	// Both of those degenerate cases are dropped, and when the field is unset
+	// the emitted XML is byte-identical to the pre-W1 template — that is the
+	// regression lock that lets W1 land before W0 without reshaping any running
+	// domain. We also declare <memballoon model='virtio'/> explicitly whenever
+	// we emit a target: libvirt adds one by default, but relying on a default
+	// for the device that makes the target achievable is not something the XML
+	// should leave implicit.
+	currentMemLine := ""
+	balloonLine := ""
+	if args.CurrentMemoryMB > 0 && args.CurrentMemoryMB < mem {
+		currentMemLine = fmt.Sprintf("  <currentMemory unit='MiB'>%d</currentMemory>\n",
+			args.CurrentMemoryMB)
+		balloonLine = "    <memballoon model='virtio'/>\n"
+	}
+
 	uefi := args.UEFILoader != ""
 
 	// <os> block: OVMF pflash loader + per-job nvram (UEFI/Windows 11) or a
@@ -122,7 +152,7 @@ func buildDomainXML(args CreateArgs, metaInner, configDriveISO string) string {
 %s
   </metadata>
   <memory unit='MiB'>%d</memory>
-  <vcpu>%d</vcpu>
+%s  <vcpu>%d</vcpu>
 %s%s%s%s  <devices>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
@@ -138,7 +168,7 @@ func buildDomainXML(args CreateArgs, metaInner, configDriveISO string) string {
       <model type='qxl'/>
     </video>
     <console type='pty'/>
-  </devices>
+%s  </devices>
 </domain>
-`, name, metaInner, mem, vcpus, osBlock, features, cpuBlock, clockBlock, source, configDrive, network)
+`, name, metaInner, mem, currentMemLine, vcpus, osBlock, features, cpuBlock, clockBlock, source, configDrive, network, balloonLine)
 }

--- a/packages/garm-provider-vmharness/src/internal/backend/domainxml_test.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/domainxml_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Metacraft Labs
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+// Gate t_domainxml_currentmemory (campaign milestone W1).
+//
+// buildDomainXML is a pure function over CreateArgs, so this gate is fully
+// hermetic: no libvirt, no virsh (not even the mock), no filesystem. It uses no
+// mock objects at all — the unit under test IS the real string builder that
+// feeds `virsh define`.
+//
+// The load-bearing assertion is TestBuildDomainXMLCurrentMemoryUnsetIsByteIdentical:
+// it pins the ENTIRE pre-W1 rendering as a literal, so adding the
+// <currentMemory>/<memballoon> lines cannot perturb the XML of any domain that
+// does not ask for a balloon target. That is what lets W1 land before W0
+// (the guest-side balloon driver) without reshaping running VMs.
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+// baseArgs is the plainest domain the builder can render: no UEFI, no
+// config-drive, no explicit disk overlay. Kept minimal so the byte-identical
+// golden below stays readable.
+func baseArgs() CreateArgs {
+	return CreateArgs{
+		Name:        "garm-win-0001",
+		SourceImage: "/var/lib/libvirt/images/win11-golden.qcow2",
+		Network:     "garmnet",
+		MemoryMB:    8192,
+		VCPUs:       4,
+	}
+}
+
+// wantPreW1 is the EXACT XML buildDomainXML emitted before W1 for baseArgs()
+// with metaInner "<meta/>" and no config-drive. Transcribed from the pre-W1
+// template; any drift here is a real change in the shape of every domain the
+// provider defines.
+const wantPreW1 = `<domain type='kvm'>
+  <name>garm-win-0001</name>
+  <metadata>
+<meta/>
+  </metadata>
+  <memory unit='MiB'>8192</memory>
+  <vcpu>4</vcpu>
+  <os>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <devices>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/win11-golden.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <interface type='network'>
+      <source network='garmnet'/>
+      <model type='virtio'/>
+    </interface>
+    <graphics type='vnc' port='-1'/>
+    <video>
+      <model type='qxl'/>
+    </video>
+    <console type='pty'/>
+  </devices>
+</domain>
+`
+
+// TestBuildDomainXMLCurrentMemoryUnsetIsByteIdentical is the regression lock:
+// with CurrentMemoryMB left at its zero value the output must equal the pre-W1
+// rendering byte for byte.
+func TestBuildDomainXMLCurrentMemoryUnsetIsByteIdentical(t *testing.T) {
+	got := buildDomainXML(baseArgs(), "<meta/>", "")
+	if got != wantPreW1 {
+		t.Errorf("domain XML changed shape with CurrentMemoryMB unset.\n--- got ---\n%s\n--- want ---\n%s",
+			got, wantPreW1)
+	}
+}
+
+// TestBuildDomainXMLCurrentMemorySet checks the whole-document rendering when a
+// balloon target below the ceiling is requested: <currentMemory> immediately
+// after <memory>, and an explicit <memballoon model='virtio'/> in <devices>.
+// Asserted as a full-document comparison (not a substring probe) so a target
+// emitted in the wrong place fails.
+func TestBuildDomainXMLCurrentMemorySet(t *testing.T) {
+	args := baseArgs()
+	args.CurrentMemoryMB = 2048
+
+	want := strings.Replace(wantPreW1,
+		"  <memory unit='MiB'>8192</memory>\n",
+		"  <memory unit='MiB'>8192</memory>\n  <currentMemory unit='MiB'>2048</currentMemory>\n",
+		1)
+	want = strings.Replace(want,
+		"    <console type='pty'/>\n",
+		"    <console type='pty'/>\n    <memballoon model='virtio'/>\n",
+		1)
+
+	got := buildDomainXML(args, "<meta/>", "")
+	if got != want {
+		t.Errorf("domain XML with CurrentMemoryMB=2048 mismatch.\n--- got ---\n%s\n--- want ---\n%s",
+			got, want)
+	}
+}
+
+// TestBuildDomainXMLCurrentMemoryDegenerate covers every value that must NOT
+// produce a balloon target: unset, negative, exactly the ceiling, and above the
+// ceiling (a target >= <memory> would mean an empty balloon, so it is dropped
+// rather than emitted as a no-op). All must render the pre-W1 XML.
+func TestBuildDomainXMLCurrentMemoryDegenerate(t *testing.T) {
+	cases := []struct {
+		name    string
+		current int
+	}{
+		{"unset", 0},
+		{"negative", -1},
+		{"equal to ceiling", 8192},
+		{"above ceiling", 16384},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := baseArgs()
+			args.CurrentMemoryMB = tc.current
+			got := buildDomainXML(args, "<meta/>", "")
+			if strings.Contains(got, "currentMemory") {
+				t.Errorf("CurrentMemoryMB=%d emitted <currentMemory>, want it omitted:\n%s",
+					tc.current, got)
+			}
+			if strings.Contains(got, "memballoon") {
+				t.Errorf("CurrentMemoryMB=%d emitted <memballoon>, want it omitted:\n%s",
+					tc.current, got)
+			}
+			if got != wantPreW1 {
+				t.Errorf("CurrentMemoryMB=%d changed the XML.\n--- got ---\n%s\n--- want ---\n%s",
+					tc.current, got, wantPreW1)
+			}
+		})
+	}
+}
+
+// TestBuildDomainXMLCurrentMemoryAgainstDefaultCeiling pins the interaction
+// with the builder's own MemoryMB default: when MemoryMB is unset the ceiling
+// is 4096, so a target must be compared against the EFFECTIVE ceiling, not
+// against the zero the caller passed. 2048 is below it (emitted); 4096 is not
+// (dropped).
+func TestBuildDomainXMLCurrentMemoryAgainstDefaultCeiling(t *testing.T) {
+	args := baseArgs()
+	args.MemoryMB = 0
+	args.CurrentMemoryMB = 2048
+	got := buildDomainXML(args, "<meta/>", "")
+	if !strings.Contains(got, "  <memory unit='MiB'>4096</memory>\n  <currentMemory unit='MiB'>2048</currentMemory>\n") {
+		t.Errorf("target below the DEFAULT ceiling was not emitted:\n%s", got)
+	}
+
+	args.CurrentMemoryMB = 4096
+	got = buildDomainXML(args, "<meta/>", "")
+	if strings.Contains(got, "currentMemory") {
+		t.Errorf("target equal to the DEFAULT ceiling should be dropped:\n%s", got)
+	}
+}
+
+// TestBuildDomainXMLCurrentMemoryUEFIPath checks the target survives the other
+// major rendering path (OVMF pflash + hyperv + config-drive), where several
+// optional blocks sit between <memory> and <devices>. This is the path the real
+// Windows runners take.
+func TestBuildDomainXMLCurrentMemoryUEFIPath(t *testing.T) {
+	args := baseArgs()
+	args.DiskSource = "/var/lib/libvirt/images/garm-win-0001.overlay.qcow2"
+	args.UEFILoader = "/run/libvirt/nix-ovmf/edk2-x86_64-code.fd"
+	args.UEFINVRAM = "/var/lib/libvirt/images/garm-win-0001.nvram.fd"
+	args.UEFINVRAMTemplate = "/run/libvirt/nix-ovmf/edk2-i386-vars.fd"
+	args.CurrentMemoryMB = 8192
+	args.MemoryMB = 65536
+
+	got := buildDomainXML(args, "<meta/>", "/var/lib/libvirt/images/garm-win-0001.iso")
+
+	if !strings.Contains(got, "  <memory unit='MiB'>65536</memory>\n  <currentMemory unit='MiB'>8192</currentMemory>\n  <vcpu>4</vcpu>\n") {
+		t.Errorf("UEFI path: <currentMemory> not emitted between <memory> and <vcpu>:\n%s", got)
+	}
+	if !strings.Contains(got, "    <memballoon model='virtio'/>\n  </devices>\n") {
+		t.Errorf("UEFI path: <memballoon> not emitted inside <devices>:\n%s", got)
+	}
+	// The balloon must not have displaced the UEFI/config-drive rendering.
+	if !strings.Contains(got, "<loader readonly='yes' type='pflash' format='raw'>") ||
+		!strings.Contains(got, "<smm state='on'/>") ||
+		!strings.Contains(got, "device='cdrom'") {
+		t.Errorf("UEFI path: expected blocks missing:\n%s", got)
+	}
+}

--- a/packages/garm-provider-vmharness/src/internal/backend/virsh.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/virsh.go
@@ -72,6 +72,9 @@ type VirshBackend struct {
 	// MemoryMB / VCPUs size the per-job domain (0 => builder defaults).
 	MemoryMB int
 	VCPUs    int
+	// CurrentMemoryMB is the balloon boot target handed to buildDomainXML (0 =>
+	// no <currentMemory>, and the domain XML keeps its pre-W1 shape).
+	CurrentMemoryMB int
 }
 
 // overlayPath is the per-job CoW overlay file (next to the config-drive so
@@ -167,6 +170,9 @@ func (v *VirshBackend) Create(ctx context.Context, args CreateArgs) (Instance, e
 		}
 		if args.VCPUs == 0 {
 			args.VCPUs = v.VCPUs
+		}
+		if args.CurrentMemoryMB == 0 {
+			args.CurrentMemoryMB = v.CurrentMemoryMB
 		}
 	}
 

--- a/packages/garm-provider-vmharness/src/internal/config/config.go
+++ b/packages/garm-provider-vmharness/src/internal/config/config.go
@@ -108,6 +108,15 @@ type Config struct {
 	MemoryMB int `toml:"memory_mb"`
 	VCPUs    int `toml:"vcpus"`
 
+	// CurrentMemoryMB is the virtio-balloon boot target (<currentMemory>) for
+	// the per-job domain: MemoryMB becomes a ceiling and this the floor the
+	// guest starts at, the rest parked in the balloon. Zero (the default, and
+	// anything not strictly between 0 and MemoryMB) omits <currentMemory>
+	// entirely, leaving the domain XML exactly as it was before. Note this is a
+	// request the guest must honour via the virtio-balloon driver, not an
+	// enforced cap.
+	CurrentMemoryMB int `toml:"current_memory_mb"`
+
 	// LibvirtURI is the libvirt connection URI (eg: "qemu:///system"). Passed
 	// to virsh as `-c`.
 	LibvirtURI string `toml:"libvirt_uri"`

--- a/packages/garm-provider-vmharness/src/internal/provider/provider.go
+++ b/packages/garm-provider-vmharness/src/internal/provider/provider.go
@@ -70,6 +70,7 @@ func NewWithConfig(cfg *config.Config) (*Provider, error) {
 			UEFINVRAMTemplate: cfg.UEFINVRAMTemplate,
 			MemoryMB:          cfg.MemoryMB,
 			VCPUs:             cfg.VCPUs,
+			CurrentMemoryMB:   cfg.CurrentMemoryMB,
 		}
 	case config.BackendIncus:
 		b = &backend.IncusBackend{

--- a/terraform/github/governance.nix
+++ b/terraform/github/governance.nix
@@ -251,8 +251,12 @@ let
     // optionalAttrs (repo ? allowRebaseMerge) { allow_rebase_merge = repo.allowRebaseMerge; }
     // optionalAttrs (repo ? mergeCommitTitle) { merge_commit_title = repo.mergeCommitTitle; }
     // optionalAttrs (repo ? mergeCommitMessage) { merge_commit_message = repo.mergeCommitMessage; }
-    // optionalAttrs (repo ? squashMergeCommitTitle) { squash_merge_commit_title = repo.squashMergeCommitTitle; }
-    // optionalAttrs (repo ? squashMergeCommitMessage) { squash_merge_commit_message = repo.squashMergeCommitMessage; }
+    // optionalAttrs (repo ? squashMergeCommitTitle) {
+      squash_merge_commit_title = repo.squashMergeCommitTitle;
+    }
+    // optionalAttrs (repo ? squashMergeCommitMessage) {
+      squash_merge_commit_message = repo.squashMergeCommitMessage;
+    }
   );
 
   branchDefaultResources =
@@ -446,14 +450,17 @@ let
   actionsRepositoryPermissionResources =
     listToResourceAttrs governance.actionsRepositoryPermissions
       (permissions: "actions-repository-permissions:${permissions.repository}")
-      (permissions: {
-        repository = permissions.repository;
-        enabled = permissions.enabled;
-        sha_pinning_required = permissions.shaPinningRequired;
-      }
-      // optionalAttrs (permissions ? allowedActions) {
-        allowed_actions = permissions.allowedActions;
-      });
+      (
+        permissions:
+        {
+          repository = permissions.repository;
+          enabled = permissions.enabled;
+          sha_pinning_required = permissions.shaPinningRequired;
+        }
+        // optionalAttrs (permissions ? allowedActions) {
+          allowed_actions = permissions.allowedActions;
+        }
+      );
 
   actionsVariableResources =
     listToResourceAttrs governance.actionsVariables

--- a/upstream-patches/CLAUDE.md
+++ b/upstream-patches/CLAUDE.md
@@ -3,7 +3,7 @@
 This directory collects fixes for upstream projects that we carry as a
 local patch in this repo and intend to contribute back upstream. It is the
 patch analog of `codetracer-native-backend/upstream-bugs/` (which collects
-*bug reports*); here each entry is a ready-to-submit *fix*.
+_bug reports_); here each entry is a ready-to-submit _fix_.
 
 Each subdirectory is named `<project>-<short-description>` and contains:
 

--- a/upstream-patches/garm-listinstances-inverted-error-check/fix.patch
+++ b/upstream-patches/garm-listinstances-inverted-error-check/fix.patch
@@ -53,4 +53,3 @@ index 3ff8aff..41822f8 100644
  			e.cfg.Name,      // label: provider
 -- 
 2.54.0
-


### PR DESCRIPTION
## Summary

- promote the current reviewed `dev` content to `main` so moving `@main` reusable-workflow consumers receive the setup-nix Darwin service-PATH fix from #590
- carry the already-reviewed opt-in GARM libvirt `<currentMemory>` support from #589; its default remains disabled (`0`)
- restore branch-content alignment after both constituent PRs merged to the repository default branch

## Exact expected effect

- Future reusable workflow/composite-action jobs resolving `metacraft-labs/nixos-modules/...@main` use the portable setup verifier: existing service PATH entries and the selected Nix stay first, conventional system/profile paths are appended, and missing helper tools fail as utility errors.
- The GARM module gains an opt-in `currentMemoryMb` setting for libvirt providers. The default `0` emits nothing, so existing consumers retain byte-identical provider configuration unless they explicitly opt in.
- This repository-only promotion performs no machine deployment, Terraform plan/apply, secret change, runner restart, cloud mutation, or topology change. Flake consumers remain pinned until their lock/input revisions are deliberately updated.

## Integrated revisions

- `main` before promotion: `08ac66a36417abf4f683158622a931e8d3c527b8`
- `dev` source: `a6b3b3f6eb8f8ea619fe8fda4778597d451a9a99`
- constituent PRs: #589 and #590

## Verification

- #589 carried its provider/domain XML and module assertion tests.
- #590 passed 25 mutation-backed setup verifier assertions, Bash syntax, ShellCheck, changed-file hooks, the targeted Nix check, all-system flake evaluation, and `git diff --check`.
- The exact `main..dev` diff passes `git diff --check`.
- Metacraft organization CI is currently backlogged; this promotion does not claim queued checks passed.
