### PR TITLE
sync: promote current reprobuild cache pin to main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4291,17 +4291,17 @@
         "stackable-hooks-src": "stackable-hooks-src"
       },
       "locked": {
-        "lastModified": 1787264122,
-        "narHash": "sha256-dCcFZn6kLSQm0R78AcErwB3KPgmBP+nO9Eg7llP6K+g=",
+        "lastModified": 1787308223,
+        "narHash": "sha256-XXla7WQMuGOk5Df0rTCG8iTnL6AJ7ir1ffWRi32kGK8=",
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "1b074d5eb5b8ea50728344a0613483d156be7991",
+        "rev": "9b03784ffdc75f9636116d961b9edc1d09e2a79d",
         "type": "github"
       },
       "original": {
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "1b074d5eb5b8ea50728344a0613483d156be7991",
+        "rev": "9b03784ffdc75f9636116d961b9edc1d09e2a79d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     # servers through this input, so an explicit pin keeps the installed
     # `repro` reproducible. Bump this SHA to roll forward (the mainline is the
     # `dev` branch; `main` was retired).
-    reprobuild.url = "github:metacraft-labs/reprobuild/1b074d5eb5b8ea50728344a0613483d156be7991";
+    reprobuild.url = "github:metacraft-labs/reprobuild/9b03784ffdc75f9636116d961b9edc1d09e2a79d";
 
     nixpkgs.follows = "nixos-2511";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
## Summary

- promote the current `dev` content to `main` so both integration branches expose the same reproducible reprobuild cache-service revision;
- carry only the explicit reprobuild pin update from `1b074d5eb5b8ea50728344a0613483d156be7991` to `9b03784ffdc75f9636116d961b9edc1d09e2a79d`;
- restore branch-content alignment after `dev` advanced one commit beyond `main`.

## Exact expected effect

- `flake.nix` and `flake.lock` resolve reprobuild at exact revision `9b03784ffdc75f9636116d961b9edc1d09e2a79d` with NAR hash `sha256-XXla7WQMuGOk5Df0rTCG8iTnL6AJ7ir1ffWRi32kGK8=`.
- No reusable Terraform workflow/module source changes in this repository.
- No Terraform plan/apply, machine deployment, cache mutation, secret change, runner restart, cloud mutation, or topology change occurs from this repository-only promotion.
- Existing consumers remain pinned until their lock/input revisions are deliberately updated. Metacraft infra `live` revision `a7d0e4ccb54c6545c2b9f0c610d988ff7225fb82` already consumes this exact nixos-modules and reprobuild pair.

## Integrated revisions

- `main` before promotion: `7ee72247fd74c314ce3b35e0c4a43277d6f12297`
- `dev` source: `cb2fcb2ae83963f7dd1425a291b4f0a907f4f962`
- exact relation: `main` is the sole parent of `dev` (0 main-only, 1 dev-only commit).

## Verification

- `git diff --check origin/main..origin/dev` passes.
- The exact diff is 2 files, 5 insertions, 5 deletions.
- `nix flake metadata --no-write-lock-file --json github:metacraft-labs/nixos-modules/cb2fcb2ae83963f7dd1425a291b4f0a907f4f962` resolves the exact nixos-modules revision, reprobuild revision, and NAR hash listed above.
- Metacraft infra live run `32474550532` passed the complete reusable CI Final Results against this exact input pair; its separate lint failure is the known Cloudflare formatting drift being corrected by metacraft-infra PR #1309, and is not attributed to this two-file pin promotion.

After merge, `dev` will be fast-forwarded to the resulting `main` commit so both branch refs are identical again.
