### PR TITLE
github-governance-secrets-render: target a terraform/ root, not only bootstrap/

### DIFF
--- a/terraform/github/github-governance-secrets-render
+++ b/terraform/github/github-governance-secrets-render
@@ -3,8 +3,19 @@ set -euo pipefail
 : "${GOVERNANCE_ROOT_CONFIG:?set GOVERNANCE_ROOT_CONFIG to the governance root config, e.g. github/<name>-governance-prod}"
 
 root="${GOVERNANCE_REPO_ROOT:-$PWD}"
-governance_dir="${root}/bootstrap/${GOVERNANCE_ROOT_CONFIG}"
-secrets_dir="${governance_dir}/secrets"
+# The secret manifest + render outputs live in a root's secrets/ dir. That root
+# is normally the Layer-0 bootstrap governance root (bootstrap/<config>), but a
+# normal terraform/ root (e.g. a per-repo Actions-secrets root) manages its own
+# secrets the same way — so GOVERNANCE_SECRETS_DIR overrides the location, and a
+# config already anchored under terraform/ or bootstrap/ is used verbatim.
+if [ -n "${GOVERNANCE_SECRETS_DIR:-}" ]; then
+  secrets_dir="${GOVERNANCE_SECRETS_DIR}"
+elif [ -d "${root}/${GOVERNANCE_ROOT_CONFIG}/secrets" ]; then
+  secrets_dir="${root}/${GOVERNANCE_ROOT_CONFIG}/secrets"
+else
+  secrets_dir="${root}/bootstrap/${GOVERNANCE_ROOT_CONFIG}/secrets"
+fi
+governance_dir="$(dirname "$secrets_dir")"
 manifest="${secrets_dir}/manifest.nix"
 rules="${secrets_dir}/secrets.nix"
 output="${secrets_dir}/payloads.generated.nix"


### PR DESCRIPTION
Lets a normal `terraform/github/secrets-*` root render its own secret payloads (the Layer-0 split). `secrets_dir` resolves via `GOVERNANCE_SECRETS_DIR`, else `<root>/<config>/secrets` if present, else the bootstrap path. ageFile resolution unchanged; `bash -n` clean.