### PR TITLE
github-bootstrap: secret-apply --assume-yes (non-interactive CI apply)

### DIFF
--- a/terraform/github/github-bootstrap
+++ b/terraform/github/github-bootstrap
@@ -54,6 +54,8 @@ while [[ $# -gt 0 ]]; do
       group="$2"; shift 2 ;;
     --all-managed)
       all_managed=1; shift ;;
+    --assume-yes|--yes)
+      assume_yes=1; shift ;;
     *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
@@ -75,6 +77,7 @@ profile="${AWS_PROFILE:-}"
 secret=""
 group=""
 all_managed=0
+assume_yes=0
 secret_target=""
 secret_targets=()
 identity_json=""
@@ -435,10 +438,16 @@ case "$action" in
     plan_managed_secret
     tofu show -no-color github-managed-secret.tfplan
     echo
-    read -r -p "Type 'apply-secret' to apply this targeted plan: " confirmation
-    if [[ "$confirmation" != "apply-secret" ]]; then
-      echo "Aborted."
-      exit 1
+    # In CI the reviewed-PR merge is the approval, so --assume-yes skips the
+    # interactive prompt. Operators omit it and type the confirmation.
+    if ((assume_yes)); then
+      echo "--assume-yes: applying the targeted plan."
+    else
+      read -r -p "Type 'apply-secret' to apply this targeted plan: " confirmation
+      if [[ "$confirmation" != "apply-secret" ]]; then
+        echo "Aborted."
+        exit 1
+      fi
     fi
     tofu apply github-managed-secret.tfplan
     ;;


### PR DESCRIPTION
`secret-apply`'s typed confirmation can't be answered in CI. `--assume-yes` skips it — the reviewed-PR merge is the approval. Operators omit it and still get the interactive prompt. Final piece for the governance-secrets apply-on-merge flow.