### PR TITLE
garm-incus-runner-host: let storagePool express a ZFS source, and make loop-file backing impossible to get by accident

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -18,6 +18,7 @@
     ./garm-multi-provider.nix
     ./garm-reconcile.nix
     ./garm-incus-runner-host.nix
+    ./garm-incus-storage-pool-source.nix
     ./garm-macos-runner-install-wrapper.nix
     ./garm-provider-vmharness-protocol.nix
     ./garm-provider-vmharness-windows-toolchain.nix

--- a/checks/garm-incus-storage-pool-source.nix
+++ b/checks/garm-incus-storage-pool-source.nix
@@ -1,0 +1,547 @@
+top@{ ... }:
+{
+  # Gate `t_garm_incus_storage_pool_source` — the `zfs` storage pool a GARM
+  # incus runner host declares must ADOPT an existing dataset, and the
+  # loop-file outcome must be impossible to reach by accident.
+  #
+  # ── THE DEFECT THIS GATE EXISTS TO KEEP OUT ────────────────────────────────
+  #
+  # `services.garm-incus-runner-host.storagePool` used to carry only `name` and
+  # `driver`, and `garm-incus-storage-network` ran a bare
+  #   incus storage create "$pool" "$driver"
+  # Incus does not treat a source-less `zfs` pool as an error. Its
+  # driver_zfs.go `FillConfig()` has an explicit branch for it:
+  #
+  #   } else if len(devices) == 0 || (len(devices) == 1 && devices[0] == loopPath) {
+  #           // Create a loop based pool.
+  #           d.config["source"] = loopPath          // <varpath>/disks/<pool>.img
+  #
+  # so `driver = "zfs"` ALONE gets you a sparse file under
+  # /var/lib/incus/disks/, a zpool built inside it, and — this is the part that
+  # makes it dangerous rather than merely wrong — `incus storage list` that
+  # goes on reporting `driver: zfs`. Every per-job container rootfs then lives
+  # in a zpool stacked on a file on the host's real pool: strictly worse than
+  # the `dir` driver a ZFS cutover exists to remove, with nothing anywhere
+  # saying so. The btrfs and lvm drivers have the same branch.
+  #
+  # The one check that tells the two apart is `ls -A /var/lib/incus/disks/`,
+  # which must be EMPTY on a host with adopted backing stores. This gate is
+  # built around exactly that check.
+  #
+  # ── HOW THIS GATE DISCRIMINATES (the negative controls) ────────────────────
+  #
+  # A gate that only asserted "the adopted pool has source=X" would pass on a
+  # host where Incus quietly ignored the key, and would say nothing about
+  # whether the hazard is real on the Incus actually pinned here. So:
+  #
+  #   (A) EVAL. Four evaluations of the SAME module differing in one option
+  #       each, asserting that the rejection fires on exactly the dangerous one
+  #       and on nothing else — including that the message names the loop-file
+  #       path and the remedy, and that `dir` (which has no such fallback) is
+  #       untouched.
+  #
+  #   (B) RUNTIME NEGATIVE CONTROL — node `loopfile`. The same module, with
+  #       `allowLoopFileBacking = true`, i.e. byte-for-byte the behaviour the
+  #       module had BEFORE this change (a bare `incus storage create <pool>
+  #       zfs`). It asserts the defect REPRODUCES on this Incus: the unit is
+  #       GREEN, `incus storage show` reports `driver: zfs`, and yet
+  #       /var/lib/incus/disks/<pool>.img exists and the pool's `source` is
+  #       that file. If a future Incus ever stopped doing this, this node fails
+  #       and the whole premise of the fix gets re-examined rather than the fix
+  #       silently becoming decorative.
+  #
+  #   (C) RUNTIME POSITIVE — node `adopted`. `source` set to a pre-existing
+  #       dataset: the pool adopts it (`source` and `zfs.pool_name` both point
+  #       at the real dataset), Incus creates its volume datasets underneath
+  #       it, and /var/lib/incus/disks/ is EMPTY.
+  #
+  #   (D) THE RUNTIME GUARD IS NOT DECORATIVE. On the `adopted` node the gate
+  #       PLANTS a loop file at the path the driver would have used and
+  #       restarts the convergence oneshot; the unit must FAIL and say so. An
+  #       eval-time assertion only constrains what this module renders — it
+  #       says nothing about what a previous generation left on the host — so
+  #       the on-host re-check has to be proven too.
+  #
+  # Both runtime nodes neutralise nixpkgs' `incus-preseed.service` (test-only
+  # `mkForce`, and the ONLY mkForce in this file) so that the module's
+  # `garm-incus-storage-network` oneshot is provably the thing that creates the
+  # pool. That is not an artificial arrangement: it is the documented state of
+  # gpu-server-001, whose incus daemon self-initialised empty before this
+  # config landed, which is why the convergence oneshot exists at all. Node
+  # `preseeded` covers the other half — a fresh incus where the PRESEED is the
+  # creator — and asserts `incus-preseed.service` is green, because a preseed
+  # that under-declares the pool's driver leaves that unit permanently red
+  # ("Storage pool X is of type zfs instead of dir").
+  perSystem =
+    {
+      pkgs,
+      lib,
+      ...
+    }:
+    let
+      flake = top.config.flake;
+
+      subnet = "10.157.159.0/24";
+
+      # The gate's own zpool, and the dataset a declared pool must adopt. Named
+      # after the milestone rather than after any host so nothing here can be
+      # mistaken for a live configuration.
+      zpoolName = "gatepool";
+      backingDataset = "${zpoolName}/incus-storage";
+      vdevFile = "/var/lib/gate-vdev.img";
+
+      # ---- (A) the eval-time half ------------------------------------------
+      #
+      # Evaluate the module standalone (no VM) and read back `config.assertions`
+      # rather than letting the module system throw, so a REJECTION is an
+      # observable value we can assert the content of.
+      evalRunnerHost =
+        storagePool: extra:
+        (lib.evalModules {
+          specialArgs = { inherit pkgs; };
+          modules = [
+            flake.modules.nixos.garm-incus-runner-host
+            {
+              options = {
+                # The handful of things the module reads out of the wider NixOS
+                # config. Stubbed so this eval needs no full nixosSystem.
+                virtualisation.incus.package = lib.mkOption {
+                  type = lib.types.package;
+                  default = pkgs.incus;
+                };
+                virtualisation.incus.preseed = lib.mkOption {
+                  type = lib.types.attrsOf lib.types.anything;
+                  default = { };
+                };
+                boot.kernelModules = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                };
+                systemd.services = lib.mkOption {
+                  type = lib.types.attrsOf lib.types.anything;
+                  default = { };
+                };
+                assertions = lib.mkOption {
+                  type = lib.types.listOf lib.types.anything;
+                  default = [ ];
+                };
+              };
+            }
+            {
+              services.garm-incus-runner-host = {
+                enable = true;
+                bridgeSubnet = subnet;
+                image.enable = false;
+                inherit storagePool;
+              }
+              // extra;
+            }
+          ];
+        }).config;
+
+      # The failing assertion messages of one such evaluation.
+      failedMessages =
+        cfg: map (a: a.message) (builtins.filter (a: !a.assertion) (cfg.assertions or [ ]));
+
+      evalCases = {
+        # THE DANGEROUS DECLARATION — must be rejected.
+        zfsNoSource = evalRunnerHost {
+          name = "default";
+          driver = "zfs";
+        } { };
+        # The fix — must be accepted. `extraConfig` rides along so the
+        # pass-through for every OTHER pool config key is covered too; an
+        # option nothing exercises is an option that quietly stops working.
+        zfsWithSource = evalRunnerHost {
+          name = "default";
+          driver = "zfs";
+          source = backingDataset;
+          extraConfig."zfs.clone_copy" = "rebase";
+        } { };
+        # The explicit opt-in — must be accepted.
+        zfsOptIn = evalRunnerHost {
+          name = "default";
+          driver = "zfs";
+          allowLoopFileBacking = true;
+        } { };
+        # `dir` has no loop-file fallback — must NOT be caught by the rejection.
+        dirNoSource = evalRunnerHost { name = "default"; } { };
+        # The module creates no pool at all here, so there is nothing to reject.
+        zfsNoSourceUnmanaged = evalRunnerHost {
+          name = "default";
+          driver = "zfs";
+        } { managePreseed = false; };
+        # btrfs shares driver_zfs.go's loop-file branch — must be rejected too.
+        btrfsNoSource = evalRunnerHost {
+          name = "default";
+          driver = "btrfs";
+        } { };
+      };
+
+      rejection = lib.head (failedMessages evalCases.zfsNoSource ++ [ "" ]);
+
+      evalFailures =
+        # The rejection fires ...
+        lib.optional (failedMessages evalCases.zfsNoSource == [ ])
+          "driver = \"zfs\" with no `source` and managePreseed = true was ACCEPTED; the module still renders a silent loop-file pool"
+        ++ lib.optional (
+          failedMessages evalCases.btrfsNoSource == [ ]
+        ) "driver = \"btrfs\" with no `source` was ACCEPTED; btrfs has the same loop-file fallback as zfs"
+        # ... and says what is wrong, where the damage lands, and how to fix it.
+        # A rejection nobody can act on is a different bug, not a fix.
+        ++ lib.optional (
+          !(lib.hasInfix "/var/lib/incus/disks/default.img" rejection)
+        ) "the rejection does not name the loop file it prevents: ${rejection}"
+        ++ lib.optional (
+          !(lib.hasInfix "storagePool.source" rejection)
+        ) "the rejection does not name the option that fixes it: ${rejection}"
+        ++ lib.optional (
+          !(lib.hasInfix "allowLoopFileBacking" rejection)
+        ) "the rejection does not name the opt-in escape hatch: ${rejection}"
+        # ... and ONLY on the dangerous declaration.
+        ++
+          lib.optional (failedMessages evalCases.zfsWithSource != [ ])
+            "declaring `source` did NOT satisfy the module: ${toString (failedMessages evalCases.zfsWithSource)}"
+        ++
+          lib.optional (failedMessages evalCases.zfsOptIn != [ ])
+            "allowLoopFileBacking = true did NOT satisfy the module: ${toString (failedMessages evalCases.zfsOptIn)}"
+        ++
+          lib.optional (failedMessages evalCases.dirNoSource != [ ])
+            "the `dir` driver was rejected; it has no loop-file fallback and must be untouched: ${toString (failedMessages evalCases.dirNoSource)}"
+        ++
+          lib.optional (failedMessages evalCases.zfsNoSourceUnmanaged != [ ])
+            "managePreseed = false was rejected; with it the module creates no pool, so there is nothing to reject: ${toString (failedMessages evalCases.zfsNoSourceUnmanaged)}"
+        # The declared `source` must reach BOTH renderers. The preseed and the
+        # oneshot create the pool on different hosts (fresh vs already
+        # self-initialised incus); a `source` that reached only one of them
+        # would leave the other producing the loop file.
+        ++ lib.optional (
+          let
+            pools = evalCases.zfsWithSource.virtualisation.incus.preseed.storage_pools or [ ];
+          in
+          !(builtins.length pools == 1 && (lib.head pools).config.source or null == backingDataset)
+        ) "the preseed's storage_pools entry does not carry config.source = ${backingDataset}"
+        ++ lib.optional (
+          let
+            pools = evalCases.zfsWithSource.virtualisation.incus.preseed.storage_pools or [ ];
+          in
+          !(builtins.length pools == 1 && (lib.head pools).config."zfs.clone_copy" or null == "rebase")
+        ) "storagePool.extraConfig does not reach the preseed's config block"
+        ++ lib.optional (
+          let
+            unit = evalCases.zfsWithSource.systemd.services.garm-incus-storage-network or null;
+            exec = if unit == null then "" else toString (unit.serviceConfig.ExecStart or "");
+            script = if exec == "" then "" else builtins.readFile exec;
+          in
+          !(lib.hasInfix "'zfs.clone_copy=rebase'" script)
+        ) "storagePool.extraConfig does not reach `incus storage create`"
+        ++ lib.optional (
+          let
+            unit = evalCases.zfsWithSource.systemd.services.garm-incus-storage-network or null;
+            exec = if unit == null then "" else toString (unit.serviceConfig.ExecStart or "");
+            script = if exec == "" then "" else builtins.readFile exec;
+          in
+          # Match the EXECUTABLE invocation, not the word. A bare
+          # `hasInfix "source=<dataset>"` was vacuous when this was first
+          # written: the unit's own progress `echo` mentions
+          # "(zfs, source=<dataset>)", so deleting the argument from
+          # `incus storage create` — the whole defect — still satisfied it.
+          # Verified by doing exactly that: `poolCreateArgs = [ ]` left the
+          # gate GREEN. Pinning the argument position (single-quoted by
+          # lib.escapeShellArgs, right after the driver) is what makes this
+          # discriminate.
+          !(lib.hasInfix "storage create \"$pool\" \"$driver\" 'source=${backingDataset}'" script)
+        ) "garm-incus-storage-network never passes source=${backingDataset} to `incus storage create`";
+
+      evalReport =
+        if evalFailures == [ ] then
+          ''
+            (A) eval contract OK:
+              - driver = "zfs" / "btrfs" with no `source` and managePreseed = true
+                is REJECTED, naming /var/lib/incus/disks/<pool>.img, the
+                `storagePool.source` remedy, and the `allowLoopFileBacking` opt-in
+              - `source`, `allowLoopFileBacking = true`, the `dir` driver and
+                managePreseed = false are each ACCEPTED (no false positives)
+              - the declared source reaches BOTH the preseed's storage_pools
+                config block and `incus storage create` in
+                garm-incus-storage-network
+          ''
+        else
+          throw ''
+            (A) eval contract FAILED:
+            - ${lib.concatStringsSep "\n- " evalFailures}
+          '';
+
+      # ---- (B)/(C)/(D) the runtime half ------------------------------------
+      #
+      # Shared node skeleton. ZFS in a nixosTest needs the module loaded and a
+      # hostId; the vdev is a sparse file on the VM's own disk so nothing here
+      # depends on the builder's RAM.
+      baseNode =
+        { config, ... }:
+        {
+          imports = [ flake.modules.nixos.garm-incus-runner-host ];
+
+          boot.supportedFilesystems.zfs = true;
+          boot.kernelModules = [ "zfs" ];
+          networking.hostId = "c0ffee01";
+          networking.nftables.enable = true;
+
+          virtualisation.incus.enable = true;
+          # Incus refuses to build a default-sized loop pool with less than
+          # 5 GiB free under /var/lib/incus (drivers/utils.go
+          # loopFileSizeDefault), and the negative control NEEDS that path to
+          # succeed — a node that was merely too small would "pass" it for the
+          # wrong reason.
+          virtualisation.diskSize = 16384;
+          virtualisation.memorySize = 4096;
+
+          environment.systemPackages = [
+            config.boot.zfs.package
+            pkgs.jq
+          ];
+
+          services.garm-incus-runner-host = {
+            enable = true;
+            bridgeSubnet = subnet;
+            # Nothing here is about images; keep the import oneshot out of the
+            # way so a failure can only be about storage.
+            image.enable = false;
+          };
+        };
+
+      # The host-side provisioning of the backing store. Deliberately a
+      # SEPARATE unit ordered before incus, mirroring how a real host provisions
+      # the dataset (`ensure-incus-storage-dataset`): this module ADOPTS an
+      # existing dataset, it never creates one.
+      zpoolNode =
+        { config, ... }:
+        {
+          systemd.services.gate-zpool = {
+            description = "Gate: create the zpool + dataset the declared Incus pool must adopt";
+            before = [ "incus.service" ];
+            wantedBy = [ "multi-user.target" ];
+            path = [
+              config.boot.zfs.package
+              pkgs.coreutils
+            ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+            };
+            script = ''
+              set -euo pipefail
+              if ! zpool list -H -o name ${zpoolName} >/dev/null 2>&1; then
+                truncate -s 4G ${vdevFile}
+                zpool create -f ${zpoolName} ${vdevFile}
+              fi
+              if ! zfs list -H -o name ${backingDataset} >/dev/null 2>&1; then
+                zfs create -o mountpoint=none ${backingDataset}
+              fi
+            '';
+          };
+          # incus (and therefore incus-preseed, which is After=incus.service)
+          # must not run before the dataset exists.
+          systemd.services.incus = {
+            after = [ "gate-zpool.service" ];
+            wants = [ "gate-zpool.service" ];
+          };
+        };
+
+      # The ONLY mkForce in this gate, and it is test-only: it reproduces the
+      # documented gpu-server-001 state — an incus daemon that self-initialised
+      # empty before this config landed, where nixpkgs' preseed contributes
+      # nothing and `garm-incus-storage-network` is the sole creator of the
+      # pool. Without it the preseed wins the race on both runtime nodes and
+      # the oneshot's `incus storage create` path would never be exercised.
+      preseedInert = {
+        systemd.services.incus-preseed.wantedBy = lib.mkForce [ ];
+      };
+    in
+    {
+      checks = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        t_garm_incus_storage_pool_source =
+          let
+            e2e = pkgs.testers.nixosTest {
+              name = "t_garm_incus_storage_pool_source";
+
+              nodes = {
+                # (C)+(D) the fix: a declared `source` adopts the dataset.
+                adopted =
+                  { ... }:
+                  {
+                    imports = [
+                      baseNode
+                      zpoolNode
+                      preseedInert
+                    ];
+                    services.garm-incus-runner-host.storagePool = {
+                      name = "default";
+                      driver = "zfs";
+                      source = backingDataset;
+                    };
+                  };
+
+                # (B) the negative control: the pre-fix behaviour, opted into.
+                loopfile =
+                  { ... }:
+                  {
+                    imports = [
+                      baseNode
+                      preseedInert
+                    ];
+                    services.garm-incus-runner-host.storagePool = {
+                      name = "default";
+                      driver = "zfs";
+                      # No `source` — exactly what the module used to emit
+                      # unconditionally. The opt-in is the only reason this
+                      # node evaluates at all, which is itself the point.
+                      allowLoopFileBacking = true;
+                    };
+                  };
+
+                # The other creator: a FRESH incus, where the preseed applies.
+                preseeded =
+                  { ... }:
+                  {
+                    imports = [
+                      baseNode
+                      zpoolNode
+                    ];
+                    services.garm-incus-runner-host.storagePool = {
+                      name = "default";
+                      driver = "zfs";
+                      source = backingDataset;
+                    };
+                  };
+              };
+
+              testScript = ''
+                start_all()
+
+                for m in (adopted, loopfile, preseeded):
+                    m.wait_for_unit("multi-user.target")
+                    m.wait_for_unit("incus.service")
+
+                with subtest("(B) NEGATIVE CONTROL: a source-less zfs pool IS silently loop-file backed"):
+                    # This node runs the module with allowLoopFileBacking = true,
+                    # i.e. the bare `incus storage create <pool> zfs` the module
+                    # used to run unconditionally. Everything about it looks
+                    # healthy — which is the defect.
+                    loopfile.wait_for_unit("garm-incus-storage-network.service")
+                    result = loopfile.succeed(
+                        "systemctl show -p Result --value garm-incus-storage-network.service"
+                    ).strip()
+                    assert result == "success", f"negative-control oneshot result={result!r}"
+
+                    pool_driver = loopfile.succeed(
+                        "incus storage show default | sed -n 's/^driver: //p'"
+                    ).strip()
+                    assert pool_driver == "zfs", f"negative control did not produce a zfs pool: {pool_driver!r}"
+
+                    # ... and yet:
+                    disks = loopfile.succeed("ls -A /var/lib/incus/disks/ || true").strip()
+                    assert "default.img" in disks, (
+                        "the loop-file hazard did NOT reproduce on this Incus "
+                        f"(/var/lib/incus/disks is {disks!r}); the premise of this fix "
+                        "no longer holds and must be re-examined"
+                    )
+                    src = loopfile.succeed("incus storage get default source").strip()
+                    assert src == "/var/lib/incus/disks/default.img", (
+                        f"negative-control pool source={src!r}"
+                    )
+                    # The `zfs list` view is the plainest statement of what went
+                    # wrong: a whole zpool living inside one file.
+                    print(loopfile.succeed("zpool status default || true"))
+
+                with subtest("(C) the declared source makes the pool ADOPT the existing dataset"):
+                    adopted.wait_for_unit("garm-incus-storage-network.service")
+                    result = adopted.succeed(
+                        "systemctl show -p Result --value garm-incus-storage-network.service"
+                    ).strip()
+                    assert result == "success", f"convergence oneshot result={result!r}"
+                    # The oneshot, not the preseed, created it here.
+                    adopted.succeed(
+                        "journalctl -u garm-incus-storage-network.service "
+                        "| grep -qF \"creating storage pool 'default' (zfs, source=${backingDataset})\""
+                    )
+
+                    pool_driver = adopted.succeed(
+                        "incus storage show default | sed -n 's/^driver: //p'"
+                    ).strip()
+                    assert pool_driver == "zfs", f"pool driver={pool_driver!r}"
+                    src = adopted.succeed("incus storage get default source").strip()
+                    assert src == "${backingDataset}", f"pool source={src!r}"
+                    pool_name = adopted.succeed("incus storage get default zfs.pool_name").strip()
+                    assert pool_name == "${backingDataset}", f"zfs.pool_name={pool_name!r}"
+
+                with subtest("(C) THE discriminator: /var/lib/incus/disks/ is empty"):
+                    disks = adopted.succeed("ls -A /var/lib/incus/disks/ 2>/dev/null || true").strip()
+                    assert disks == "", (
+                        f"/var/lib/incus/disks is not empty ({disks!r}) — the pool is "
+                        "loop-file backed, not adopted"
+                    )
+
+                with subtest("(C) Incus really writes into the adopted dataset"):
+                    # Datasets appearing UNDER the adopted one is the positive
+                    # proof that the pool is rooted there rather than merely
+                    # labelled with its name.
+                    adopted.succeed("incus storage volume create default gatevol")
+                    datasets = adopted.succeed("zfs list -H -o name -r ${backingDataset}")
+                    assert "${backingDataset}/custom" in datasets, (
+                        f"no volume datasets under ${backingDataset}: {datasets!r}"
+                    )
+                    adopted.succeed("incus storage volume delete default gatevol")
+
+                with subtest("(D) the on-host guard fails the unit if a loop file ever appears"):
+                    # An eval assertion constrains what this module RENDERS; it
+                    # says nothing about a loop file an earlier generation left
+                    # behind. Plant one and require the unit to refuse.
+                    adopted.succeed("mkdir -p /var/lib/incus/disks && touch /var/lib/incus/disks/default.img")
+                    adopted.fail("systemctl restart garm-incus-storage-network.service")
+                    adopted.succeed(
+                        "journalctl -u garm-incus-storage-network.service "
+                        "| grep -qF 'LOOP-FILE BACKED'"
+                    )
+                    adopted.succeed("rm -f /var/lib/incus/disks/default.img")
+                    adopted.succeed("systemctl restart garm-incus-storage-network.service")
+
+                with subtest("the preseed alone also produces an ADOPTED pool, and stays green"):
+                    # `incus admin init --preseed` HARD-FAILS on a driver
+                    # mismatch against an existing pool, so a preseed that
+                    # under-declares the pool leaves this unit permanently red.
+                    preseeded.wait_for_unit("incus-preseed.service")
+                    result = preseeded.succeed(
+                        "systemctl show -p Result --value incus-preseed.service"
+                    ).strip()
+                    assert result == "success", f"incus-preseed.service result={result!r}"
+                    src = preseeded.succeed("incus storage get default source").strip()
+                    assert src == "${backingDataset}", f"preseeded pool source={src!r}"
+                    disks = preseeded.succeed("ls -A /var/lib/incus/disks/ 2>/dev/null || true").strip()
+                    assert disks == "", f"preseeded /var/lib/incus/disks is not empty ({disks!r})"
+
+                with subtest("the default profile's root disk lands on the adopted pool"):
+                    for m in (adopted, preseeded):
+                        rootpool = m.succeed("incus profile device get default root pool").strip()
+                        assert rootpool == "default", f"root device pool={rootpool!r}"
+              '';
+            };
+          in
+          pkgs.runCommand "t_garm_incus_storage_pool_source"
+            {
+              passthru = { inherit e2e; };
+              meta.description =
+                "A declared zfs storage pool adopts an existing dataset; the "
+                + "silent loop-file fallback is rejected at eval and refused on the host";
+            }
+            ''
+              mkdir -p "$out"
+              cat > "$out/eval-contract.txt" <<'EOF'
+              ${evalReport}
+              EOF
+              ln -s ${e2e} "$out/e2e"
+              echo passed > "$out/result"
+            '';
+      };
+    };
+}

