### PR TITLE
render: decrypt each age source once (cache by path) — fixes 220 passphrase prompts

### DIFF
--- a/terraform/github/github-governance-secrets-render
+++ b/terraform/github/github-governance-secrets-render
@@ -411,6 +411,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Decrypted-plaintext cache keyed by age-file path. Many manifest entries can
+# share one age source (e.g. a per-repo secret sourced from a single shared
+# file), so decrypt each unique source at most once. Without this, a
+# passphrase-protected operator SSH key is re-decrypted once per entry — 220
+# prompts for a 110-repo fan-out. Lives under tmp_dir (umask 077, cleaned on
+# exit), the same posture as the transient plaintext files.
+plaintext_cache_dir="${tmp_dir}/plaintext-cache"
+mkdir -p "$plaintext_cache_dir"
+
 echo "Rendering GitHub-encrypted payloads for ${selected_count} secret(s)."
 echo "Output: ${output#"$root/"}"
 echo "Managed ids: ${managed_output#"$root/"}"
@@ -467,11 +476,15 @@ while IFS= read -r encoded; do
   if [[ -n "$identity" ]]; then
     args+=(-i "$identity")
   fi
-  (
-    cd "$secrets_dir"
-    umask 077
-    RULES="$rules" agenix "${args[@]}" > "$plaintext_file"
-  )
+  cache_file="${plaintext_cache_dir}/$(printf '%s' "$relative" | tr '/' '_')"
+  if [[ ! -s "$cache_file" ]]; then
+    (
+      cd "$secrets_dir"
+      umask 077
+      RULES="$rules" agenix "${args[@]}" > "$cache_file"
+    )
+  fi
+  cp "$cache_file" "$plaintext_file"
   [[ -s "$plaintext_file" ]] || fail "agenix produced an empty plaintext file for ${provider_id}"
 
   encrypted_value="$(encrypt_for_github "$secret_json" "$plaintext_file")"


### PR DESCRIPTION
Rendering the CI_TOKEN_PROVIDER group (110 repos × 2 = 220 entries sourced from **2 shared age files**) re-prompted the operator's SSH passphrase **220 times** — the render decrypted the age source once per manifest entry, and a passphrase-protected key is re-decrypted on every `agenix` call. A single mistype aborted the whole run (as happened).

Fix: cache decrypted plaintext **by age-file path** under the existing umask-077 tmp dir (auto-cleaned on exit), so `agenix` runs once per **unique** source — **2 prompts, not 220**. Payloads are byte-identical. `bash -n` clean.