### PR TITLE
chore: reconcile main and dev histories

### DIFF
--- a/.github/setup-nix/verify-nix-config.sh
+++ b/.github/setup-nix/verify-nix-config.sh
@@ -67,7 +67,15 @@ setup_nix_system_paths=(
   /run/current-system/sw/bin
   /nix/var/nix/profiles/default/bin
 )
-for setup_nix_system_dir in "${setup_nix_system_paths[@]}"; do
+# `${a[@]+"${a[@]}"}` rather than a plain `"${a[@]}"`: on bash < 4.4 — which is
+# what macOS ships as /bin/bash, and therefore what the aarch64-darwin runner
+# executes this with — expanding an EMPTY array under `set -u` is a fatal
+# "unbound variable" error. The contract test builds a mutation of this script
+# with the path entries deleted, so the empty case is real and must stay
+# runnable. The outer expansion is unquoted on purpose: that is what makes it
+# vanish entirely when the array is empty, while the inner "${a[@]}" keeps every
+# element individually quoted so paths containing spaces still survive.
+for setup_nix_system_dir in ${setup_nix_system_paths[@]+"${setup_nix_system_paths[@]}"}; do
   if [ -d "$setup_nix_system_dir" ]; then
     case ":${PATH:-}:" in
       *":$setup_nix_system_dir:"*) ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
       # on github-hosted runners
       matrix:
         include:
-          - runner: eph-linux-x64
+          - runner: eph-linux-x64-g2
             nix-version: ''
-          - runner: eph-linux-x64
+          - runner: eph-linux-x64-g2
             nix-version: 2.28.5
-          - runner: eph-linux-x64
+          - runner: eph-linux-x64-g2
             nix-version: 2.33.0
     runs-on: ${{ matrix.runner }}
     steps:
@@ -59,7 +59,7 @@ jobs:
   # `.github/setup-nix/tests/devshell-fixture/`.
   test-setup-nix-devshell:
     name: Validate setup-nix devShell build-failure detection
-    runs-on: eph-linux-x64
+    runs-on: eph-linux-x64-g2
     steps:
       - name: Checkout first to use locally defined actions
         uses: actions/checkout@v6.0.2
@@ -157,7 +157,7 @@ jobs:
         run: bash .github/setup-nix/tests/verify-nix-config-test.sh
 
   test-mcl-secret-integration:
-    runs-on: eph-linux-x64
+    runs-on: eph-linux-x64-g2
     steps:
       - name: Checkout first to use locally defined actions
         uses: actions/checkout@v6.0.2
@@ -183,10 +183,18 @@ jobs:
       # Foundry takes longer than vm-harness's currently deployed 600-second
       # default. Remove this override after this PR's provider fix is deployed.
       foundry-darwin-bootstrap-runner: '["aarch64-darwin"]'
