### PR TITLE
terraform-ci-matrix: exclude adoption_pending roots from steady state

### DIFF
--- a/docs/Terraform-Import-Phase.md
+++ b/docs/Terraform-Import-Phase.md
@@ -124,10 +124,14 @@ The only permitted non-import creates are the GitHub governance-app org secrets
 
 ### M7 — Drift detection and steady state
 
-Once imported, enable scheduled drift detection (the DRIFT role/plan) and switch
-to the normal workflow: changes land as PRs, plan on PR, apply on merge through
-the `production` Environment. The import blocks are not needed again unless you
-adopt a new resource class — regenerate on demand.
+Once imported, remove `adoption_pending: true` from the root's `metadata.json`
+so it **rejoins the steady-state CI matrix**. During M5/M6 the root carries that
+flag, which excludes it from the steady-state `terraform-ci-matrix` — otherwise a
+steady-state plan/apply on the still-empty state would try to (re)create the live
+resources the import is adopting. With the flag removed, the normal workflow
+takes over: changes land as PRs, plan on PR, apply on merge through the
+`production` Environment. The import blocks are not needed again unless you adopt
+a new resource class — regenerate on demand.
 
 ## Why import blocks are never committed
 

--- a/terraform/ci/metadata.schema.json
+++ b/terraform/ci/metadata.schema.json
@@ -17,6 +17,7 @@
     "enable_checkov": { "type": "boolean" },
     "provider_allowlist": { "type": "array", "minItems": 1, "items": { "type": "string" }, "description": "Exact terraform.required_providers source values permitted in this root." },
     "smoke_test_command": { "type": "string", "description": "Optional post-apply smoke test command." },
+    "adoption_pending": { "type": "boolean", "default": false, "description": "When true, this root is in the import/adoption phase (methodology M5/M6) and is EXCLUDED from the steady-state CI matrix — it is driven by the provider-specific import workflow instead. Remove the flag once the import has populated state." },
     "split_boundary": { "type": "object", "description": "Optional prose documenting why this root is a separate state boundary (see the root-layering runbook)." }
   },
   "allOf": [

--- a/terraform/ci/terraform-ci-matrix
+++ b/terraform/ci/terraform-ci-matrix
@@ -92,6 +92,15 @@ while IFS= read -r root; do
     failures=$((failures + 1)); continue
   fi
 
+  # Roots still in the import/adoption phase (methodology M5/M6) are driven by
+  # the provider-specific import workflow, not the steady-state matrix — their
+  # state is empty, so a steady-state plan/apply would try to (re)create live
+  # resources. Skip them until the import completes and the flag is removed.
+  if [[ "$(jq -r '.adoption_pending // false' "$metadata_file")" == true ]]; then
+    echo "Skipping '${root}' (adoption_pending: managed by the import workflow)." >&2
+    continue
+  fi
+
   credential_mode="$(jq -r '.credential_mode' "$metadata_file")"
   backend_uses_aws_oidc="$(jq -r '.backend_uses_aws_oidc // false' "$metadata_file")"
   uses_aws_oidc=false


### PR DESCRIPTION
Closes a methodology gap the metacraft Cloudflare adoption surfaced: `terraform-ci-matrix` discovers **every** `metadata.json` root and puts it in the steady-state pr/apply/drift matrix — but a root still in the import phase (M5/M6) has **empty state**, so a steady-state apply-on-merge would try to **create the live resources the import is adopting** (duplicate DNS records, failed zone creates on production).

Adds an `adoption_pending: true` metadata flag that **excludes** a root from the steady-state matrix. Such a root is driven by its provider-specific import workflow (`cloudflare-import.yml` / `github-governance-import.yml`) instead; the flag is removed at M7 to rejoin steady state.

- `terraform-ci-matrix`: skip `adoption_pending` roots (logged).
- `metadata.schema.json`: register the optional boolean.
- `Terraform-Import-Phase.md`: document the M5/M6 → M7 transition.

Verified: matrix skips a flagged root (`include: []`); both `terraform/ci/tests/*` suites pass.

Unblocks safely merging infra#1331 (the Cloudflare root ships `adoption_pending: true` until its import populates state).