### PR TITLE
sync: promote current reprobuild pin to main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4291,17 +4291,17 @@
         "stackable-hooks-src": "stackable-hooks-src"
       },
       "locked": {
-        "lastModified": 1787308223,
-        "narHash": "sha256-XXla7WQMuGOk5Df0rTCG8iTnL6AJ7ir1ffWRi32kGK8=",
+        "lastModified": 1787320247,
+        "narHash": "sha256-cOZ/2Op+QrzT0gArmwUCEj0u9vOuxc69+hE0xI647oU=",
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "9b03784ffdc75f9636116d961b9edc1d09e2a79d",
+        "rev": "8c47b5239a85970ac038fa67bbaecca962191fa1",
         "type": "github"
       },
       "original": {
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "9b03784ffdc75f9636116d961b9edc1d09e2a79d",
+        "rev": "8c47b5239a85970ac038fa67bbaecca962191fa1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     # servers through this input, so an explicit pin keeps the installed
     # `repro` reproducible. Bump this SHA to roll forward (the mainline is the
     # `dev` branch; `main` was retired).
-    reprobuild.url = "github:metacraft-labs/reprobuild/9b03784ffdc75f9636116d961b9edc1d09e2a79d";
+    reprobuild.url = "github:metacraft-labs/reprobuild/8c47b5239a85970ac038fa67bbaecca962191fa1";
 
     nixpkgs.follows = "nixos-2511";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
Promotes the single signed `dev` commit `e14e82858d55fc82c5b10c4bf423cd7cecb11290` to `main`, updating only the reproducible reprobuild source pin from `9b03784ffdc75f9636116d961b9edc1d09e2a79d` to `8c47b5239a85970ac038fa67bbaecca962191fa1` in `flake.nix` and `flake.lock`.

Expected impact:
- exactly two source files change (`flake.nix`, `flake.lock`);
- the reprobuild input advances to the already integrated metacraft-infra revision;
- no Terraform root, workflow, state, provider, backend, output, or cloud resource changes;
- no deployment is initiated by this PR;
- after merge, `dev` will be fast-forwarded to the merge commit so `main` and `dev` are byte-identical again.

Any additional source change, unexpected lock graph movement, Terraform effect, or deployment effect contradicts this expectation and blocks the reconciliation.