### PR TITLE
ci: repin metacraft-github-actions actions from @main to @dev

### DIFF
--- a/.github/workflows/reusable-recorder-ci.yml
+++ b/.github/workflows/reusable-recorder-ci.yml
@@ -74,7 +74,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Setup dev env
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: ${{ inputs.env-flavor }}
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -101,7 +101,7 @@ jobs:
       - name: Mirror test logs to S3 (non-blocking)
         if: failure()
         continue-on-error: true
-        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@dev
         with:
           path: ${{ inputs.log-path }}
           prefix: test-logs-${{ matrix.runner }}/${{ github.run_id }}


### PR DESCRIPTION
After the org-wide `main`->`dev` rename of `metacraft-labs/metacraft-github-actions`, its old `main` branch no longer resolves for GitHub Actions (`git/ref/heads/main` 404s; `@main` fails at action-load). This repins every `uses: metacraft-labs/metacraft-github-actions/<action>@main` here to `@dev` (the new mainline).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>