--- a/modules/garm/incus-runner-host.nix
+++ b/modules/garm/incus-runner-host.nix
@@ -12,7 +12,9 @@
   #   (2) `virtualisation.incus.preseed` for the FULL host triple a fresh GARM
   #       host needs — the managed `incusbr0` bridge on the per-host /24
   #       (high-mem-server 10.157.159.0/24, gpu-server-001 10.158.160.0/24), a
-  #       `dir` storage pool, and the `default` profile's root+eth0 devices.
+  #       storage pool on the declared driver/`source` (`dir` by default; a
+  #       `zfs` pool ADOPTS an existing dataset), and the `default` profile's
+  #       root+eth0 devices.
   #       nixpkgs' incus module ships an idempotent `incus-preseed.service`
   #       (ordered After=incus.service) that applies the preseed; the preseed
   #       CREATES/UPDATES entities but never REMOVES them, so it is safe to
@@ -140,10 +142,82 @@
           driver = mkOption {
             type = types.str;
             default = "dir";
+            example = "zfs";
             description = ''
-              The storage pool driver. `dir` (the default) matches
-              high-mem-server and needs no extra host setup (a plain directory
-              pool under /var/lib/incus).
+              The storage pool driver. `dir` (the default) needs no extra host
+              setup (a plain directory pool under /var/lib/incus).
+
+              For `zfs`, `btrfs` and `lvm` you MUST also set
+              {option}`storagePool.source` (or opt in to
+              {option}`storagePool.allowLoopFileBacking`) — see the hazard
+              documented on `source`.
+            '';
+          };
+
+          source = mkOption {
+            type = types.str;
+            default = "";
+            example = "zroot/root/var/lib/incus-storage";
+            description = ''
+              The pool's `source=` config key — the EXISTING backing store the
+              pool ADOPTS. For the `zfs` driver this is a dataset name
+              (`<zpool>/<path>`); for `btrfs`/`lvm` a block device or existing
+              subvolume/VG; for `dir` an existing directory. Empty (the
+              default) leaves `source` unset.
+
+              THIS IS NOT COSMETIC ON A LOOP-FILE-CAPABLE DRIVER. Incus'
+              `FillConfig()` (internal/server/storage/drivers/driver_zfs.go,
+              and the btrfs/lvm equivalents) treats "no source" as a REQUEST
+              for a loop-backed pool: it rewrites `source` to
+              `/var/lib/incus/disks/<pool>.img`, creates a sparse file there
+              and builds the zpool/filesystem INSIDE it. No error, no warning,
+              and `incus storage list` still reports `driver: zfs` — so the
+              host looks converged while every per-job container rootfs lives
+              in a zpool-in-a-file stacked on the host's real pool, which is
+              strictly worse than the `dir` driver it replaced.
+
+              The check that distinguishes an adopted dataset from that
+              outcome is `ls -A /var/lib/incus/disks/` — it must be EMPTY. The
+              module refuses to render a loop-backed pool at eval time (see
+              {option}`storagePool.allowLoopFileBacking`) and re-checks the
+              live host in `garm-incus-storage-network`.
+            '';
+          };
+
+          extraConfig = mkOption {
+            type = types.attrsOf types.str;
+            default = { };
+            example = {
+              "zfs.pool_name" = "zroot";
+            };
+            description = ''
+              Additional storage-pool config keys, emitted verbatim in the
+              preseed's `config` block and passed as `key=value` arguments to
+              `incus storage create`. `source` has its own option above
+              because the module reasons about it; everything else
+              (`zfs.pool_name`, `size`, `lvm.vg_name`, `ceph.cluster_name`, …)
+              goes here.
+
+              Only consulted at pool CREATION — the convergence oneshot never
+              mutates an existing pool's config.
+            '';
+          };
+
+          allowLoopFileBacking = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Explicit opt-in to a LOOP-FILE-BACKED storage pool, i.e. a
+              `zfs`/`btrfs`/`lvm` pool declared with no
+              {option}`storagePool.source`, which Incus silently builds inside
+              `/var/lib/incus/disks/<pool>.img`.
+
+              With this `false` (the default) that configuration is REJECTED at
+              eval time, and `garm-incus-storage-network` additionally fails
+              the host if a loop file for the declared pool is ever found on
+              disk. Set it true only when a file-backed pool is what you
+              actually want (a throwaway VM, a laptop, a test); it is never
+              what a CI runner host wants.
             '';
           };
         };