+      # Route this repo's flake-check matrix at the GPU hosts' ephemeral scale
+      # set `eph-linux-x64-g1` (gpu-server-001) instead of the saturated
+      # `eph-linux-x64` class on high-mem-server. Only this CALLER is
+      # re-pointed; the reusable workflow's own defaults stay on
+      # `eph-linux-x64` (checks/deployment-production-cutover.nix asserts
+      # those literals), and `results-runner` is deliberately left alone
+      # because `ci / Final Results` is a required status check.
+      non-nix-runner: '["eph-linux-x64-g1"]'
       runners: |
         {
           "x86_64-linux": [
-            "eph-linux-x64"
+            "eph-linux-x64-g1"
           ],
           "aarch64-darwin": [
             "eph-macos-arm64"

--- a/checks/deployment-pull-agent-darwin.nix
+++ b/checks/deployment-pull-agent-darwin.nix
@@ -205,6 +205,20 @@ top@{
         lib.findFirst (package: lib.getName package == "mcl-deploy-agent")
           (throw "second Darwin pull-agent entrypoint package is absent from environment.systemPackages")
           staticB.config.environment.systemPackages;
+      staticLaunchdLauncherPackage =
+        lib.findFirst (package: lib.getName package == "mcl-deploy-agent-launcher")
+          (throw "Darwin pull-agent immutable launchd launcher is absent from environment.systemPackages")
+          staticA.config.environment.systemPackages;
+      staticLaunchdLauncherPackageB =
+        lib.findFirst (package: lib.getName package == "mcl-deploy-agent-launcher")
+          (throw "second Darwin pull-agent immutable launchd launcher is absent")
+          staticB.config.environment.systemPackages;
+      expectedLaunchdArguments = [
+        (lib.getExe staticLaunchdLauncherPackage)
+        stableEntrypoint
+        "120"
+        "1"
+      ];
       staticSystemEntrypoint = "${staticA.config.system.path}/bin/mcl-deploy-agent";
       staticSystemEntrypointB = "${staticB.config.system.path}/bin/mcl-deploy-agent";
       staticActivation = staticA.config.system.activationScripts.preActivation.text;
@@ -309,8 +323,11 @@ top@{
           disabledSystem.config.launchd.daemons ? mcl-deploy-agent
         ) "Darwin pull agent is not disabled by default")
         (lib.optional (
-          staticServiceA.ProgramArguments != [ stableEntrypoint ]
-        ) "LaunchDaemon does not use the generation-stable entrypoint")
+          staticServiceA.ProgramArguments != expectedLaunchdArguments
+        ) "LaunchDaemon does not use the immutable bounded launcher")
+        (lib.optional (
+          builtins.head staticServiceA.ProgramArguments == stableEntrypoint
+        ) "LaunchDaemon still executes the not-yet-published current-system link directly")
         (lib.optional (staticServiceA.UserName != "root") "LaunchDaemon is not explicitly root-owned")
         (lib.optional (
           staticServiceA.GroupName != "wheel"
@@ -332,7 +349,13 @@ top@{
         (lib.optional (
           staticEntrypointPackage == staticEntrypointPackageB
         ) "generation-specific packages do not change the resolved wrapper")
-        (lib.optional (lib.hasInfix "/nix/store" (builtins.toJSON staticServiceA)) "LaunchDaemon plist embeds a generation-specific store path")
+        (lib.optional (
+          staticLaunchdLauncherPackage != staticLaunchdLauncherPackageB
+        ) "immutable launchd launcher changes with the wrapped agent generation")
+        (lib.optional (
+          builtins.elem (lib.getExe staticEntrypointPackage) staticServiceA.ProgramArguments
+          || builtins.elem (lib.getExe staticEntrypointPackageB) staticServiceA.ProgramArguments
+        ) "LaunchDaemon plist embeds a generation-specific agent wrapper")
         (lib.optional (lib.hasInfix "sudo" (builtins.toJSON staticServiceA)) "LaunchDaemon plist requires sudo")
         (lib.optional (
           !lib.hasInfix staticPreparationExe staticActivationText
@@ -808,13 +831,51 @@ top@{
           ''
             test ${lib.escapeShellArg (toString staticServiceA.Label)} = ${lib.escapeShellArg (toString staticServiceB.Label)}
             test ${lib.escapeShellArg (builtins.toJSON staticServiceA.ProgramArguments)} = ${lib.escapeShellArg (builtins.toJSON staticServiceB.ProgramArguments)}
+            launcher=${lib.escapeShellArg (lib.getExe staticLaunchdLauncherPackage)}
+            test "$(printf '%s' ${lib.escapeShellArg (builtins.toJSON staticServiceA.ProgramArguments)} | ${pkgs.jq}/bin/jq -r '.[0]')" = "$launcher"
+            test "$launcher" != ${lib.escapeShellArg stableEntrypoint}
             test ${lib.escapeShellArg (lib.getExe staticEntrypointPackage)} != ${lib.escapeShellArg (lib.getExe staticEntrypointPackageB)}
+            test ${lib.escapeShellArg (lib.getExe staticLaunchdLauncherPackage)} = ${lib.escapeShellArg (lib.getExe staticLaunchdLauncherPackageB)}
             test -x ${lib.escapeShellArg (lib.getExe staticEntrypointPackage)}
             test -x ${lib.escapeShellArg (lib.getExe staticEntrypointPackageB)}
             test -L ${lib.escapeShellArg staticSystemEntrypoint}
             test -L ${lib.escapeShellArg staticSystemEntrypointB}
             test "$(readlink ${lib.escapeShellArg staticSystemEntrypoint})" = ${lib.escapeShellArg (lib.getExe staticEntrypointPackage)}
             test "$(readlink ${lib.escapeShellArg staticSystemEntrypointB})" = ${lib.escapeShellArg (lib.getExe staticEntrypointPackageB)}
+
+            # Simulate nix-darwin's first-enable ordering with the exact
+            # evaluated launcher: launchd starts it while the current-system
+            # entrypoint is absent, then activation publishes that executable.
+            fixture="$TMPDIR/first-enable/current-system/sw/bin/mcl-deploy-agent"
+            mkdir -p "$(dirname "$fixture")"
+            "$launcher" "$fixture" 100 0.01 > "$TMPDIR/first-enable.stdout" \
+              2> "$TMPDIR/first-enable.stderr" &
+            launcher_pid=$!
+            sleep 0.05
+            kill -0 "$launcher_pid"
+            printf '%s\n' '#!/bin/sh' 'printf "%s\\n" first-enable-ran' > "$fixture"
+            chmod +x "$fixture"
+            wait "$launcher_pid"
+            grep -Fxq first-enable-ran "$TMPDIR/first-enable.stdout"
+            test ! -s "$TMPDIR/first-enable.stderr"
+
+            # Permanent absence is bounded and diagnostic rather than an
+            # ENOENT launch failure or an activation-long hang.
+            if "$launcher" "$TMPDIR/permanently-absent" 2 0.01 \
+              > "$TMPDIR/absent.stdout" 2> "$TMPDIR/absent.stderr"; then
+              echo 'immutable launchd launcher accepted a permanently absent entrypoint' >&2
+              exit 1
+            else
+              test "$?" -eq 75
+            fi
+            grep -Fq 'entrypoint unavailable after 2 attempts' "$TMPDIR/absent.stderr"
+            test ! -s "$TMPDIR/absent.stdout"
+            if "$launcher" 'relative/path' 2 0.01 >/dev/null 2>&1; then
+              echo 'immutable launchd launcher accepted a relative executable path' >&2
+              exit 1
+            else
+              test "$?" -eq 64
+            fi
             mkdir -p "$out"
             printf '%s\n' 'test_darwin_pull_agent_entrypoint_survives_generation_change: passed' > "$out/result"
           '';

--- a/checks/secret-integration/AGENTS.md
+++ b/checks/secret-integration/AGENTS.md
@@ -36,7 +36,15 @@ path (`/nix/store/...`), which would be read-only.
      `mcl.secrets.services.broken-svc.secrets` is a `throw`, so forcing its
      secrets fails. Used to verify `list`'s per-machine `tryEval` resilience
      (the whole-fleet eval must not abort) without making `nix flake check`
-     force the intentional error.
+     force the intentional error. It cannot be a real `nixosSystem`: the
+     module maps `services.<name>.secrets` into `age.secrets`, so the throw
+     would reach `system.build.toplevel` and the machine could not be
+     evaluated at all. Because it stands in for a `nixosSystem`, it must
+     still expose both members that consumers of a `nixosConfigurations`
+     entry read — `config` and `pkgs`. Tooling that walks the flake's
+     outputs (`nix flake show`, `nix flake check`) reads
+     `pkgs.stdenv.system` to decide which system a machine belongs to, so
+     dropping `pkgs` breaks those commands for the flake as a whole.
    - `test-secret-machine-vm` — a valid machine whose name ends in `-vm`,
      used to verify VM filtering in `list`.
 2. A `writeShellApplication` check that runs `test-mcl-secret.sh` with

--- a/checks/secret-integration/default.nix
+++ b/checks/secret-integration/default.nix
@@ -64,21 +64,36 @@ in
   # A machine-shaped fixture whose secrets fail to evaluate. `mcl secret list`
   # forces `attrNames services.<name>.secrets`, so a throwing `secrets` attrset
   # triggers the `builtins.tryEval` guard and yields an `__error__` marker
-  # instead of aborting the whole-fleet evaluation. This is intentionally not a
-  # full nixosSystem: flake-check still gets a toplevel derivation, while the
-  # command-specific test remains the only path that forces the secret error.
-  flake.nixosConfigurations.broken-machine = {
-    config = {
-      system.build.toplevel =
-        inputs.nixpkgs.legacyPackages.x86_64-linux.runCommand "nixos-system-broken-machine-secret-fixture"
-          { }
-          ''
-            mkdir -p "$out"
-          '';
+  # instead of aborting the whole-fleet evaluation.
+  #
+  # This is intentionally not a full nixosSystem. Routing the throw through the
+  # real module would pull it into `age.secrets` (which maps over
+  # `services.<name>.secrets`) and therefore into `system.build.toplevel`, so
+  # the machine could not be evaluated at all — the command-specific test must
+  # remain the only path that forces the secret error.
+  #
+  # Because it stands in for a nixosSystem, the fixture has to offer the same
+  # surface that consumers of a `nixosConfigurations` entry read. That is not
+  # just `config`: tooling that walks the flake's outputs (`nix flake show`,
+  # `nix flake check`) reads `pkgs.stdenv.system` to decide which system a
+  # machine belongs to. A fixture without `pkgs` makes those commands fail on
+  # the flake as a whole, so `pkgs` is part of the fixture's contract and is
+  # also what supplies its placeholder toplevel below.
+  flake.nixosConfigurations.broken-machine =
+    let
+      pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
+    in
+    {
+      inherit pkgs;
 
-      mcl.secrets.services.broken-svc.secrets = throw "intentional eval failure for broken-machine";
+      config = {
+        system.build.toplevel = pkgs.runCommand "nixos-system-broken-machine-secret-fixture" { } ''
+          mkdir -p "$out"
+        '';
+
+        mcl.secrets.services.broken-svc.secrets = throw "intentional eval failure for broken-machine";
+      };
     };
-  };
 
   # A valid machine whose name ends in `-vm`; `list` hides it unless
   # `--include-vms` is passed.

--- a/docs/deployment/pull-agent.md
+++ b/docs/deployment/pull-agent.md
@@ -212,12 +212,15 @@ infrastructure integrations can use it to require runtime-only credentials
 without embedding those credentials in the Nix store.
 
 The module installs a root LaunchDaemon with `RunAtLoad` and periodic polling.
-Its plist deliberately contains `/run/current-system/sw/bin/mcl-deploy-agent`
-instead of a Nix store path. That stable wrapper is exported through
-`environment.systemPackages`; only after launch does it resolve the current
-generation's `mcl`, trust file, and lifecycle hooks. A nix-darwin activation
-can therefore replace the system environment without unloading the process
-that is applying it.
+Its plist executes a small immutable Nix-store launcher whose derivation is
+independent of the configured agent package and host arguments. On a true first
+enable, nix-darwin may load the job before advancing `/run/current-system`; the
+launcher waits up to 120 seconds for
+`/run/current-system/sw/bin/mcl-deploy-agent`, reports a diagnostic, and exits
+75 if that bounded activation window expires. Once available, that stable
+wrapper resolves the current generation's `mcl`, trust file, and lifecycle
+hooks. Agent-package changes therefore leave the plist and launcher identical,
+so an agent can activate its own replacement without launchd unloading it.
 
 Every invocation takes a non-blocking `flock` supplied by the wrapper's Darwin
 runtime closure and applies umask `0027`. Darwin uses canonical
@@ -291,7 +294,9 @@ Implemented M5 coverage:
   hook, profile/activation, health, and rollback surface with fatal markers and
   proves `deploy-apply --dry-run` reaches none of them; the equivalent non-dry
   override configuration fails before creating state or events.
-- Darwin module contract checks for its root LaunchDaemon, stable entrypoint,
+- Darwin module contract checks for its root LaunchDaemon, immutable bounded
+  launcher, delayed first-enable entrypoint availability and timeout, stable
+  self-update semantics,
   polling interval, canonical dedicated paths, root:wheel preparation commands,
   transactional late-failure rollback, exact original-mode restoration,
   invocation-created cleanup, rollback-time race preservation, mode repair,

--- a/modules/deployment/pull-agent-darwin.nix
+++ b/modules/deployment/pull-agent-darwin.nix
@@ -66,10 +66,48 @@
         cfg.postSwitchHook
       ];
 
-      # The plist deliberately names only this generation-independent path.
-      # Once launchd has opened the wrapper, it may safely activate a system
-      # whose environment contains a different wrapper and mcl package.
       stableEntrypoint = "/run/current-system/sw/bin/mcl-deploy-agent";
+      # nix-darwin loads a newly declared LaunchDaemon before it advances
+      # /run/current-system. Naming the stable link directly therefore makes a
+      # true first enable fail with ENOENT. Keep the plist stable across agent
+      # upgrades, but make its executable an already-realised immutable store
+      # launcher. The launcher waits only for the bounded activation window;
+      # later polls continue to resolve the active generation through the
+      # stable entrypoint, so an agent can activate its own replacement without
+      # launchd unloading it merely because the wrapped package changed.
+      launchdLauncherPackage = pkgs.writeShellApplication {
+        name = "mcl-deploy-agent-launcher";
+        runtimeInputs = [ pkgs.coreutils ];
+        text = ''
+          set -euo pipefail
+
+          if [[ $# -ne 3 ]]; then
+            echo "mcl-deploy-agent-launcher: expected ENTRYPOINT ATTEMPTS DELAY_SECONDS" >&2
+            exit 64
+          fi
+          entrypoint="$1"
+          attempts="$2"
+          delay_seconds="$3"
+          if [[ "$entrypoint" != /* || "$entrypoint" == *$'\n'* \
+            || ! "$attempts" =~ ^[1-9][0-9]{0,3}$ \
+            || ! "$delay_seconds" =~ ^(0\.[0-9]{1,3}|[1-9][0-9]{0,2}(\.[0-9]{1,3})?)$ ]]; then
+            echo "mcl-deploy-agent-launcher: invalid bounded-wait arguments" >&2
+            exit 64
+          fi
+
+          for ((attempt = 1; attempt <= attempts; attempt++)); do
+            if [[ -f "$entrypoint" && -x "$entrypoint" ]]; then
+              exec "$entrypoint"
+            fi
+            if (( attempt < attempts )); then
+              sleep "$delay_seconds"
+            fi
+          done
+          printf 'mcl-deploy-agent-launcher: entrypoint unavailable after %s attempts: %s\n' \
+            "$attempts" "$entrypoint" >&2
+          exit 75
+        '';
+      };
       entrypointPackage = pkgs.writeShellApplication {
         name = "mcl-deploy-agent";
         runtimeInputs = [
@@ -906,6 +944,7 @@
 
         environment.systemPackages = [
           cfg.package
+          launchdLauncherPackage
           entrypointPackage
         ];
 
@@ -919,7 +958,12 @@
         launchd.daemons.mcl-deploy-agent = {
           serviceConfig = {
             Label = "org.metacraft-labs.mcl-deploy-agent";
-            ProgramArguments = [ stableEntrypoint ];
+            ProgramArguments = [
+              (getExe launchdLauncherPackage)
+              stableEntrypoint
+              "120"
+              "1"
+            ];
             UserName = "root";
             GroupName = "wheel";
             RunAtLoad = true;

--- a/modules/mcl-repro-deploy-agent/default.nix
+++ b/modules/mcl-repro-deploy-agent/default.nix
@@ -43,6 +43,21 @@
         { inputs', ... }: inputs'.reprobuild.packages.reprobuild
       );
 
+      # The apply path shells out to `repro __repro-compile-profile`, which
+      # compiles the desired-state profile with Nim. The current reprobuild
+      # release looks Nim up on PATH and fails the tick outright when it is
+      # absent ("vendored-Nim auto-bootstrap is deferred to a later phase"), so
+      # supplying it is the consumer's job. Take the same Nim reprobuild builds
+      # itself with, plus the C toolchain Nim drives to link the profile.
+      defaultProfileCompilerPath = withSystem pkgs.stdenv.hostPlatform.system (
+        { inputs', ... }:
+        [
+          inputs'.reprobuild.packages.nim-fork
+          pkgs.gcc
+          pkgs.binutils
+        ]
+      );
+
       # The allowlist may be provided inline (a list of 130-char hex pubkeys) or
       # as an out-of-store path. Inline keys are rendered to a store file.
       inlineAllowedSigners = pkgs.writeText "mcl-repro-deploy-agent-allowed-signers" (
@@ -88,6 +103,29 @@
           default = defaultPackage;
           defaultText = lib.literalMD "the reprobuild flake's `reprobuild` (`repro`) package";
           description = "Package providing the `repro` binary (with the `deploy-agent` verb).";
+        };
+
+        repoRoot = mkOption {
+          type = types.str;
+          default = "${inputs.reprobuild}";
+          defaultText = lib.literalMD "the reprobuild flake input's source tree";
+          description = ''
+            Value for `$REPROBUILD_REPO_ROOT`. `repro`'s profile compiler
+            resolves reprobuild's Nim library sources beneath this path and
+            runs `nim` with it as the working directory.
+          '';
+        };
+
+        profileCompilerPath = mkOption {
+          type = types.listOf types.package;
+          default = defaultProfileCompilerPath;
+          defaultText = lib.literalMD "the reprobuild flake's `nim-fork`, plus `gcc` and `binutils`";
+          description = ''
+            Packages placed on the unit's PATH so that `repro`'s apply path can
+            compile the desired-state profile. The current reprobuild release
+            requires `nim` on PATH and fails the tick with
+            `profile compilation failed` without it.
+          '';
         };
 
         targetName = mkOption {
@@ -245,6 +283,10 @@
           after = [ "network-online.target" ];
           wants = [ "network-online.target" ];
 
+          # `repro` compiles the desired-state profile with Nim during apply;
+          # systemd units get an empty PATH, so it has to be handed one.
+          path = cfg.profileCompilerPath;
+
           serviceConfig = {
             Type = "oneshot";
             ExecStart = agentCommand;
@@ -271,6 +313,17 @@
               ++ [
                 "HOME=%S/repro-deploy-agent"
                 "XDG_CACHE_HOME=%S/repro-deploy-agent/.cache"
+                # The profile compiler resolves reprobuild's own Nim libraries
+                # relative to $REPROBUILD_REPO_ROOT, falling back to a path
+                # baked in at reprobuild build time — which, in reprobuild's
+                # own words, "is NOT guaranteed to exist on installed
+                # deployments". On a NixOS host it does not, so `nim` was
+                # spawned with a working directory that is not there and the
+                # apply died in setCurrentDir with ENOENT. reprobuild's wrapper
+                # already pins the packaged tree as $REPROBUILD_SOURCE_ROOT for
+                # its other entry points but never feeds it to this one; point
+                # it at the same source.
+                "REPROBUILD_REPO_ROOT=${cfg.repoRoot}"
               ];
 
             TimeoutStartSec = cfg.timeoutStartSec;

--- a/modules/mcl-s3-artifact-store/default.nix
+++ b/modules/mcl-s3-artifact-store/default.nix
@@ -114,6 +114,11 @@
         runtimeInputs = [
           mcl-garage
           pkgs.jq
+          # The stale-key prune below pipes `key list` into awk. A systemd
+          # unit's PATH has no gawk, and writeShellApplication only *prepends*
+          # runtimeInputs, so without this the pipeline exits 127 under
+          # `set -o pipefail` and the function dies before it prints its JSON.
+          pkgs.gawk
         ];
         text = ''
           set -euo pipefail
@@ -241,6 +246,14 @@
 
           # Pass 2: apply each bucket's S3 lifecycle expiry (mirrors the Attic
           # retention-period / artifact retention-days).
+          if [[ -z "$bootstrapKeyJson" ]]; then
+            # This used to be silent: the unit skipped every lifecycle rule,
+            # printed "complete." and exited 0, so a broken key mint looked
+            # exactly like a healthy boot.
+            echo "s3-artifact-store-bootstrap: WARNING could not mint the bootstrap key;" \
+              "no lifecycle expiry was applied to any bucket." >&2
+          fi
+
           if [[ -n "$bootstrapKeyJson" ]]; then
             keyId=$(jq -r '.keyId' <<<"$bootstrapKeyJson")
             secret=$(jq -r '.secretKey' <<<"$bootstrapKeyJson")

--- a/packages/mcl/src/mcl/utils/deploy_state.d
+++ b/packages/mcl/src/mcl/utils/deploy_state.d
@@ -382,6 +382,24 @@ version (Posix)
             description ~ " is writable by its group or other users.");
     }
 
+    // The anchor of the no-follow walk is the filesystem root (or the process
+    // working directory), never a path component the caller chose.  Its owner
+    // is therefore not a control we hold: inside a chroot or a user namespace
+    // — the Nix Linux build sandbox being the case that matters here — "/" is
+    // legitimately owned by nobody rather than by root or by the deployment
+    // user, and demanding otherwise makes every state directory unreachable.
+    // What the anchor must still guarantee is that no other user can plant
+    // entries in it, which is exactly the write-bit rule below; every named
+    // component beneath it keeps the full ownership check.
+    private void validateWalkAnchorDescriptor(int fd, string description)
+    {
+        auto metadata = descriptorMetadata(fd, description);
+        enforce(S_ISDIR(metadata.st_mode), description ~ " is not a directory.");
+        enforce((metadata.st_mode & groupOrOtherWriteBits) == 0
+                || (metadata.st_mode & stickyBit) != 0,
+            description ~ " is writable by its group or other users.");
+    }
+
     version (unittest)
     private void validateDeployStateTestFixtureAncestorDescriptor(
         int fd,
@@ -466,30 +484,10 @@ version (Posix)
             if (currentFd >= 0)
                 close(currentFd);
         ensureCloseOnExec(currentFd, "deployment state directory walk anchor");
-        version (unittest)
-        {
-            auto anchor = absolute ? "/" : ".";
-            if (shouldRelaxDeployStateTestFixtureOwner(
-                anchor,
-                trustedTestFixtureBoundary,
-            ))
-                validateDeployStateTestFixtureAncestorDescriptor(
-                    currentFd,
-                    "Deployment state directory walk anchor",
-                );
-            else
-                validateTrustedAncestorDescriptor(
-                    currentFd,
-                    "Deployment state directory walk anchor",
-                    expectedOwner,
-                );
-        }
-        else
-            validateTrustedAncestorDescriptor(
-                currentFd,
-                "Deployment state directory walk anchor",
-                expectedOwner,
-            );
+        validateWalkAnchorDescriptor(
+            currentFd,
+            "Deployment state directory walk anchor",
+        );
 
         string walked = absolute ? "" : ".";
         foreach (component; components)
@@ -578,11 +576,14 @@ version (Posix)
         else
             auto parentFd = openOrCreateTrustedParentDirectory(parentPath, expectedOwner);
         scope(exit) close(parentFd);
-        validateDirectoryDescriptor(
-            parentFd,
-            "Deployment state directory parent " ~ parentPath,
-            expectedOwner,
-        );
+        // openOrCreateTrustedParentDirectory() has already validated this very
+        // descriptor as a trusted ancestor.  Re-checking it here with
+        // validateDirectoryDescriptor() applied a *different*, stricter policy
+        // to the same directory: it has no sticky exemption at all, so a state
+        // directory placed directly inside a world-writable sticky parent —
+        // `--state-dir /tmp/<name>`, which the walk had just accepted — was
+        // rejected one line later.  The parent is an ancestor; it is validated
+        // by the ancestor rule, once.
 
         auto stateFd = openat(
             parentFd,
@@ -1133,6 +1134,39 @@ unittest
         scope(exit) stateLock.release();
         assert((root.getAttributes & 1023) == 1023);
         assert((boundary.getAttributes & permissionBits) == stateDirectoryCreateMode);
+        assert(targetStateLockPath(stateDir, "target").exists);
+    }
+}
+
+@("test_deploy_state_lock_accepts_state_directory_directly_inside_sticky_parent")
+unittest
+{
+    version (Posix)
+    {
+        import std.file : getAttributes, mkdirRecurse, rmdirRecurse, setAttributes;
+
+        // Every deployment integration test — and every operator who types
+        // `--state-dir /tmp/<name>` — puts the state directory *directly*
+        // inside a world-writable sticky directory, so the sticky parent is
+        // the immediate parent rather than a distant ancestor.  The walk
+        // accepted that; a second, stricter validation of the same descriptor
+        // then rejected it.
+        auto boundary = uniqueDeployStateTestPath("sticky-parent");
+        auto container = boundary.dirName.buildPath(
+            "mcl-deploy-lock-sticky-parent-container-" ~ randomUUID.toString,
+        );
+        auto stateDir = container.buildPath(boundary.baseName);
+        scope(exit)
+            if (container.exists)
+                container.rmdirRecurse;
+
+        container.mkdirRecurse;
+        container.setAttributes(1023); // 01777: writable only while sticky.
+
+        auto stateLock = acquireDeployTargetStateLock(stateDir, "target");
+        scope(exit) stateLock.release();
+        assert((container.getAttributes & 1023) == 1023);
+        assert((stateDir.getAttributes & permissionBits) == stateDirectoryCreateMode);
         assert(targetStateLockPath(stateDir, "target").exists);
     }
 }

--- a/terraform/cloudflare/README.md
+++ b/terraform/cloudflare/README.md
@@ -33,3 +33,22 @@ its reviewed `terraform/cloudflare/<name>-prod/inventory.md` and generates its
 own `imports.tf` from it (kept under `.result/`, never committed — see the
 [import-phase methodology](../../docs/Terraform-Import-Phase.md)). Only the
 inventory tool and the methodology are shared.
+
+## `cloudflare-token` — parametric API-token deep-links (shared engine)
+
+Builds a Cloudflare dashboard "create token" deep-link whose **permission groups
+are derived from the `cloudflare_*` resource types a repo actually manages** —
+least-privilege by construction, no per-repo scope list to maintain. The canonical
+`resource-type → permission-group` mapping lives in the script; each infra repo
+(metacraft / agent-harbor / blocksense) calls it with only its token **name** +
+account/zone.
+
+```sh
+cloudflare-token plan  --scan terraform/cloudflare/metacraft-prod --name "Metacraft Terraform" --open
+cloudflare-token apply --scan terraform/cloudflare/metacraft-prod --name "Metacraft Terraform"
+cloudflare-token import --scan terraform/cloudflare/metacraft-prod --name "Metacraft Terraform"
+```
+`--scan DIR` discovers managed types from the root's `resource "…"` / `to = …`
+blocks; `--resource-types a,b` overrides. `plan` = read on every managed group,
+`apply` = edit on writable groups + `zone:read`, `import` = broad read for
+inventory. Managing zone-level settings? add `--zone-writable`.

--- a/terraform/cloudflare/cloudflare-token
+++ b/terraform/cloudflare/cloudflare-token
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Cloudflare API-token deep-link builder — scopes DERIVED from managed resources.
+
+Shared engine consumed by every infra repo (metacraft, agent-harbor, blocksense).
+The required Cloudflare permission groups for a plan / apply / import token are
+COMPUTED from the set of `cloudflare_*` resource types a repo's Terraform actually
+manages, via the canonical resource-type -> permission-group mapping below. So the
+token is least-privilege by construction and there is NO per-repo hand-maintained
+scope list — only the token NAME (company label) and the account/zone differ per
+repo, and those are passed in.
+
+Usage:
+  cloudflare-token <plan|apply|import> --scan <tf-root-dir> --name "Metacraft Terraform"
+  cloudflare-token plan --resource-types cloudflare_zone,cloudflare_dns_record --name "X" --open
+
+Discovery: `--scan DIR` greps the managed `cloudflare_<type>` resource types out of
+the root's *.tf (resource blocks + `to =` import targets); or pass them explicitly
+with `--resource-types`.
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+import urllib.parse
+import webbrowser
+
+# ---------------------------------------------------------------------------
+# Canonical Cloudflare resource-type -> permission group.
+# `writable` = an apply that manages this type needs the group at `edit`
+# (vs merely `read`). `zone` is intentionally read-only here: managing DNS /
+# R2 / Pages needs Zone:Read to reference the zone, not Zone:Edit — a repo that
+# manages zone-level settings can bump `cloudflare_zone` to writable via
+# --zone-writable. Names are the dashboard permissionGroupKeys.
+# ---------------------------------------------------------------------------
+RESOURCE_SCOPES = {
+    "cloudflare_zone":                 {"group": "zone",                "writable": False},
+    "cloudflare_zone_setting":         {"group": "zone",                "writable": True},
+    "cloudflare_zone_settings_override": {"group": "zone",              "writable": True},
+    "cloudflare_dns_record":           {"group": "dns",                 "writable": True},
+    "cloudflare_record":               {"group": "dns",                 "writable": True},  # provider v4 name
+    "cloudflare_r2_bucket":            {"group": "workers_r2",          "writable": True},
+    "cloudflare_r2_custom_domain":     {"group": "workers_r2",          "writable": True},
+    "cloudflare_r2_managed_domain":    {"group": "workers_r2",          "writable": True},
+    "cloudflare_pages_project":        {"group": "page",                "writable": True},
+    "cloudflare_pages_domain":         {"group": "page",                "writable": True},
+    "cloudflare_workers_script":       {"group": "workers_scripts",     "writable": True},
+    "cloudflare_worker_script":        {"group": "workers_scripts",     "writable": True},  # v4 name
+    "cloudflare_workers_route":        {"group": "workers_routes",      "writable": True},
+    "cloudflare_workers_kv_namespace": {"group": "workers_kv_storage",  "writable": True},
+    "cloudflare_workers_kv":           {"group": "workers_kv_storage",  "writable": True},
+    "cloudflare_d1_database":          {"group": "d1",                  "writable": True},
+    "cloudflare_queue":                {"group": "queues",              "writable": True},
+    "cloudflare_ruleset":              {"group": "waf",                 "writable": True},
+}
+
+# `import` (inventory/adoption) tokens read broadly for discovery — the union of
+# every group this engine knows about, plus account settings.
+ALL_GROUPS = sorted({v["group"] for v in RESOURCE_SCOPES.values()})
+
+
+def discover_resource_types(scan_dir):
+    """Return the set of cloudflare_* resource types managed under scan_dir.
+
+    Matches only real resource contexts — `resource "cloudflare_X"`, `data
+    "cloudflare_X"`, and `to = cloudflare_X.…` import targets — so variables
+    (`var.cloudflare_api_token`) and comments don't count.
+    """
+    found = set()
+    pat = re.compile(
+        r'(?:resource|data)\s+"(cloudflare_[a-z0-9_]+)"'
+        r'|\bto\s*=\s*(cloudflare_[a-z0-9_]+)\b'
+    )
+    for tf in glob.glob(os.path.join(scan_dir, "**", "*.tf"), recursive=True):
+        with open(tf, encoding="utf-8", errors="replace") as fh:
+            for a, b in pat.findall(fh.read()):
+                found.add(a or b)
+    return found
+
+
+def compute_permissions(resource_types, mode, zone_writable=False):
+    """Compute the [{key, type}] permission set for the given mode."""
+    unknown = sorted(t for t in resource_types if t not in RESOURCE_SCOPES)
+
+    if mode == "import":
+        groups = list(ALL_GROUPS)
+        perms = [{"key": "account_settings", "type": "read"}]
+        perms += [{"key": g, "type": "read"} for g in groups]
+        return perms, unknown
+
+    # plan / apply: derive groups from the managed types.
+    want = {}  # group -> writable?
+    for t in resource_types:
+        spec = RESOURCE_SCOPES.get(t)
+        if not spec:
+            continue
+        w = spec["writable"] or (spec["group"] == "zone" and zone_writable)
+        want[spec["group"]] = want.get(spec["group"], False) or w
+
+    perms = []
+    for g in sorted(want):
+        if mode == "plan":
+            perms.append({"key": g, "type": "read"})
+        else:  # apply
+            perms.append({"key": g, "type": "edit" if want[g] else "read"})
+    return perms, unknown
+
+
+def build_url(permissions, name, owner, account_id, zone_id):
+    perm_json = json.dumps(permissions, separators=(",", ":"))
+    q_perm = urllib.parse.quote(perm_json, safe="")
+    q_name = urllib.parse.quote(name, safe="")
+    if owner == "account":
+        return (
+            "https://dash.cloudflare.com/?to=/:account/api-tokens"
+            f"&permissionGroupKeys={q_perm}&name={q_name}"
+        )
+    return (
+        "https://dash.cloudflare.com/profile/api-tokens"
+        f"?permissionGroupKeys={q_perm}"
+        f"&accountId={urllib.parse.quote(account_id, safe='')}"
+        f"&zoneId={urllib.parse.quote(zone_id, safe='')}"
+        f"&name={q_name}"
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(description="Build a Cloudflare API-token deep-link with scopes derived from managed resources.")
+    p.add_argument("mode", choices=["plan", "apply", "import"])
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--scan", help="Terraform root dir to scan for managed cloudflare_* resource types.")
+    src.add_argument("--resource-types", help="Comma-separated cloudflare_* types (instead of --scan).")
+    p.add_argument("--name", required=True, help="Token name prefix (company label), e.g. 'Metacraft Terraform'.")
+    p.add_argument("--owner", choices=["account", "user"], default="account")
+    p.add_argument("--account-id", default="*")
+    p.add_argument("--zone-id", default="all")
+    p.add_argument("--zone-writable", action="store_true", help="Grant Zone:Edit (managing zone-level settings).")
+    p.add_argument("--open", action="store_true", help="Open the URL in a browser.")
+    p.add_argument("--json", action="store_true", help="Emit machine-readable metadata.")
+    args = p.parse_args()
+
+    if args.resource_types:
+        types = {t.strip() for t in args.resource_types.split(",") if t.strip()}
+    else:
+        types = discover_resource_types(args.scan)
+        if not types:
+            print(f"WARNING: no cloudflare_* resource types found under {args.scan}", file=sys.stderr)
+
+    perms, unknown = compute_permissions(types, args.mode, args.zone_writable)
+    name = f"{args.name} {args.mode.capitalize()}"
+    url = build_url(perms, name, args.owner, args.account_id, args.zone_id)
+
+    if args.json:
+        print(json.dumps({"mode": args.mode, "name": name, "resource_types": sorted(types),
+                          "permissions": perms, "unknown_types": unknown, "url": url}, indent=2))
+    else:
+        print(name)
+        print(f"Derived from {len(types)} managed resource type(s).")
+        if unknown:
+            print(f"NOTE: no scope mapping for: {', '.join(unknown)} (add to RESOURCE_SCOPES if managed).", file=sys.stderr)
+        print("Permissions:")
+        for perm in perms:
+            print(f"  - {perm['key']}: {perm['type']}")
+        print()
+        print(url)
+
+    if args.open and not webbrowser.open(url, new=2):
+        print("Could not open a browser automatically.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terraform/github/manifest-lib.nix
+++ b/terraform/github/manifest-lib.nix
@@ -1,0 +1,38 @@
+# Parametric helpers for governance secret manifests, shared across the infra
+# repos (metacraft / agent-harbor / blocksense). Each repo's manifest.nix keeps
+# only the repo-specific data (owner, repo); the boilerplate lives here.
+#
+#   let h = import "${inputs.nixos-modules}/terraform/github/manifest-lib.nix" { };
+#   in { secrets = [ (h.mkAgenixCiSecret { owner = "metacraft-labs"; repo = "infra"; }) … ]; }
+{ }:
+rec {
+  # A repository-scoped github_actions_secret manifest entry. `ageFile` defaults
+  # to the conventional secrets/actions/repos/<repo>/<name>.age path.
+  mkRepoActionsSecret =
+    { owner
+    , repo
+    , name
+    , ageFile ? "secrets/actions/repos/${repo}/${name}.age"
+    , rotationGroup ? null
+    }:
+    {
+      providerResource = "github_actions_secret";
+      scope = "repository";
+      repository = repo;
+      inherit name;
+      providerId = "${owner}/${repo}:${name}";
+      inherit ageFile;
+      manageWithTerraform = true;
+    }
+    // (if rotationGroup != null then { inherit rotationGroup; } else { });
+
+  # The repo-specific agenix CI key (PRIVATE half) that reusable-terraform-ci
+  # decrypts agenix-token secrets (e.g. Cloudflare API tokens) with. Public half
+  # is a recipient in the token rules. Governance-managed, not `gh secret set`.
+  mkAgenixCiSecret =
+    { owner, repo }:
+    mkRepoActionsSecret {
+      inherit owner repo;
+      name = "AGENIX_CI_PRIVATE_KEY";
+    };
+}


### PR DESCRIPTION
## Summary

- merge exact `origin/dev` `886f890cbe3a507185bfe967457263383fdac317` into exact `origin/main` `ea7c26ad5b956105ead4b3efb7779967e81571bd`
- preserve main's shared Terraform import, governance, secrets, and CI engines
- preserve dev's deployment, Darwin, GPU-runner routing, and reusable infrastructure fixes
- resolve the sole overlapping Cloudflare README by retaining both the reusable import workflow and parametric token-scope documentation
- after this lands on `main`, fast-forward `dev` to the resulting merge commit so both branches are identical

## Local verification

- Setup Nix contract: 25/25
- Cloudflare token syntax and independent contracts: 10/10
- MCL exact CI suite: 138/138
- secret integration: 21/21
- full `x86_64-linux` offline `nix flake check --no-build`: passed
- Terraform CI matrix, GitHub governance/bootstrap rendering, manifest/actions-secrets composition, and pre-commit checks: passed
- no ignored, skipped, or weakened tests were introduced

## Native Darwin gate

The Darwin derivations evaluate to concrete drvPaths on Linux, but their closures were not built here. Before merge, require:

- `Validate setup-nix verification (aarch64-darwin)`
- `ci / deployment-pull-agent-darwin-integration | aarch64-darwin`
- `ci / deployment-darwin-activation-integration | aarch64-darwin`
- `ci / setup-nix-transfer-resilience | aarch64-darwin`
- `ci / mcl | aarch64-darwin`
- aggregate `ci / Final Results`
