### PR TITLE
ci: route x86_64 Linux jobs to the GPU host scale sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
       # on github-hosted runners
       matrix:
         include:
-          - runner: eph-linux-x64
+          - runner: eph-linux-x64-g2
             nix-version: ''
-          - runner: eph-linux-x64
+          - runner: eph-linux-x64-g2
             nix-version: 2.28.5
-          - runner: eph-linux-x64
+          - runner: eph-linux-x64-g2
             nix-version: 2.33.0
     runs-on: ${{ matrix.runner }}
     steps:
@@ -59,7 +59,7 @@ jobs:
   # `.github/setup-nix/tests/devshell-fixture/`.
   test-setup-nix-devshell:
     name: Validate setup-nix devShell build-failure detection
-    runs-on: eph-linux-x64
+    runs-on: eph-linux-x64-g2
     steps:
       - name: Checkout first to use locally defined actions
         uses: actions/checkout@v6.0.2
@@ -157,7 +157,7 @@ jobs:
         run: bash .github/setup-nix/tests/verify-nix-config-test.sh
 
   test-mcl-secret-integration:
-    runs-on: eph-linux-x64
+    runs-on: eph-linux-x64-g2
     steps:
       - name: Checkout first to use locally defined actions
         uses: actions/checkout@v6.0.2
@@ -183,10 +183,18 @@ jobs:
       # Foundry takes longer than vm-harness's currently deployed 600-second
       # default. Remove this override after this PR's provider fix is deployed.
       foundry-darwin-bootstrap-runner: '["aarch64-darwin"]'
+      # Route this repo's flake-check matrix at the GPU hosts' ephemeral scale
+      # set `eph-linux-x64-g1` (gpu-server-001) instead of the saturated
+      # `eph-linux-x64` class on high-mem-server. Only this CALLER is
+      # re-pointed; the reusable workflow's own defaults stay on
+      # `eph-linux-x64` (checks/deployment-production-cutover.nix asserts
+      # those literals), and `results-runner` is deliberately left alone
+      # because `ci / Final Results` is a required status check.
+      non-nix-runner: '["eph-linux-x64-g1"]'
       runners: |
         {
           "x86_64-linux": [
-            "eph-linux-x64"
+            "eph-linux-x64-g1"
           ],
           "aarch64-darwin": [
             "eph-macos-arm64"


### PR DESCRIPTION
`eph-linux-x64-g1` and `eph-linux-x64-g2` exist on the two GPU hosts, are enabled, and **have never received a job** — no workflow names them. Meanwhile `high-mem-server` (a Dell R620 on six consumer QLC SSDs behind a PERC H710) carries all of it.

## Changes — `.github/workflows/ci.yml` only, 5 hunks

- `test-mcl` matrix rows → `eph-linux-x64-g2`
- `test-setup-nix-devshell` → `-g2`
- `test-mcl-secret-integration` → `-g2`
- ci-matrix caller `runners.x86_64-linux` → `eph-linux-x64-g1`
- new caller input `non-nix-runner: '["eph-linux-x64-g1"]'`

## Exclusions, verified rather than assumed

- **`results-runner` untouched.** `ci / Final Results` **is** a required status check on `metacraft-labs/nixos-modules@main` *and* `metacraft-labs/nix-blockchain-development@main` (confirmed via the branch-protection API). It still falls through to the reusable default.
- **The reusable workflow's defaults are untouched.** `infra/checks/deployment-production-cutover.nix` asserts the `default: '["eph-linux-x64"]'` literals against the *reusable* file, never against the caller — so re-pointing the caller is safe.
- `test-setup-nix-verification` and `test-act` (`eph-linux-x64-nested`) unchanged. Re-parsed with `yq` to confirm.

## Why the caller and not the defaults

Changing the reusable defaults would move every consumer at once and would trip the assertion above. The caller is the per-repo decision point.