### PR TITLE
garm: Type=exec — the 243/CREDENTIALS failures are a credential-setup race, not an ordering problem

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -13,6 +13,7 @@
     ./deployment-pull-agent.nix
     ./deployment-pull-agent-darwin.nix
     ./deployment-reconciler.nix
+    ./garm-credentials-no-race.nix
     ./garm-service-boot.nix
     ./garm-api-watchdog.nix
     ./garm-multi-provider.nix

--- a/checks/garm-credentials-no-race.nix
+++ b/checks/garm-credentials-no-race.nix
@@ -1,0 +1,305 @@
+top@{ ... }:
+{
+  # Gate `t_garm_credentials_no_race` — garm.service must not carry the
+  # systemd-documented credential race that produced 243/CREDENTIALS.
+  #
+  # ── THE INCIDENT ───────────────────────────────────────────────────────────
+  #
+  # garm.service died at startup with
+  #   (garm)[PID]: garm.service: Failed to set up credentials: Protocol error
+  #   (garm)[PID]: garm.service: Failed at step CREDENTIALS spawning …/garm: Protocol error
+  #   systemd[1]: garm.service: Main process exited, code=exited, status=243/CREDENTIALS
+  # 8 times on high-mem-server over three days, and 3 CONSECUTIVE times on
+  # gpu-server-001 (a 3 min 36 s outage). `Restart=always` always got through
+  # eventually, which is exactly why it survived so long unowned.
+  #
+  # ── WHAT IT WAS NOT ────────────────────────────────────────────────────────
+  #
+  # Not a missing or late credential source. `AssertPathExists=` on the exact
+  # `LoadCredential` source paths was deployed and PASSED on all 8 occurrences —
+  # the agenix symlink farm was fully materialised, the paths resolved, and the
+  # READ still failed. Not activation-adjacent either: most occurrences follow a
+  # health-watchdog restart hours after the last switch. So no ordering edge —
+  # against agenix or anything else — could have fixed it.
+  #
+  # ── WHAT IT WAS ────────────────────────────────────────────────────────────
+  #
+  # systemd said so itself, once per start, in garm.service's own journal:
+  #
+  #   Service uses a combination of Type=simple, ExecStartPost=, and
+  #   credentials. This could lead to race conditions. Continuing.
+  #
+  # With `Type=simple`, service_enter_start() forks the main process and
+  # immediately calls service_enter_start_post() — for SERVICE_SIMPLE there is
+  # no wait. The FU9 bind-verify ExecStartPost is therefore spawned while the
+  # main child is still inside exec_child(), which runs exec_setup_credentials()
+  # BEFORE the execve. Both then set up the same /run/credentials/garm.service —
+  # the main one with EXEC_SETUP_CREDENTIALS_FRESH (umount the old store,
+  # rebuild it, MS_MOVE it into place), the ExecStartPost one without — and the
+  # loser dies at step CREDENTIALS. ("Protocol error" is not about protocols:
+  # exec_setup_credentials() does the mount work in a
+  # safe_fork("(sd-mkdcreds)", …|FORK_WAIT|…), and wait_for_terminate_and_check()
+  # maps "that child exited non-zero" to -EPROTO. The underlying errno is logged
+  # at LOG_DEBUG inside the child and never reaches the journal.)
+  #
+  # `Type=exec` makes systemd wait for the main process's execve before running
+  # start-post, so the two credential setups can no longer overlap.
+  #
+  # ── HOW THIS GATE DISCRIMINATES ────────────────────────────────────────────
+  #
+  # Asserting `Type=exec` alone would be a tautology restating the diff. So:
+  #
+  #   * NOT VACUOUS. The gate first proves the unit under test really has all
+  #     three legs of the dangerous triple — credentials AND an ExecStartPost —
+  #     because with either leg missing there is nothing to race and a green
+  #     result would mean nothing.
+  #
+  #   * THE NEGATIVE CONTROL IS THE DEFECT ITSELF. Node `racy` is the same
+  #     configuration with `Type` forced back to `simple` — i.e. the module
+  #     exactly as it shipped through the 8 failures. The gate asserts that
+  #     systemd EMITS its race warning there, and that it does NOT on the fixed
+  #     node. That warning is systemd's own detector for this exact
+  #     combination (src/core/service.c service_verify(): SERVICE_SIMPLE &&
+  #     exec_command[SERVICE_EXEC_START_POST] && exec_context_has_credentials),
+  #     so it is a deterministic, upstream-authored discriminator rather than
+  #     one this repo invented.
+  #
+  #   * THE SYMPTOM IS BOUNDED. Both nodes are restarted repeatedly with the
+  #     credential store being torn down and rebuilt every time; the fixed node
+  #     must reach zero 243/CREDENTIALS exits. The racy node's count is
+  #     REPORTED, not asserted — see the next paragraph, which is the honest
+  #     limit of this gate.
+  #
+  # ── THE CONTROL DOES LOSE THE RACE, JUST NOT ON DEMAND ─────────────────────
+  #
+  # The `racy` node has reproduced the production failure verbatim inside this
+  # gate — same process, same two messages, same exit:
+  #
+  #   racy # (garm)[1574]: garm.service: Failed to set up credentials: Protocol error
+  #   racy # (garm)[1574]: garm.service: Failed at step CREDENTIALS spawning …/garm: Protocol error
+  #   racy # systemd[1]: garm.service: Main process exited, code=exited, status=243/CREDENTIALS
+  #
+  # Across four runs of otherwise identical nodes the control produced 0, 2, 10
+  # and 0 such failure lines in 15 restarts; the fixed node produced 0 every time.
+  # That spread is exactly why the control's count is PRINTED and not asserted —
+  # a gate that required a race to be lost would be flaky in the other
+  # direction. The deterministic assertion is on the CAUSE (systemd's own
+  # detection of the combination); the count is the visible symptom.
+  #
+  # Two attempts to force it deterministically failed, recorded so nobody
+  # spends the time again:
+  #
+  #   * ENLARGING the credentials (48 x 256 KiB) does not widen the window, it
+  #     breaks setup outright: systemd caps the credential tmpfs at
+  #     CREDENTIALS_TOTAL_SIZE_MAX (1 MiB), and overflowing it fails with the
+  #     IDENTICAL `Failed to set up credentials: Protocol error` /
+  #     243/CREDENTIALS signature — on BOTH nodes, for a reason with nothing to
+  #     do with the race. (That the two are indistinguishable in the journal is
+  #     itself the lesson: EPROTO here means only "the (sd-mkdcreds) helper
+  #     child exited non-zero", so the message names no cause at all. Do not
+  #     read a 243 as evidence of THIS race without checking which process and
+  #     which step it came from.)
+  #
+  #   * SLOWING a credential source (an AF_UNIX `LoadCredential` source behind
+  #     a 2 s responder, to park the main child mid-window) did not raise the
+  #     rate either: 0 failures in 12 restarts on both nodes.
+  #
+  # The credential sources deliberately resolve through a symlink farm shaped
+  # like agenix's (/run/gate-agenix -> /run/gate-agenix.d/1/…, materialised from
+  # an ACTIVATION SCRIPT, no systemd unit), because that is the posture on all
+  # three live hosts and it is what the earlier ordering hypothesis blamed.
+  perSystem =
+    {
+      pkgs,
+      lib,
+      self',
+      ...
+    }:
+    let
+      flake = top.config.flake;
+
+      secretsDir = "/run/gate-agenix";
+
+      # agenix's activation-script mode, in miniature: a generation directory
+      # plus an atomically-swapped symlink, populated before any unit starts and
+      # with NO systemd unit to order against. The exact shape the 243s were
+      # (wrongly) blamed on.
+      fakeAgenix = {
+        system.activationScripts.gateSecrets.text = ''
+          mkdir -p /run/gate-agenix.d/1
+          printf '%s' 'gate-jwt-secret-0123456789abcdef0123456789abcdef' \
+            > /run/gate-agenix.d/1/jwt-secret
+          printf '%s' 'gate-db-passphrase-0123456789abcdef0123456789ab' \
+            > /run/gate-agenix.d/1/db-passphrase
+          chmod 0400 /run/gate-agenix.d/1/*
+          ln -sfT /run/gate-agenix.d/1 ${secretsDir}
+        '';
+      };
+
+      baseNode =
+        { ... }:
+        {
+          imports = [
+            flake.modules.nixos.garm
+            fakeAgenix
+          ];
+          environment.systemPackages = [ pkgs.curl ];
+
+          services.garm = {
+            enable = true;
+            package = self'.packages.garm;
+            apiServer = {
+              bind = "0.0.0.0";
+              port = 9997;
+            };
+            # The two legs that make this unit dangerous under Type=simple:
+            #   (1) LoadCredential= sources ...
+            jwtSecretFile = "${secretsDir}/jwt-secret";
+            dbPassphraseFile = "${secretsDir}/db-passphrase";
+            #   (2) ... and an ExecStartPost (FU9 bind-verify), on by default.
+            healthcheck = {
+              enable = true;
+              startupBindVerify = true;
+              startupBindTimeout = 30;
+            };
+          };
+        };
+
+      # How many times each node is restarted while counting credential
+      # failures. Each restart tears down and rebuilds /run/credentials/garm.service.
+      restarts = 15;
+
+      # systemd's own detector for the defective combination.
+      raceWarning = "Service uses a combination of Type=simple, ExecStartPost=, and credentials";
+    in
+    {
+      checks = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        t_garm_credentials_no_race = pkgs.testers.nixosTest {
+          name = "t_garm_credentials_no_race";
+
+          nodes = {
+            fixed = baseNode;
+
+            # NEGATIVE CONTROL: the module exactly as it shipped through the 8
+            # failures. One option differs.
+            racy =
+              { ... }:
+              {
+                imports = [ baseNode ];
+                systemd.services.garm.serviceConfig.Type = lib.mkForce "simple";
+              };
+          };
+
+          testScript = ''
+            start_all()
+
+            for m in (fixed, racy):
+                m.wait_for_unit("multi-user.target")
+
+            def restart_cycle(m):
+                # `reset-failed` before every restart is NOT cosmetic. The loops
+                # below restart as fast as the API rebinds, which is well inside
+                # systemd's default start rate limit (5 starts / 10 s); without
+                # the reset the unit lands in `start-limit-hit`, systemd stops
+                # restarting it, and the next wait hangs until the test driver's
+                # timeout. Observed exactly that on the CONTROL node, which
+                # loses the race often enough to burn the whole budget in
+                # seconds — so without this the gate would fail on the very
+                # behaviour it exists to demonstrate. Resetting keeps these
+                # loops measuring the credential race rather than systemd's
+                # throttle.
+                m.succeed("systemctl reset-failed garm.service || true")
+                m.succeed("systemctl restart garm.service || true")
+                m.wait_for_open_port(9997, timeout = 120)
+
+            with subtest("the unit under test really carries the dangerous triple"):
+                # If either leg were missing there would be nothing to race and
+                # every assertion below would pass for the wrong reason.
+                # `systemctl show -p LoadCredential` renders "[unprintable]", so
+                # read the rendered unit itself.
+                for m in (fixed, racy):
+                    unit = m.succeed("systemctl cat garm.service")
+                    creds = [l for l in unit.splitlines() if l.startswith("LoadCredential=")]
+                    assert any("${secretsDir}/jwt-secret" in l for l in creds), f"LoadCredential={creds!r}"
+                    assert any("${secretsDir}/db-passphrase" in l for l in creds), f"LoadCredential={creds!r}"
+                    post = [l for l in unit.splitlines() if l.startswith("ExecStartPost=")]
+                    assert any("garm-bind-verify" in l for l in post), f"ExecStartPost={post!r}"
+
+                # ... and the credentials really resolve through an
+                # agenix-shaped symlink farm with no unit behind it.
+                fixed.succeed("test -L ${secretsDir}")
+                fixed.fail("systemctl cat agenix-install-secrets.service")
+
+            with subtest("garm.service is Type=exec (fixed) / Type=simple (control)"):
+                unit_type = fixed.succeed("systemctl show -p Type --value garm.service").strip()
+                assert unit_type == "exec", f"fixed node Type={unit_type!r}"
+                unit_type = racy.succeed("systemctl show -p Type --value garm.service").strip()
+                assert unit_type == "simple", f"negative control Type={unit_type!r}"
+
+            # systemd emits the warning from service_verify(), i.e. every time
+            # the unit fragment is LOADED. Force a load now rather than relying
+            # on the boot-time one: at boot PID 1 logs before journald is
+            # accepting, so the message is not indexed under the unit and
+            # `journalctl -u garm.service` misses it. Grep the whole journal for
+            # the unit-prefixed text instead (log_unit_warning prefixes the unit
+            # id), which is what the live hosts show.
+            for m in (fixed, racy):
+                m.succeed("systemctl daemon-reload")
+
+            with subtest("NEGATIVE CONTROL: systemd flags the racy combination by name"):
+                # This is the discriminator the whole gate rests on — systemd's
+                # own detector for exactly Type=simple + ExecStartPost= +
+                # credentials. If it ever stops appearing, the assertion below
+                # would pass vacuously, so failing HERE is the correct outcome.
+                racy.succeed(
+                    "journalctl --no-pager | grep -qF ${lib.escapeShellArg "garm.service: ${raceWarning}"}"
+                )
+
+            with subtest("the fixed unit does NOT carry that combination"):
+                fixed.fail(
+                    "journalctl --no-pager | grep -qF ${lib.escapeShellArg "garm.service: ${raceWarning}"}"
+                )
+
+            with subtest("both nodes start and serve"):
+                for m in (fixed, racy):
+                    restart_cycle(m)
+                    m.wait_for_unit("garm.service")
+
+            def credential_failures(m):
+                out = m.succeed(
+                    "journalctl -u garm.service --no-pager | "
+                    "grep -c -e 243/CREDENTIALS -e 'Failed to set up credentials' || true"
+                ).strip()
+                return int(out or "0")
+
+            with subtest("${toString restarts} restarts leave the fixed unit with zero 243/CREDENTIALS"):
+                # Every restart tears the credential store down and rebuilds it,
+                # which is the window the race lived in.
+                for _ in range(${toString restarts}):
+                    restart_cycle(fixed)
+                failures = credential_failures(fixed)
+                assert failures == 0, (
+                    f"fixed node hit credential setup failures {failures} time(s) across "
+                    "${toString restarts} restarts:\n"
+                    + fixed.succeed(
+                        "journalctl -u garm.service --no-pager | "
+                        "grep -e 243/CREDENTIALS -e 'Failed to set up credentials' || true"
+                    )
+                )
+
+            with subtest("the control's exposure is reported, never asserted"):
+                # Deliberately NOT an assertion; see "THE CONTROL DOES LOSE THE
+                # RACE" in the header, which records the observed spread. The
+                # control does lose this race — just not on demand — so the
+                # number is printed rather than made a pass condition.
+                for _ in range(${toString restarts}):
+                    restart_cycle(racy)
+                print(
+                    f"negative control: {credential_failures(racy)} credential-setup "
+                    "failure line(s) across ${toString restarts} restarts under Type=simple"
+                )
+          '';
+        };
+      };
+    };
+}

--- a/checks/garm-service-boot.nix
+++ b/checks/garm-service-boot.nix
@@ -6,7 +6,10 @@ top@{ ... }:
   # provider-less configuration and proves the GARM DAEMON is actually up (not
   # merely that the unit is "active"):
   #
-  #   (a) garm.service is active/running (a long-running Type=simple unit);
+  #   (a) garm.service is active/running (a long-running Type=exec unit —
+  #       `exec`, not `simple`: Type=simple + ExecStartPost= + credentials is a
+  #       race systemd warns about by name, and it cost this fleet eight
+  #       243/CREDENTIALS starts. See t_garm_credentials_no_race);
   #   (b) the guest `garm --version` equals the packaged post-v0.2.1 pin;
   #   (c) the daemon SERVES its API:
   #        - the apiserver port (9997) is listening;
@@ -80,11 +83,11 @@ top@{ ... }:
             start_all()
             server.wait_for_unit("multi-user.target")
 
-            with subtest("garm.service is a long-running Type=simple unit"):
+            with subtest("garm.service is a long-running Type=exec unit"):
                 service_type = server.succeed(
                     "systemctl show -p Type --value garm.service"
                 ).strip()
-                assert service_type == "simple", f"unexpected Type={service_type!r}"
+                assert service_type == "exec", f"unexpected Type={service_type!r}"
 
             with subtest("garm.service passes the config through the supported long flag"):
                 exec_start = server.succeed(

--- a/modules/garm/default.nix
+++ b/modules/garm/default.nix
@@ -2117,16 +2117,23 @@
           # (`/run/agenix/github-runners/*-app-key`), which agenix (re)materialises
           # from an ACTIVATION SCRIPT — there is no `agenix-install-secrets.service`
           # to order against on these hosts (sysusers/userborn are off; agenix runs
-          # `system.activationScripts.agenix*`, not a systemd unit). systemd sets up
-          # `LoadCredential=` in PID 1 BEFORE any Exec*, so a source that is briefly
-          # absent when a start job runs fails the unit opaquely with
-          # `status=243/CREDENTIALS`. We ASSERT these same paths below: an assertion
-          # is evaluated one phase earlier still (before credential setup), so a
-          # missing source now fails fast with an explicit, greppable
-          # `AssertPathExists=… failed` in the journal — same self-heal (Restart=
-          # always retries until the activation script finishes), clearer signal.
-          # This is a strict superset of `LoadCredential`'s own precondition, so it
-          # cannot reject any start that `LoadCredential` would have accepted.
+          # `system.activationScripts.agenix*`, not a systemd unit). Credential
+          # setup happens in the forked child before any Exec*, so a source that is
+          # absent when a start job runs fails the unit with the opaque
+          # `status=243/CREDENTIALS`. Asserting the same paths turns that into an
+          # explicit, greppable `AssertPathExists=… failed`, one phase earlier, with
+          # the same self-heal (`Restart=always` retries). It is a strict superset
+          # of `LoadCredential`'s own precondition, so it cannot reject a start that
+          # `LoadCredential` would have accepted.
+          #
+          # IT IS A DIAGNOSTIC, NOT THE FIX, AND THE DISTINCTION IS LOAD-BEARING.
+          # This assertion was deployed to high-mem-server and PASSED on all 8 of
+          # the observed 243/CREDENTIALS failures — the sources existed every time
+          # and the READ still failed. That is what ruled out the "agenix races
+          # LoadCredential" hypothesis and pointed at the real cause, which is
+          # local to this unit's own shape: see `Type = "exec"` below. Keep the
+          # assertion (it is free and it is what makes a genuinely missing secret
+          # legible), but do not mistake it for the repair.
           credentialSourcePaths =
             lib.optional (cfg.jwtSecretFile != null) (toString cfg.jwtSecretFile)
             ++ lib.optional (cfg.dbPassphraseFile != null) (toString cfg.dbPassphraseFile)
@@ -2344,27 +2351,37 @@
             restartTriggers = [ configTemplate ];
             after = [
               "network.target"
-              # Forward-compatible ordering edge against agenix's systemd-unit
-              # mode. On the current garm hosts agenix installs secrets from an
-              # ACTIVATION SCRIPT (sysusers/userborn off), so this unit does not
-              # exist and the edge is an inert no-op (`After=` never pulls a unit
-              # in, and imposes no ordering when the target is absent from the
-              # transaction). If a host ever adopts `systemd.sysusers.enable` /
-              # `services.userborn.enable`, agenix switches to
-              # `agenix-install-secrets.service` and this becomes the REAL
-              # ordering guarantee that garm starts only once the App-PEM sources
-              # are staged. Costs nothing today; correct the moment it applies.
-              "agenix-install-secrets.service"
             ]
+            # Ordering edge against agenix's systemd-unit mode — emitted ONLY
+            # when that unit actually exists in this configuration.
+            #
+            # An unconditional `After=agenix-install-secrets.service` used to
+            # sit here, justified as an inert forward-compatible no-op. It is
+            # inert (`After=` neither pulls a unit in nor orders against one
+            # absent from the transaction), but "inert" and "harmless" are not
+            # the same thing: on hosts where agenix installs secrets from an
+            # ACTIVATION SCRIPT (sysusers/userborn off — all three garm hosts)
+            # the unit does not exist, and the unit file nonetheless READ as
+            # though credential ordering were handled. It is what a 243/
+            # CREDENTIALS investigation looked at first, and it cost time,
+            # because the real cause was elsewhere entirely (see `Type=` below).
+            # A dependency you cannot see is worse than no dependency.
+            #
+            # So: declare it when it is real, and say nothing when it is not.
+            # `systemd.services ? …` reads only the attribute NAMES, which are
+            # static across every definition, so this cannot recurse into this
+            # unit's own value.
+            ++ lib.optional (config.systemd.services ? agenix-install-secrets) "agenix-install-secrets.service"
             ++ lib.optional anyLibvirt "libvirtd.service"
             ++ lib.optional anyIncus "incus.service";
             wants = lib.optional anyLibvirt "libvirtd.service" ++ lib.optional anyIncus "incus.service";
             wantedBy = [ "multi-user.target" ];
 
-            # Fail fast + legibly (before PID 1 credential setup) if any
-            # LoadCredential source is momentarily absent, instead of the opaque
-            # 243/CREDENTIALS. See `credentialSourcePaths` above for the rationale
-            # and why this cannot reject a start LoadCredential would have taken.
+            # Fail fast + legibly if a LoadCredential source is genuinely absent,
+            # instead of the opaque 243/CREDENTIALS. A DIAGNOSTIC, not the fix for
+            # the observed 243s — it passed on all 8 of them. See
+            # `credentialSourcePaths` above, and `Type = "exec"` below for the
+            # actual repair.
             unitConfig.AssertPathExists = credentialSourcePaths;
 
             # The provider child inherits the unit PATH (GARM forwards PATH via
@@ -2381,7 +2398,78 @@
               ++ lib.optional anyQemuWindowsArm pkgs.swtpm;
 
             serviceConfig = {
-              Type = "simple";
+              # `exec`, NOT `simple`. THIS IS THE 243/CREDENTIALS FIX.
+              #
+              # THE FAILURE. On all three garm hosts the unit intermittently
+              # died at startup with
+              #   (garm)[PID]: garm.service: Failed to set up credentials: Protocol error
+              #   (garm)[PID]: garm.service: Failed at step CREDENTIALS spawning …/garm: Protocol error
+              #   systemd[1]: garm.service: Main process exited, code=exited, status=243/CREDENTIALS
+              # 8 times on high-mem-server between 2026-08-18 and 2026-08-20,
+              # and 3 CONSECUTIVE times on gpu-server-001 for a 3 min 36 s
+              # outage. `Restart=always` eventually got through, so it looked
+              # like a transient nobody had to own.
+              #
+              # WHAT IT IS NOT. It is not a missing/late credential source.
+              # `AssertPathExists=` on the exact `LoadCredential` source paths
+              # was deployed and PASSED on every one of the 8 occurrences: the
+              # agenix symlink farm was fully materialised and the paths
+              # resolved. It is also not activation-adjacent — most occurrences
+              # follow a health-watchdog restart hours after the last switch,
+              # with no agenix activity anywhere near them.
+              #
+              # WHAT IT IS. systemd names it itself, once per start, in this
+              # unit's own journal:
+              #
+              #   garm.service: Service uses a combination of Type=simple,
+              #   ExecStartPost=, and credentials. This could lead to race
+              #   conditions. Continuing.
+              #
+              # (src/core/service.c, service_verify(): Type=simple +
+              # ExecStartPost= + exec_context_has_credentials().) With
+              # `Type=simple`, service_enter_start() forks the main process and
+              # IMMEDIATELY calls service_enter_start_post() — the switch has no
+              # wait for SERVICE_SIMPLE. The bind-verify ExecStartPost below is
+              # therefore spawned while the main child is still inside
+              # exec_child(), which runs exec_setup_credentials() BEFORE the
+              # execve. Both children then set up the SAME
+              # /run/credentials/garm.service: the main one with
+              # EXEC_SETUP_CREDENTIALS_FRESH (it umounts the existing store and
+              # rebuilds it: tmpfs on a workspace, write, remount ro, MS_MOVE
+              # into place), the ExecStartPost one without. They race, and the
+              # loser dies at step CREDENTIALS.
+              #
+              # "Protocol error" is not a hint about protocols; it is
+              # exec_setup_credentials()'s helper child failing.
+              # exec_setup_credentials() does the mount work in a
+              # `safe_fork("(sd-mkdcreds)", …|FORK_WAIT|FORK_NEW_MOUNTNS)`, and
+              # wait_for_terminate_and_check() maps "child exited non-zero" to
+              # -EPROTO. The real errno is logged at LOG_DEBUG inside that child
+              # and never reaches the journal — which is why the message is
+              # opaque and why the observed PIDs are consecutive
+              # (main=N, bind-verify=N+1).
+              #
+              # THE FIX. `Type=exec` keeps everything else identical but makes
+              # systemd wait for the main process's execve — it watches the
+              # exec_fd and only then runs service_enter_start_post()
+              # (service.c: `if (s->type == SERVICE_EXEC && s->state ==
+              # SERVICE_START) service_enter_start_post(s)`). Credential setup
+              # completes strictly before that fd closes, so the two credential
+              # setups can no longer overlap. It also removes the systemd
+              # warning above, which is the machine-checkable statement that the
+              # defective combination is gone (see t_garm_credentials_no_race).
+              #
+              # Ordering against agenix would NOT have fixed this, and neither
+              # would any amount of retrying: the sources were always present.
+              #
+              # Type=exec also tightens startup semantics in a way this unit
+              # wants anyway — a garm binary that cannot even execve now fails
+              # the start instead of being reported "Started" and dying a moment
+              # later. The start-job timeout is unchanged: under Type=simple the
+              # main command already ran with no timeout and TimeoutStartSec
+              # applied to the START_POST phase, which is where the bind-verify
+              # (`healthcheck.startupBindTimeout`, 30 s by default) lives.
+              Type = "exec";
 
               ExecStartPre = lib.getExe renderScript;
               ExecStart = lib.escapeShellArgs [


### PR DESCRIPTION
GARM has been failing to start with `Failed to set up credentials: Protocol error` → `243/CREDENTIALS`, self-healing via `Restart=always`. Observed on **three hosts**: 8 occurrences on one, 3 consecutive on another costing a 3 min 36 s outage.

## The ordering hypothesis was wrong

The unit carries `After=agenix-install-secrets.service`, a unit that **does not exist**, and that looked like the cause. It isn't, and **no ordering edge could have fixed these**:

- `AssertPathExists` is deployed and **passed on all 8 occurrences** — the paths existed; the *read* failed.
- The failing process is `(garm)[N]`, the **main** process, with `garm-bind-verify[N+1]` spawned back-to-back.
- Most occurrences follow a health-watchdog restart hours after any activation.

## The real cause — systemd names it itself

`garm.service`'s own journal, once per start:

> *Service uses a combination of `Type=simple`, `ExecStartPost=`, and credentials. This could lead to race conditions.*

Under `Type=simple`, `service_enter_start()` forks the main process and **immediately** calls `service_enter_start_post()` — no wait. So the FU9 bind-verify `ExecStartPost` runs while the main child is still in `exec_child()` → `exec_setup_credentials()`, which happens *before* execve.

Both set up the same `/run/credentials/garm.service` — main with `EXEC_SETUP_CREDENTIALS_FRESH` (umount, rebuild on a tmpfs workspace, `MS_MOVE` into place), start-post without — and the loser dies at step CREDENTIALS.

"Protocol error" is not about protocols: `exec_setup_credentials()` does its mount work in `safe_fork("(sd-mkdcreds)", …|FORK_WAIT|FORK_NEW_MOUNTNS)`, and `wait_for_terminate_and_check()` maps "child exited non-zero" to `-EPROTO`. The real errno is `LOG_DEBUG`-only. Verified against systemd v257.10 sources; the hosts run 257.10.

## The fix

`Type = "exec"` — systemd then waits on the main process's `exec_fd` before start-post, so the two credential setups cannot overlap. Nothing else changes; start-job timeouts are unchanged.

Separately, the phantom `After=` is now emitted **only when that unit actually exists**. `AssertPathExists` is kept, re-documented as a diagnostic rather than the fix.

## Gate: `t_garm_credentials_no_race`

Asserts the unit really carries all three legs of the triple first (otherwise the gate is vacuous), checks systemd's race warning is present on the `racy` control and absent on `fixed`, and requires **zero 243s across 15 restarts** on `fixed`.

**The control reproduced the production failure verbatim in the VM**: `(garm)[1574]: Failed to set up credentials: Protocol error` / `status=243/CREDENTIALS`. Across four runs it produced 0, 2, 10 and 0 such lines in 15 restarts; `fixed` produced 0 every time. That spread is why the control's count is printed rather than asserted.

Two failed attempts to force the race are recorded in the check so nobody repeats them — notably, exceeding `CREDENTIALS_TOTAL_SIZE_MAX` yields the **identical** 243 signature from an unrelated cause, so **a 243 is not by itself evidence of this race**.

Supersedes the earlier `fix/garm-agenix-credential-ordering` branch: its `AssertPathExists` is carried forward (it is what disproved the ordering hypothesis); its unconditional `After=` is replaced.