### PR TITLE
fix(setup-nix): survive an empty system-paths array on macOS (bash 3.2)

### DIFF
--- a/.github/setup-nix/verify-nix-config.sh
+++ b/.github/setup-nix/verify-nix-config.sh
@@ -67,7 +67,15 @@ setup_nix_system_paths=(
   /run/current-system/sw/bin
   /nix/var/nix/profiles/default/bin
 )
-for setup_nix_system_dir in "${setup_nix_system_paths[@]}"; do
+# `${a[@]+"${a[@]}"}` rather than a plain `"${a[@]}"`: on bash < 4.4 — which is
+# what macOS ships as /bin/bash, and therefore what the aarch64-darwin runner
+# executes this with — expanding an EMPTY array under `set -u` is a fatal
+# "unbound variable" error. The contract test builds a mutation of this script
+# with the path entries deleted, so the empty case is real and must stay
+# runnable. The outer expansion is unquoted on purpose: that is what makes it
+# vanish entirely when the array is empty, while the inner "${a[@]}" keeps every
+# element individually quoted so paths containing spaces still survive.
+for setup_nix_system_dir in ${setup_nix_system_paths[@]+"${setup_nix_system_paths[@]}"}; do
   if [ -d "$setup_nix_system_dir" ]; then
     case ":${PATH:-}:" in
       *":$setup_nix_system_dir:"*) ;;


### PR DESCRIPTION
`Validate setup-nix verification (aarch64-darwin)` has been red since 2026-08-20, at 8 of 25 assertions:

```
setup_nix_system_paths[@]: unbound variable
```

## Cause

Expanding an empty array as `"${a[@]}"` under `set -u` is **fatal before bash 4.4**. macOS ships bash 3.2; Linux runners have bash 5. That version difference is the entire reason this job fails on `aarch64-darwin` and passes everywhere else.

The harness deliberately generates a fixture with that array emptied, which is exactly the case the expansion cannot survive.

Worth being precise about the blast radius: **the shipped guard was never broken on macOS** — only the mutated test copy was. This is a test-harness portability fix, not a production defect.

## Verification

25/25 assertions pass under **both bash 4.3 and bash 5.3**, so the fix is verified against a pre-4.4 shell rather than assumed.