### PR TITLE
terraform-ci: github-app credential mode (mint short-lived App token for GitHub provider roots)

### DIFF
--- a/.github/workflows/reusable-terraform-ci.yml
+++ b/.github/workflows/reusable-terraform-ci.yml
@@ -116,9 +116,21 @@ on:
         required: false
         default: '3600'
 
+      github_app_owner:
+        description: 'Org/user for the github-app credential mode; the minted installation token is scoped here. Empty disables github-app minting.'
+        type: string
+        required: false
+        default: ''
+
     secrets:
       AGENIX_CI_PRIVATE_KEY:
         description: 'SSH private key for agenix secret decryption'
+        required: false
+      GH_APP_ID:
+        description: 'GitHub App id for the github-app credential mode (mints a short-lived installation token exported as GITHUB_TOKEN for the github provider).'
+        required: false
+      GH_APP_PRIVATE_KEY:
+        description: 'GitHub App private key (PEM) paired with GH_APP_ID.'
         required: false
       NIX_GITHUB_TOKEN:
         description: 'GitHub token for Nix flake fetches'
@@ -337,6 +349,25 @@ jobs:
             printf '%s\n' "$TOKEN"
             printf '__MCL_TERRAFORM_SECRET__\n'
           } >> "$GITHUB_ENV"
+
+      # github-app credential mode: mint a short-lived installation token from
+      # the App (e.g. the governance App) and export it as GITHUB_TOKEN for the
+      # github provider. Preferred over a long-lived PAT — nothing new is stored,
+      # the token expires in ~1h, and it is scoped to github_app_owner.
+      - name: Mint GitHub App token
+        if: inputs.github_app_owner != ''
+        id: gh_app_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.github_app_owner }}
+
+      - name: Export GITHUB_TOKEN for the github provider
+        if: inputs.github_app_owner != ''
+        run: |
+          echo "::add-mask::${{ steps.gh_app_token.outputs.token }}"
+          echo "GITHUB_TOKEN=${{ steps.gh_app_token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Configure AWS credentials for plan
         if: inputs.aws_plan_role_arn != ''
@@ -724,6 +755,21 @@ jobs:
             printf '__MCL_TERRAFORM_SECRET__\n'
           } >> "$GITHUB_ENV"
 
+      - name: Mint GitHub App token
+        if: inputs.github_app_owner != ''
+        id: gh_app_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.github_app_owner }}
+
+      - name: Export GITHUB_TOKEN for the github provider
+        if: inputs.github_app_owner != ''
+        run: |
+          echo "::add-mask::${{ steps.gh_app_token.outputs.token }}"
+          echo "GITHUB_TOKEN=${{ steps.gh_app_token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Configure AWS credentials for apply
         if: inputs.aws_apply_role_arn != ''
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
@@ -898,6 +944,21 @@ jobs:
             printf '%s\n' "$TOKEN"
             printf '__MCL_TERRAFORM_SECRET__\n'
           } >> "$GITHUB_ENV"
+
+      - name: Mint GitHub App token
+        if: inputs.github_app_owner != ''
+        id: gh_app_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ inputs.github_app_owner }}
+
+      - name: Export GITHUB_TOKEN for the github provider
+        if: inputs.github_app_owner != ''
+        run: |
+          echo "::add-mask::${{ steps.gh_app_token.outputs.token }}"
+          echo "GITHUB_TOKEN=${{ steps.gh_app_token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Configure AWS credentials for drift
         if: inputs.aws_plan_role_arn != '' || inputs.aws_drift_role_arn != ''

--- a/terraform/ci/metadata.schema.json
+++ b/terraform/ci/metadata.schema.json
@@ -9,7 +9,8 @@
     "state_key": { "type": "string", "description": "Backend state key. Must be terraform/<config>.tfstate (standard) or terraform-sensitive/<config>.tfstate (sensitive), where <config> is the root path minus the leading terraform/." },
     "state_sensitivity": { "enum": ["standard", "sensitive"] },
     "backend_config_file": { "type": "string", "description": "Path to the root's backends/*.hcl (state key only; never secrets)." },
