### PR TITLE
github-bootstrap: secret-apply --group (fan a rotationGroup in one targeted plan)

### DIFF
--- a/terraform/github/github-bootstrap
+++ b/terraform/github/github-bootstrap
@@ -14,15 +14,17 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  github-bootstrap <plan|apply|outputs|secret-plan|secret-apply|governance-app-secrets-plan|governance-app-secrets-apply> <github/<name>> [--secret <owner/repo:NAME>] [--root-dir DIR]
+  github-bootstrap <plan|apply|outputs|secret-plan|secret-apply|governance-app-secrets-plan|governance-app-secrets-apply> <github/<name>> [--secret <owner/repo:NAME> | --group <rotationGroup>] [--root-dir DIR]
 
 Actions:
-  secret-plan / secret-apply     Targeted plan/apply for a single Terraform-managed
-                                 GitHub Actions secret (--secret <owner/repo:NAME>).
-                                 A full plan of a large governance root refreshes
-                                 every declared resource and blows GitHub's hourly
-                                 API rate limit, so single-secret changes are
-                                 applied targeted, without a full-tree refresh.
+  secret-plan / secret-apply     Targeted plan/apply for Terraform-managed GitHub
+                                 Actions secrets. Select ONE with
+                                 --secret <owner/repo:NAME>, or a whole
+                                 rotationGroup with --group <name> (e.g. a per-repo
+                                 secret fanned across many repos). A full plan of a
+                                 large governance root refreshes every declared
+                                 resource and blows GitHub's hourly API rate limit,
+                                 so these apply targeted, without a full-tree refresh.
 
 Environment:
   AWS_PROFILE                    AWS profile for the S3 state backend (set by the dev shell).
@@ -46,6 +48,9 @@ while [[ $# -gt 0 ]]; do
     --secret)
       [[ $# -ge 2 ]] || { echo "--secret requires <owner/repo:NAME>." >&2; exit 2; }
       secret="$2"; shift 2 ;;
+    --group)
+      [[ $# -ge 2 ]] || { echo "--group requires a rotationGroup name." >&2; exit 2; }
+      group="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
@@ -65,7 +70,9 @@ config_slug="$(printf '%s' "$config" | tr '/' '-')"
 backend="${root}/${GITHUB_BOOTSTRAP_BACKEND_FILE:-backends/${config_slug}.hcl}"
 profile="${AWS_PROFILE:-}"
 secret=""
+group=""
 secret_target=""
+secret_targets=()
 identity_json=""
 expected_account_id=""
 actual_account_id=""
@@ -276,6 +283,34 @@ EOF
   fi
 }
 
+# Resolve every Terraform-managed secret in a rotationGroup to its resource
+# address (same keying convention as above). Fans a per-repo secret across all
+# its repos in one targeted plan/apply. manageWithTerraform gate applies.
+resolve_group_targets() {
+  local grp="$1"
+  mapfile -t secret_targets < <(
+    nix eval --json --file "${src}/secrets/manifest.nix" 2>/dev/null | jq -r --arg grp "$grp" '
+      .secrets[]
+      | select((.rotationGroup // "") == $grp)
+      | select((.manageWithTerraform // false) == true)
+      | (
+          if .providerResource == "github_actions_secret" then "github_actions_secret"
+          elif .providerResource == "github_actions_organization_secret" then "github_actions_organization_secret"
+          else .providerResource end
+        ) as $type
+      | "\($type).secret_" + (.providerId | gsub("[/:.]"; "_"))
+    '
+  )
+  if [[ ${#secret_targets[@]} -eq 0 ]]; then
+    cat >&2 <<EOF
+No Terraform-managed secrets in rotationGroup '${grp}' for ${config}.
+Entries must have manageWithTerraform = true and be rendered
+(github-governance-secrets-render) before applying.
+EOF
+    exit 2
+  fi
+}
+
 # Targeted plan for one managed secret. A full plan of a large governance root
 # refreshes every declared resource against the GitHub API and blows the hourly
 # rate limit, so single-secret changes MUST be targeted and refresh-free. Import
@@ -283,16 +318,29 @@ EOF
 # in state, whereas a managed secret is a plain create/update. -lock=false keeps
 # an interrupted plan from leaving a stale state lock behind.
 plan_managed_secret() {
-  [[ -n "$secret" ]] || { echo "secret-plan/secret-apply require --secret <owner/repo:NAME>." >&2; exit 2; }
-  resolve_secret_target "$secret"
+  local target_args=()
+  if [[ -n "$group" && -n "$secret" ]]; then
+    echo "Use either --secret or --group, not both." >&2; exit 2
+  elif [[ -n "$group" ]]; then
+    resolve_group_targets "$group"
+    local t
+    for t in "${secret_targets[@]}"; do target_args+=(-target="$t"); done
+  elif [[ -n "$secret" ]]; then
+    resolve_secret_target "$secret"
+    secret_targets=("$secret_target")
+    target_args=(-target="$secret_target")
+  else
+    echo "secret-plan/secret-apply require --secret <owner/repo:NAME> or --group <name>." >&2
+    exit 2
+  fi
   rm -f imports.tf
   tofu plan -input=false -no-color -lock=false -refresh=false \
-    -target="$secret_target" \
+    "${target_args[@]}" \
     -out=github-managed-secret.tfplan
   cat <<EOF
 
 Saved targeted plan:
-  github-managed-secret.tfplan  (target: ${secret_target})
+  github-managed-secret.tfplan  (${#secret_targets[@]} target(s))
 
 Review it with:
   tofu show -no-color github-managed-secret.tfplan


### PR DESCRIPTION
Extends `secret-plan`/`secret-apply` (from #605) with `--group <rotationGroup>`: resolves every Terraform-managed secret in the group and applies them in **one** targeted, refresh-free plan (many `-target`). Applying a per-repo secret fanned across N repos — e.g. `CI_TOKEN_PROVIDER` = 220 resources over 110 repos — is now a single operation instead of 220 runs, while still avoiding the full-tree refresh that blows GitHub's hourly rate limit. `--secret`/`--group` mutually exclusive. Verified: resolves 220 `ci-token-provider` targets; `bash -n` clean.