@@ -191,6 +265,38 @@
           derivedGateway = lib.concatStringsSep "." ((lib.sublist 0 3 octets) ++ [ "1" ]);
           gateway = if cfg.bridgeGateway != "" then cfg.bridgeGateway else derivedGateway;
 
+          # ---- The storage pool's config block ---------------------------------
+          #
+          # `source` gets its own option (the module reasons about it — see the
+          # loop-file hazard below); everything else is passed through verbatim.
+          # One value, rendered into BOTH the preseed's `config:` mapping and the
+          # `incus storage create` argument list, so the two can never disagree.
+          poolConfig =
+            lib.optionalAttrs (cfg.storagePool.source != "") { source = cfg.storagePool.source; }
+            // cfg.storagePool.extraConfig;
+
+          # `incus storage create <pool> <driver> key=value …`
+          poolCreateArgs = lib.mapAttrsToList (k: v: "${k}=${v}") poolConfig;
+
+          # Incus' `internalUtil.VarPath()`. The loop file a source-less
+          # zfs/btrfs/lvm pool is silently built inside lands at
+          # <varPath>/disks/<pool>.img (drivers/utils.go: loopFilePath).
+          incusVarPath = "/var/lib/incus";
+          poolLoopFile = "${incusVarPath}/disks/${cfg.storagePool.name}.img";
+
+          # The drivers whose FillConfig() turns "no source" into a loop file
+          # rather than an error. `dir` and the networked drivers (ceph*,
+          # powerflex, linstor, truenas) have no such fallback, so a missing
+          # `source` there is either legal or a loud Incus error.
+          loopFileCapableDrivers = [
+            "zfs"
+            "btrfs"
+            "lvm"
+          ];
+          driverIsLoopFileCapable = lib.elem cfg.storagePool.driver loopFileCapableDrivers;
+          # The exact declaration that yields a silent loop-file pool.
+          poolWouldBeLoopFileBacked = driverIsLoopFileCapable && cfg.storagePool.source == "";
+
           # (2b) The idempotent storage+network+profile convergence oneshot.
           # Every step is create-if-missing so it is a no-op on a converged host
           # and never mutates an existing pool's immutable fields. `</dev/null`