-    "credential_mode": { "enum": ["aws-oidc", "agenix-token", "none"], "description": "Provider credential mode. Backend authentication is declared independently by backend_uses_aws_oidc." },
+    "credential_mode": { "enum": ["aws-oidc", "agenix-token", "github-app", "none"], "description": "Provider credential mode. github-app mints a short-lived GitHub App installation token (exported as GITHUB_TOKEN) for the github provider. Backend authentication is declared independently by backend_uses_aws_oidc." },
+    "github_app_owner": { "type": "string", "description": "Required for github-app: org/user the minted installation token is scoped to (e.g. metacraft-labs)." },
     "backend_uses_aws_oidc": { "type": "boolean", "default": false, "description": "Whether the Terraform state backend also requires the caller's AWS OIDC role. This is independent of provider credential_mode so, for example, an agenix-token provider can use an S3 backend." },
     "credentials_env_name": { "type": "string", "description": "Required for agenix-token: env var the decrypted token is exported as (e.g. GITHUB_TOKEN, CLOUDFLARE_API_TOKEN)." },
     "agenix_plan_secret_path": { "type": "string", "description": "Required for agenix-token: repo-relative path to the read-only (plan) agenix secret." },
@@ -28,6 +29,15 @@
       },
       "then": {
         "required": ["credentials_env_name", "agenix_plan_secret_path", "agenix_apply_secret_path"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "credential_mode": { "const": "github-app" } },
+        "required": ["credential_mode"]
+      },
+      "then": {
+        "required": ["github_app_owner"]
       }
     }
   ]

--- a/terraform/ci/terraform-ci-matrix
+++ b/terraform/ci/terraform-ci-matrix
@@ -66,7 +66,8 @@ while IFS= read -r root; do
     (.state_key | nonempty_string)
     and (.backend_config_file | nonempty_string)
     and (.state_sensitivity | IN("standard", "sensitive"))
-    and (.credential_mode | IN("aws-oidc", "agenix-token", "none"))
+    and (.credential_mode | IN("aws-oidc", "agenix-token", "github-app", "none"))
+    and (.credential_mode != "github-app" or (.github_app_owner | nonempty_string))
     and (
       (has("backend_uses_aws_oidc") | not)
       or (.backend_uses_aws_oidc | type == "boolean")
@@ -143,6 +144,7 @@ while IFS= read -r root; do
     --arg agenix_plan_secret_path "$agenix_plan_secret_path" \
     --arg agenix_apply_secret_path "$agenix_apply_secret_path" \
     --arg smoke_test_command "$smoke_test_command" \
+    --arg github_app_owner "$(jq -r '.github_app_owner // ""' "$metadata_file")" \
     '{
       root: $root,
       config: $config,
@@ -157,7 +159,8 @@ while IFS= read -r root; do
       credentials_env_name: $credentials_env_name,
       agenix_plan_secret_path: $agenix_plan_secret_path,
       agenix_apply_secret_path: $agenix_apply_secret_path,
-      smoke_test_command: $smoke_test_command
+      smoke_test_command: $smoke_test_command,
+      github_app_owner: $github_app_owner
     }')"
   rows+=("$row")
 done < <(cd "$root_dir" && find terraform -name metadata.json -exec dirname {} \; 2>/dev/null | sort)


### PR DESCRIPTION
Enables normal `terraform/github/*` roots (e.g. per-repo Actions secrets) to ride the matrix flow. A GitHub-provider root needs a token with **cross-repo** scope; the built-in Actions `GITHUB_TOKEN` is repo-scoped, and OIDC only federates to *external* clouds (AWS/GCP) — GitHub's own API has no OIDC path. So the matrix gains a `github-app` credential mode:

- When `github_app_owner` is set, `reusable-terraform-ci` mints a **~1h installation token** via `actions/create-github-app-token` from `GH_APP_ID`/`GH_APP_PRIVATE_KEY` and exports it as `GITHUB_TOKEN` (plan/apply/drift jobs).
- **Nothing long-lived is stored** — same "short-lived, no stored credential" posture as AWS OIDC, delivered via App-token minting. Points at the existing governance App (admin/secrets:write); its key stays centralized.

Changes: `reusable-terraform-ci.yml` (input + secrets + mint/export in 3 jobs), `metadata.schema.json` (enum + required `github_app_owner`), `terraform-ci-matrix` (validate + emit). actionlint clean; schema valid; matrix contract tests pass.

Part 1 of moving per-repo secrets out of the Layer-0 bootstrap root into a normal matrix-managed `terraform/github/secrets-*` root.