### PR TITLE
github-governance-secrets-render: fix bash 3.2 empty-array under set -u

### DIFF
--- a/terraform/github/github-governance-secrets-render
+++ b/terraform/github/github-governance-secrets-render
@@ -327,11 +327,15 @@ need nix
 [[ -f "$rules" ]] || fail "missing agenix rules file: $rules"
 
 json="$(nix eval --json --file "$manifest")"
-secret_selector_json="$(json_array_from_args "${secret_selectors[@]}")"
-group_selector_json="$(json_array_from_args "${group_selectors[@]}")"
-set_selector_json="$(json_array_from_args "${set_selectors[@]}")"
+# Expand possibly-empty arrays with the ${arr[@]+…} guard so `set -u` does not
+# abort under bash 3.2 (macOS), where "${empty[@]}" is treated as unbound. The
+# render must run on the operator's workstation (only the operator key decrypts
+# the age sources), so bash 3.2 compatibility is required, not optional.
+secret_selector_json="$(json_array_from_args ${secret_selectors[@]+"${secret_selectors[@]}"})"
+group_selector_json="$(json_array_from_args ${group_selectors[@]+"${group_selectors[@]}"})"
+set_selector_json="$(json_array_from_args ${set_selectors[@]+"${set_selectors[@]}"})"
 
-for selector in "${secret_selectors[@]}"; do
+for selector in ${secret_selectors[@]+"${secret_selectors[@]}"}; do
   exact_count="$(jq --arg secret "$selector" '[.secrets[] | select(.providerId == $secret)] | length' <<<"$json")"
   name_count="$(jq --arg secret "$selector" '[.secrets[] | select(.name == $secret)] | length' <<<"$json")"
   if [[ "$exact_count" == "0" && "$name_count" != "1" ]]; then


### PR DESCRIPTION
`--group`/`--set` without `--secret` leaves `secret_selectors` empty; `"${secret_selectors[@]}"` under `set -u` aborts with *unbound variable* on **bash 3.2 (macOS)** — works on bash 5 (Linux CI). Render must run on the operator's workstation (only the operator key decrypts the age sources), so macOS support is required. Guarded the possibly-empty selector arrays with `${arr[@]+"${arr[@]}"}`. Verified: `--group ci-token-provider --dry-run` enumerates 220 entries on bash 3.2.57.