### PR TITLE
fix(mcl-s3-artifact-store): give mcl-garage-issue-key the awk it pipes into

### DIFF
--- a/modules/mcl-s3-artifact-store/default.nix
+++ b/modules/mcl-s3-artifact-store/default.nix
@@ -114,6 +114,11 @@
         runtimeInputs = [
           mcl-garage
           pkgs.jq
+          # The stale-key prune below pipes `key list` into awk. A systemd
+          # unit's PATH has no gawk, and writeShellApplication only *prepends*
+          # runtimeInputs, so without this the pipeline exits 127 under
+          # `set -o pipefail` and the function dies before it prints its JSON.
+          pkgs.gawk
         ];
         text = ''
           set -euo pipefail
@@ -241,6 +246,14 @@
 
           # Pass 2: apply each bucket's S3 lifecycle expiry (mirrors the Attic
           # retention-period / artifact retention-days).
+          if [[ -z "$bootstrapKeyJson" ]]; then
+            # This used to be silent: the unit skipped every lifecycle rule,
+            # printed "complete." and exited 0, so a broken key mint looked
+            # exactly like a healthy boot.
+            echo "s3-artifact-store-bootstrap: WARNING could not mint the bootstrap key;" \
+              "no lifecycle expiry was applied to any bucket." >&2
+          fi
+
           if [[ -n "$bootstrapKeyJson" ]]; then
             keyId=$(jq -r '.keyId' <<<"$bootstrapKeyJson")
             secret=$(jq -r '.secretKey' <<<"$bootstrapKeyJson")


### PR DESCRIPTION
`t_s3_artifact_store_acl_and_creds` has been red since 2026-07-30:

```
get-bucket-lifecycle-configuration -> 404 NoSuchLifecycleConfiguration (aws exit 254)
```

## Cause

`mcl-garage-issue-key` pipes `garage key list` into `awk` but never declares `gawk`. A systemd unit's PATH has no awk, so under `writeShellApplication`'s `set -o pipefail` the script dies at **exit 127** before printing its key JSON.

The bootstrap unit then swallowed that with `|| true`, **skipped the entire lifecycle pass, logged "complete." and exited 0.**

## ⚠ Operational consequence, beyond the failing check

Because the lifecycle pass has been silently skipped, hosts running this unit have very likely had **no expiry rule on their artifact buckets since 2026-07-30** — so those buckets have been growing unbounded for over three weeks. Worth checking actual bucket sizes on affected hosts independently of this fix.

## Verification

Builds and passes locally.