@@ -201,21 +307,95 @@
               incusPkg
               pkgs.coreutils
               pkgs.gnugrep
+              pkgs.gnused
             ];
             text = ''
               set -euo pipefail
               pool="${cfg.storagePool.name}"
               driver="${cfg.storagePool.driver}"
+              declared_source="${cfg.storagePool.source}"
+              loop_file="${poolLoopFile}"
+              allow_loop="${lib.boolToString cfg.storagePool.allowLoopFileBacking}"
+              # True only for the declaration the eval-time assertion rejects.
+              refuse_sourceless="${
+                lib.boolToString (poolWouldBeLoopFileBacked && !cfg.storagePool.allowLoopFileBacking)
+              }"
               bridge="${cfg.bridgeName}"
               addr="${gateway}/${prefix}"
               nat="${lib.boolToString cfg.nat}"
 
+              # The LOOP-FILE GUARD, run before and after the pool step. A
+              # zfs/btrfs/lvm pool created with no `source=` is not an error in
+              # Incus — FillConfig() rewrites `source` to $loop_file, builds the
+              # pool inside a sparse file there, and `incus storage list` goes on
+              # reporting the real driver name. Nothing else on the host ever
+              # says anything is wrong. So we say it, here, and fail.
+              assert_not_loop_backed() { # $1 = when (a label for the message)
+                # storagePool.allowLoopFileBacking = true ⇒ a file-backed pool is
+                # what this host explicitly asked for; nothing to assert.
+                if [ "$allow_loop" = "true" ]; then
+                  return 0
+                fi
+                if [ -e "$loop_file" ]; then
+                  echo "garm-incus-storage-network: FATAL ($1): storage pool '$pool' is" \
+                    "LOOP-FILE BACKED — '$loop_file' exists, so Incus built the pool inside" \
+                    "a sparse file instead of adopting a real backing store. Every per-job" \
+                    "container rootfs would live in a $driver pool stacked on a file on the" \
+                    "host filesystem. Set" \
+                    "services.garm-incus-runner-host.storagePool.source to the backing" \
+                    "store to adopt (or .allowLoopFileBacking = true if a file-backed pool" \
+                    "is genuinely wanted). Contents of ${incusVarPath}/disks:" >&2
+                  ls -A "${incusVarPath}/disks" >&2 || true
+                  exit 1
+                fi
+              }
+
+              assert_not_loop_backed "pre-existing"
+
               # Storage pool (immutable-safe: only create if absent).
               if ${incusBin} storage show "$pool" </dev/null >/dev/null 2>&1; then
                 echo "garm-incus-storage-network: storage pool '$pool' present — no-op"
