### PR TITLE
flake: bump reprobuild to b5b88139 (the empty-profile deploy-agent fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2519,6 +2519,22 @@
         "type": "github"
       }
     },
+    "nim-shm-lease": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787532379,
+        "narHash": "sha256-iGn2tdtIYKuAMkHOH0XT8KtLx5Fe0eFBXFieJyFgzrk=",
+        "owner": "metacraft-labs",
+        "repo": "nim-shm-lease",
+        "rev": "2e8b66fdd260ed356dca440fe6394e1f56fe0018",
+        "type": "github"
+      },
+      "original": {
+        "owner": "metacraft-labs",
+        "repo": "nim-shm-lease",
+        "type": "github"
+      }
+    },
     "nim-shm-queue-src": {
       "flake": false,
       "locked": {
@@ -4291,17 +4307,17 @@
         "stackable-hooks-src": "stackable-hooks-src"
       },
       "locked": {
-        "lastModified": 1787377162,
-        "narHash": "sha256-zRgRNpvnnGTJq5fGA45E7F25d8vHAmEWgycgYJWzdFI=",
+        "lastModified": 1787673032,
+        "narHash": "sha256-DR1cpkKod/ogdxA029eIMkBxv+TdvwJL7HwJXk3WSJk=",
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "c81f0a07eb1938060e34740aed8d77d61600e1c2",
+        "rev": "b5b88139767d97e96ca646b6f83641d8bb2e69c5",
         "type": "github"
       },
       "original": {
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "c81f0a07eb1938060e34740aed8d77d61600e1c2",
+        "rev": "b5b88139767d97e96ca646b6f83641d8bb2e69c5",
         "type": "github"
       }
     },
@@ -4382,13 +4398,37 @@
       }
     },
     "runquota-src": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": [
+          "reprobuild",
+          "runquota-src",
+          "nixos-modules",
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "reprobuild",
+          "runquota-src",
+          "nixos-modules",
+          "git-hooks-nix"
+        ],
+        "nim-shm-lease": "nim-shm-lease",
+        "nixos-modules": [
+          "reprobuild",
+          "nixos-modules"
+        ],
+        "nixpkgs": [
+          "reprobuild",
+          "runquota-src",
+          "nixos-modules",
+          "nixpkgs-unstable"
+        ]
+      },
       "locked": {
-        "lastModified": 1782279680,
-        "narHash": "sha256-xFJ30wKib5O1KLgiGchzCF3G4rPsEEsx8DdQoJxzEzM=",
+        "lastModified": 1787618104,
+        "narHash": "sha256-93KLZF8xbw+MSF8Xxthe20IlZbCQcIpkdyJF/bSESEI=",
         "owner": "metacraft-labs",
         "repo": "runquota",
-        "rev": "aa3a30182ec11be9bc703f8b5b6fcf5a2ab625c4",
+        "rev": "b71e8e9061b479334d9b78638cfb828af2db938d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
     # still parse the current manifests (`repro workspace status`) and still
     # satisfy the installed managed-hook contract
     # (`repro hooks protocol --require=2 --hook-contract=...`).
-    reprobuild.url = "github:metacraft-labs/reprobuild/c81f0a07eb1938060e34740aed8d77d61600e1c2";
+    reprobuild.url = "github:metacraft-labs/reprobuild/b5b88139767d97e96ca646b6f83641d8bb2e69c5";
 
     nixpkgs.follows = "nixos-2511";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
Unblocks `ci / t_repro_deploy_agent_https_converges`, which is the **only** remaining real failure on #596, #602 and #603 (`ci / Final Results` is the aggregate and follows automatically).

## Why this revision

**`b5b88139767d`** — the merge commit of [reprobuild#97](https://github.com/metacraft-labs/reprobuild/pull/97), i.e. the *smallest* revision on `dev` that contains the fix.

Deliberately **not** the `dev` tip (`87c143f5`, 40 commits further). This is already a 76-commit roll from `c81f0a07`; an earlier bisect found unrelated regressions in a nearby range, so collecting 40 more changes to fix one bug is a bad trade. PR #97's own branch head was rejected as off-mainline. Ancestry confirmed linear: `c81f0a07` → `b5b88139` → `origin/dev`.

## The bug it fixes

`repro deploy-agent` failed **any** manifest with an empty `profileText`: the apply hook applied a `ProfileResolver` unconditionally, an empty Nim module compiles and prints nothing, and the JSON→RBPI bridge died on `parseJson("")` with `input(1, 0) Error: { expected`.

Causality is confirmed at the fixture level — `checks/repro-deploy-agent-https.nix` mints its RDMF manifest with `profileText=""` (line 66, *"empty profileText, no build actions"*), which is exactly the case #97 fixes.

## Pre-bump verification, per `flake.nix`'s own instructions

Both run against a `repro` built from the candidate:

- **`repro workspace status`** — exit 0, 369 lines, all manifests parsed. The drift it reports is pre-existing workspace state and explicitly advisory.
- **`repro hooks protocol --require=2 --hook-contract=…`** — exit 0 for all four contract tokens (`pre-push`, `post-checkout`, `post-commit`, `post-merge`), read out of the actually-installed managed hooks rather than invented.

## Verified

`nix build .#checks.x86_64-linux.t_repro_deploy_agent_https_converges` → exit 0, all 7 subtests green including the two that were failing. All 51 `checks.x86_64-linux` attributes eval to `drvPath` with no regression from the input bump.

## Companion PR — must land together

`flake.nix` documents that bumping is a **two-file edit**, because `codetracer` mirrors this SHA by hand (it overrides six of reprobuild's inputs to get a `repro` built with `ct_interpose`, which a bare `follows` cannot express). The matching branch is `bump/reprobuild-pin-empty-profile-fix` in `codetracer`, based on `dev`.

`codetracer` is the **only** independent pin in the workspace — verified across every `flake.nix` and top-level `flake.lock`. `infra` reaches `repro` through this input and will pick the bump up when its `nixos-modules` input rolls.

## Note

`flake.nix:42` points at `metacraft-specs/how-to-distribute-new-reprobuild-versions-internally.md`, which **does not exist** — not in `metacraft-specs` (32 tracked files, nothing reprobuild-related, nothing matching in history on any branch) nor in `reprobuild-specs`. The comment block itself was treated as the complete specification. Worth either writing that doc or dropping the pointer.