### PR TITLE
flake: bump reprobuild pin to dev 88ab6f12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2300,17 +2300,17 @@
     "io-mon-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1787845469,
-        "narHash": "sha256-Pd0g5lxoNr8vfb+r1j2+ThLLbakb9NPD7xOx4HoPP9c=",
+        "lastModified": 1787917584,
+        "narHash": "sha256-oVj85ukC5bLmegp0gqmY1/HGs5ximDC5tUlBSJN3Pzc=",
         "owner": "metacraft-labs",
         "repo": "io-mon",
-        "rev": "cb26b626e6642f00818da0f64938e64c7ae0d209",
+        "rev": "e2ee15afe8dd7f538ec2ce79af9a1aa512addce2",
         "type": "github"
       },
       "original": {
         "owner": "metacraft-labs",
         "repo": "io-mon",
-        "rev": "cb26b626e6642f00818da0f64938e64c7ae0d209",
+        "rev": "e2ee15afe8dd7f538ec2ce79af9a1aa512addce2",
         "type": "github"
       }
     },
@@ -4324,17 +4324,17 @@
         "runquota-src": "runquota-src"
       },
       "locked": {
-        "lastModified": 1787924792,
-        "narHash": "sha256-4Aw0rOiq9xsuJ/gsCa6TA482fKGk7MyfiZwC+euG6Ls=",
+        "lastModified": 1788438361,
+        "narHash": "sha256-dwRQ3Z5iAhgkF6NPWaLHZ3todEgbY1Cy7FqhjvfaJXE=",
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "2f124aebbc8a9e61e87de1aa13e15298a83f88c6",
+        "rev": "88ab6f12c055c49cc7581d9630d1c3cb00704744",
         "type": "github"
       },
       "original": {
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "2f124aebbc8a9e61e87de1aa13e15298a83f88c6",
+        "rev": "88ab6f12c055c49cc7581d9630d1c3cb00704744",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
     # still parse the current manifests (`repro workspace status`) and still
     # satisfy the installed managed-hook contract
     # (`repro hooks protocol --require=2 --hook-contract=...`).
-    reprobuild.url = "github:metacraft-labs/reprobuild/2f124aebbc8a9e61e87de1aa13e15298a83f88c6";
+    reprobuild.url = "github:metacraft-labs/reprobuild/88ab6f12c055c49cc7581d9630d1c3cb00704744";
 
     nixpkgs.follows = "nixos-2511";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
## Summary

- pin reprobuild to merged `dev` revision `88ab6f12c055c49cc7581d9630d1c3cb00704744`
- refresh the corresponding lock node without relying on Nix's ref cache

## Validation

- `nix build --no-link github:metacraft-labs/reprobuild/88ab6f12c055c49cc7581d9630d1c3cb00704744#default` on x86_64 Linux
- packaged `repro workspace status` parsed the current 155-repository workspace
- packaged `repro hooks protocol --require=2 --hook-contract=…` accepted the re-anchored managed-hook contract
- `git diff --check`

Darwin packaging was not validated locally because this Linux workstation has no configured Darwin remote builder. The attempted `aarch64-darwin` build fails at the same pre-existing `libblake3-prefix` `/bin/sh` impure-host dependency for both the old and new revisions; macOS post-fixup, Mach-O rewriting, and signing remain for the Darwin CI lane to establish.