+
+                # A pool that is already there is never mutated (Incus cannot
+                # change a pool's driver in place and has no `storage rename`),
+                # but a SILENT divergence between the declaration and the live
+                # pool is how this host drifts back to the defect. Say it loudly
+                # and leave the cutover to the operator — a hard failure here
+                # would break every deploy on a host merely awaiting a window.
+                have_driver=$(${incusBin} storage show "$pool" </dev/null 2>/dev/null \
+                  | sed -n 's/^driver: //p' | head -n1)
+                if [ -n "$have_driver" ] && [ "$have_driver" != "$driver" ]; then
+                  echo "garm-incus-storage-network: NEEDS-OPERATOR-CUTOVER: storage pool" \
+                    "'$pool' is on driver '$have_driver' but this configuration declares" \
+                    "'$driver'. Incus cannot change a pool's driver in place." >&2
+                fi
+                if [ -n "$declared_source" ]; then
+                  have_source=$(${incusBin} storage get "$pool" source </dev/null 2>/dev/null || true)
+                  if [ -n "$have_source" ] && [ "$have_source" != "$declared_source" ]; then
+                    echo "garm-incus-storage-network: NEEDS-OPERATOR-CUTOVER: storage pool" \
+                      "'$pool' has source '$have_source' but this configuration declares" \
+                      "'$declared_source'." >&2
+                  fi
+                fi
               else
