### PR TITLE
github-bootstrap: secret-apply --all-managed + ambient AWS creds (governance-secrets CI)

### DIFF
--- a/terraform/github/github-bootstrap
+++ b/terraform/github/github-bootstrap
@@ -19,12 +19,13 @@ Usage:
 Actions:
   secret-plan / secret-apply     Targeted plan/apply for Terraform-managed GitHub
                                  Actions secrets. Select ONE with
-                                 --secret <owner/repo:NAME>, or a whole
-                                 rotationGroup with --group <name> (e.g. a per-repo
-                                 secret fanned across many repos). A full plan of a
-                                 large governance root refreshes every declared
-                                 resource and blows GitHub's hourly API rate limit,
-                                 so these apply targeted, without a full-tree refresh.
+                                 --secret <owner/repo:NAME>, a whole rotationGroup
+                                 with --group <name>, or every rendered managed
+                                 secret with --all-managed (the governance-secrets
+                                 CI flow). A full plan of a large governance root
+                                 refreshes every declared resource and blows
+                                 GitHub's hourly API rate limit, so these apply
+                                 targeted, without a full-tree refresh.
 
 Environment:
   AWS_PROFILE                    AWS profile for the S3 state backend (set by the dev shell).
@@ -51,6 +52,8 @@ while [[ $# -gt 0 ]]; do
     --group)
       [[ $# -ge 2 ]] || { echo "--group requires a rotationGroup name." >&2; exit 2; }
       group="$2"; shift 2 ;;
+    --all-managed)
+      all_managed=1; shift ;;
     *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
@@ -71,6 +74,7 @@ backend="${root}/${GITHUB_BOOTSTRAP_BACKEND_FILE:-backends/${config_slug}.hcl}"
 profile="${AWS_PROFILE:-}"
 secret=""
 group=""
+all_managed=0
 secret_target=""
 secret_targets=()
 identity_json=""
@@ -311,6 +315,38 @@ EOF
   fi
 }
 
+# Resolve every RENDERED managed secret (the providerIds in
+# secrets/managed.generated.nix, which is exactly the set the governance root
+# emits github_actions_secret resources for) to its resource address. This is
+# the primitive the governance-secrets CI flow applies on merge: it reconciles
+# all managed secrets in one targeted, refresh-free plan.
+resolve_all_managed_targets() {
+  local managed_file="${src}/secrets/managed.generated.nix"
+  [[ -f "$managed_file" ]] || {
+    echo "Missing ${managed_file}; run github-governance-secrets-render first." >&2
+    exit 2
+  }
+  local managed_ids
+  managed_ids="$(nix eval --json --file "$managed_file" 2>/dev/null | jq -c '.providerIds // []')"
+  mapfile -t secret_targets < <(
+    nix eval --json --file "${src}/secrets/manifest.nix" 2>/dev/null | jq -r --argjson ids "$managed_ids" '
+      .secrets[]
+      | select([.providerId] | inside($ids))
+      | select((.manageWithTerraform // false) == true)
+      | (
+          if .providerResource == "github_actions_secret" then "github_actions_secret"
+          elif .providerResource == "github_actions_organization_secret" then "github_actions_organization_secret"
+          else .providerResource end
+        ) as $type
+      | "\($type).secret_" + (.providerId | gsub("[/:.]"; "_"))
+    '
+  )
+  if [[ ${#secret_targets[@]} -eq 0 ]]; then
+    echo "No rendered managed secrets found in ${managed_file}." >&2
+    exit 2
+  fi
+}
+
 # Targeted plan for one managed secret. A full plan of a large governance root
 # refreshes every declared resource against the GitHub API and blows the hourly
 # rate limit, so single-secret changes MUST be targeted and refresh-free. Import
@@ -319,8 +355,13 @@ EOF
 # an interrupted plan from leaving a stale state lock behind.
 plan_managed_secret() {
   local target_args=()
-  if [[ -n "$group" && -n "$secret" ]]; then
-    echo "Use either --secret or --group, not both." >&2; exit 2
+  local selectors=$(( (all_managed) + (${#group} > 0 ? 1 : 0) + (${#secret} > 0 ? 1 : 0) ))
+  if [[ "$selectors" -gt 1 ]]; then
+    echo "Use exactly one of --secret, --group, or --all-managed." >&2; exit 2
+  elif ((all_managed)); then
+    resolve_all_managed_targets
+    local t
+    for t in "${secret_targets[@]}"; do target_args+=(-target="$t"); done
   elif [[ -n "$group" ]]; then
     resolve_group_targets "$group"
     local t
@@ -330,7 +371,7 @@ plan_managed_secret() {
     secret_targets=("$secret_target")
     target_args=(-target="$secret_target")
   else
-    echo "secret-plan/secret-apply require --secret <owner/repo:NAME> or --group <name>." >&2
+    echo "secret-plan/secret-apply require --secret <owner/repo:NAME>, --group <name>, or --all-managed." >&2
     exit 2
   fi
   rm -f imports.tf

--- a/terraform/github/github-bootstrap
+++ b/terraform/github/github-bootstrap
@@ -88,15 +88,22 @@ render_config() {
   jq . "${dst}/config.tf.json" >/dev/null
 }
 
+# Two credential modes: an operator supplies AWS_PROFILE (SSO/dev shell); CI
+# supplies ambient creds (GitHub OIDC role assumed into AWS_ACCESS_KEY_ID / a web
+# identity token). In ambient mode we use the creds already in the environment
+# instead of exporting them from a profile.
+ambient_aws=0
 if [[ -z "$profile" ]]; then
-  cat >&2 <<'EOF'
-AWS_PROFILE is not set.
-Enter the repo dev shell or export the profile explicitly, for example:
-
-  export AWS_PROFILE=<your-admin-profile>
-
+  if [[ -n "${AWS_ACCESS_KEY_ID:-}" || -n "${AWS_WEB_IDENTITY_TOKEN_FILE:-}" ]]; then
+    ambient_aws=1
+  else
+    cat >&2 <<'EOF'
+Neither AWS_PROFILE nor ambient AWS credentials are set.
+For an operator: enter the repo dev shell or `export AWS_PROFILE=<admin-profile>`.
+For CI: assume the AWS OIDC role before invoking this tool.
 EOF
-  exit 1
+    exit 1
+  fi
 fi
 
 if [[ ! -f "$backend" ]]; then
@@ -127,28 +134,39 @@ if [[ -z "$expected_account_id" || -z "$aws_region" || -z "$github_access_check_
   exit 1
 fi
 
-if ! identity_json="$(aws --region "$aws_region" sts get-caller-identity --profile "$profile" --output json 2>/dev/null)"; then
-  echo "AWS profile '${profile}' is not authenticated. Run your dev shell's aws-login for ${profile}." >&2
+sts_args=(--region "$aws_region" sts get-caller-identity --output json)
+((ambient_aws)) || sts_args+=(--profile "$profile")
+if ! identity_json="$(aws "${sts_args[@]}" 2>/dev/null)"; then
+  if ((ambient_aws)); then
+    echo "Ambient AWS credentials are not valid. Assume the AWS OIDC role first." >&2
+  else
+    echo "AWS profile '${profile}' is not authenticated. Run your dev shell's aws-login for ${profile}." >&2
+  fi
   exit 1
 fi
 
 actual_account_id="$(jq -r '.Account' <<<"$identity_json")"
 if [[ "$actual_account_id" != "$expected_account_id" ]]; then
   cat >&2 <<EOF
-AWS profile '${profile}' is authenticated to account ${actual_account_id}, but
-GitHub bootstrap is pinned to backend account ${expected_account_id}.
+AWS credentials are for account ${actual_account_id}, but GitHub bootstrap is
+pinned to backend account ${expected_account_id}.
 Refusing to use the wrong Terraform state backend.
 EOF
   exit 1
 fi
 
-export AWS_PROFILE="$profile"
 export AWS_REGION="$aws_region"
 export AWS_DEFAULT_REGION="$aws_region"
-export AWS_SDK_LOAD_CONFIG=1
-unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
-unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
-eval "$(aws --region "$aws_region" configure export-credentials --profile "$profile" --format env)"
+if ((ambient_aws)); then
+  # Keep the ambient (OIDC-assumed) credentials already in the environment.
+  :
+else
+  export AWS_PROFILE="$profile"
+  export AWS_SDK_LOAD_CONFIG=1
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
+  unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
+  eval "$(aws --region "$aws_region" configure export-credentials --profile "$profile" --format env)"
+fi
 
 if [[ -n "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
   export GITHUB_TOKEN="$GH_TOKEN"


### PR DESCRIPTION
Two changes enabling a **PR-gated CI flow** for governance managed secrets (parallel to the Cloudflare import flow), instead of an operator running `secret-apply` by hand:

1. **`--all-managed`** — `secret-plan`/`secret-apply` resolve every *rendered* managed secret (the `providerIds` in `managed.generated.nix` — exactly what the governance root emits secret resources for) into one targeted, refresh-free plan/apply. The primitive CI runs on merge to reconcile all managed GitHub Actions secrets without a full-tree refresh (which blows GitHub's hourly rate limit). Verified: 223 targets.

2. **Ambient AWS creds** — the driver forced `AWS_PROFILE` + `aws configure export-credentials` (operator dev shell). CI has the AWS OIDC role already assumed into ambient env creds. Added an ambient mode (used when `AWS_PROFILE` is empty but creds/web-identity token are present): STS account-guard without `--profile`, no profile export. `GITHUB_TOKEN` (App token) already supported. One tool now serves operator **and** CI.

`bash -n` clean.