-                echo "garm-incus-storage-network: creating storage pool '$pool' ($driver)"
-                ${incusBin} storage create "$pool" "$driver" </dev/null
+                # Inert while the eval-time assertion stands; kept so the unit
+                # still refuses if this script is ever reached by another route
+                # (a hand-edited unit, a stale generation left on the host).
+                if [ "$refuse_sourceless" = "true" ]; then
+                  echo "garm-incus-storage-network: FATAL: refusing to create a '$driver'" \
+                    "pool with no source= — Incus would build it inside '$loop_file'." >&2
+                  exit 1
+                fi
+                echo "garm-incus-storage-network: creating storage pool '$pool'" \
+                  "($driver${
+                    lib.optionalString (cfg.storagePool.source != "") ", source=${cfg.storagePool.source}"
+                  })"
+                ${incusBin} storage create "$pool" "$driver" ${lib.escapeShellArgs poolCreateArgs} </dev/null
+
+                # Post-condition. `incus storage create` succeeding proves
+                # nothing about WHAT it created: the loop-file fallback is a
+                # success path.
+                assert_not_loop_backed "just created"
               fi
 
               # Managed bridge (only create if absent — never re-set an existing
@@ -284,6 +464,61 @@
           };
         in
         {
+          # (0) THE LOOP-FILE OUTCOME IS UNREACHABLE, not merely documented.
+          #
+          # `driver = "zfs"` with no `source` is not rejected by Incus — it is
+          # QUIETLY REINTERPRETED as "build me a zpool inside
+          # /var/lib/incus/disks/<pool>.img" (driver_zfs.go FillConfig(), and the
+          # btrfs/lvm equivalents). The host then reports `driver: zfs` while
+          # every per-job container rootfs lives in a file-backed pool stacked on
+          # the real one — strictly worse than the `dir` driver a ZFS cutover
+          # exists to remove, and indistinguishable from success in every status
+          # output an operator would think to check.
+          #
+          # An option alone does not fix that: the defect is that the DEFAULT
+          # (omit `source`) is the dangerous one. So the combination is refused
+          # here, at eval, naming the hazard and the remedy — and the only way to
+          # get a file-backed pool is to ask for one by name. The convergence
+          # oneshot re-checks the live host on every switch (see
+          # `assert_not_loop_backed` above), because an assertion only constrains
+          # what THIS module renders, not what a previous generation left behind.
+          #
+          # Scoped to `managePreseed` because that is exactly when this module
+          # creates a pool. With `managePreseed = false` both the preseed and the
+          # convergence oneshot are inert, the options are pure declaration for
+          # host-local units to read, and rejecting them here would fail hosts
+          # this module never touches.
+          assertions = [
+            {
+              assertion =
+                !(cfg.managePreseed && poolWouldBeLoopFileBacked && !cfg.storagePool.allowLoopFileBacking);
+              message = ''
+                services.garm-incus-runner-host.storagePool declares
+                driver = "${cfg.storagePool.driver}" with an empty `source`, and
+                managePreseed = true.
+
+                Incus does NOT treat that as an error. Its ${cfg.storagePool.driver} driver
+                FillConfig() rewrites the pool's `source` to
+                ${poolLoopFile}, creates a sparse file there, and builds the
+                pool INSIDE it. The result reports `driver: ${cfg.storagePool.driver}` in
+                `incus storage list` while every per-job container rootfs lives
+                in a file-backed pool stacked on the host filesystem — worse
+                than the `dir` driver, and silent. The check that tells the two
+                apart is `ls -A /var/lib/incus/disks/`, which must be empty.
+
+                Fix: set
+                  services.garm-incus-runner-host.storagePool.source
+                to the EXISTING backing store the pool should adopt (for zfs, a
+                dataset name such as "zroot/root/var/lib/incus-storage"; the
+                dataset must already exist — this module adopts, it does not
+                create).
+
+                If a loop-file-backed pool really is what you want, say so:
+                  services.garm-incus-runner-host.storagePool.allowLoopFileBacking = true;
+              '';
+            }
+          ];
+
           # (1) FUSE on the HOST kernel. Incus bind-mounts `/dev/fuse` into
           # every container from its own static device set — NOT from LXC's
           # config templates, which only carry the `c 10:229 rwm` cgroup allow.
@@ -319,8 +554,8 @@
           # setuid. That half lives in the vm-harness runner-image recipe.
           boot.kernelModules = [ "fuse" ];
 
-          # (2) The full host triple — managed incusbr0 bridge + a `dir` storage
-          # pool + the `default` profile's root/eth0 devices — declared via
+          # (2) The full host triple — managed incusbr0 bridge + the declared
+          # storage pool + the `default` profile's root/eth0 devices — declared via
           # incus.preseed. nixpkgs' incus module renders an idempotent
           # incus-preseed.service that CREATES/UPDATES (never removes) these
           # after incus.service, on a FRESH (uninitialised) incus. For a host
@@ -339,10 +574,22 @@
               }
             ];
             storage_pools = [
-              {
-                name = cfg.storagePool.name;
-                driver = cfg.storagePool.driver;
-              }
+              (
+                {
+                  name = cfg.storagePool.name;
+                  driver = cfg.storagePool.driver;
+                }
+                # `config.source` is what makes a zfs/btrfs/lvm pool ADOPT an
+                # existing backing store instead of being built inside
+                # /var/lib/incus/disks/<pool>.img. Emitted from the same
+                # `poolConfig` the convergence oneshot passes to `incus storage
+                # create`, so preseed and oneshot cannot disagree — and note
+                # `incus admin init --preseed` HARD-FAILS on a driver mismatch
+                # against an existing pool ("Storage pool X is of type zfs
+                # instead of dir"), so a preseed that under-declares the pool
+                # leaves incus-preseed.service permanently red.
+                // lib.optionalAttrs (poolConfig != { }) { config = poolConfig; }
+              )
             ];
             profiles = [
               {


### PR DESCRIPTION
`storagePool` had only `name` and `driver`, and `garm-incus-storage-network` ran a bare `incus storage create "$pool" "$driver"`.

So `driver = "zfs"` **silently produced a loop file.** Incus's `driver_zfs.go` `FillConfig()` sets `source` to `/var/lib/incus/disks/<pool>.img` and builds the pool inside it — no error, no warning, and `incus storage list` still reports `driver: zfs`. That is worse than `dir` and looks correct. Consumers were working around it with a `lib.mkForce` preseed override.

## Options

`storagePool.source` (str) + `storagePool.extraConfig` (attrsOf str) + `storagePool.allowLoopFileBacking` (bool, false).

`source` gets its own option rather than living inside a general `config` attrset because the module *reasons* about it — both the eval assertion and the runtime guard name it. `extraConfig` carries every other pool key (`zfs.pool_name`, `size`, `lvm.vg_name`, …) so the next key needs no module change.

Both merge into one `poolConfig` rendered into **both** the preseed `config:` block and `incus storage create`'s arguments from a single value, so the two creation paths — fresh incus via preseed, already-initialised incus via the convergence oneshot — cannot disagree.

## Making the loop file unreachable, in three layers

The option alone is not the fix.

1. **Eval rejection.** `zfs`/`btrfs`/`lvm` + empty `source` + `managePreseed = true` fails evaluation, naming the `.img` path, the `FillConfig()` branch that creates it, the `ls -A /var/lib/incus/disks/` discriminator, the `storagePool.source` remedy, and the `allowLoopFileBacking` opt-in.
2. **On-host post-condition.** The unit refuses (exit 1) if a loop file for the declared pool exists — checked before the pool step **and again after** `incus storage create`, because create succeeding proves nothing: the loop-file fallback *is* a success path.
3. **Drift is loud.** A pre-existing pool whose driver or `source` differs logs `NEEDS-OPERATOR-CUTOVER` (non-fatal; Incus cannot convert in place).

## Gate: `t_garm_incus_storage_pool_source`

Six standalone module evals differing in one option each, plus three ZFS VM nodes. The **negative control** (`allowLoopFileBacking = true` — the pre-fix behaviour) proves the hazard is real on the pinned Incus: unit green, `driver: zfs`, and `zpool status` showing a pool whose only vdev is `/var/lib/incus/disks/default.img`.

**Worth recording: the first version of one assertion passed while broken.** `hasInfix "source=<dataset>"` was satisfied by the unit's own progress `echo`. Rewritten to pin the argument position, then re-broken to confirm it fails. Four other mutations each fired exactly the intended assertion.

## Downstream note

`infra`'s GPU hosts will **fail evaluation** on the bump until they add `storagePool.source = incusStorageDataset;` — deliberately. In exchange they delete the `mkForce` preseed block and a ~110-line host-local convergence unit.