### PR TITLE
ci: run test-act on eph-linux-x64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,12 +202,14 @@ jobs:
         }
 
   # The `just act lint` step builds `ci-image` and runs the lint workflow inside
-  # it via `act`, i.e. it needs nested Docker. This is exactly what the
-  # `eph-linux-x64-nested` class provides (vmharness-nested: nested docker + nested KVM),
-  # so this job targets that class rather than plain `eph-linux-x64`. It will queue until
-  # an `eph-linux-x64-nested` runner is attached to the fleet.
+  # it via `act`, i.e. it needs nested Docker. Every `eph-linux-x64` container
+  # now provides it: the runner-image consolidation folded the retired
+  # `vmharness-nested` provider's capability into the single `vmharness` provider
+  # and `vmh-linux-runner` image (nested Docker + nested KVM), so the separate
+  # `eph-linux-x64-nested` class is a transitional alias for the same container
+  # and carries no extra capability.
   test-act:
-    runs-on: eph-linux-x64-nested
+    runs-on: eph-linux-x64
     steps:
       - name: Checkout first to use locally defined actions
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
`test-act` needs nested Docker, which used to mean targeting `eph-linux-x64-nested`.

The runner-image consolidation folded the retired `vmharness-nested` provider's capability into the single `vmharness` provider and `vmh-linux-runner` image (docker + qemu/KVM + fuse3 baked, `security.nesting` on), so **every** `eph-linux-x64` container now provides it. `eph-linux-x64-nested` is a transitional alias resolving to the same container.

Moving this job lets the alias be retired. Per `infra/services/garm-incus-runners.nix:455-461`, once no external consumer uses the name, its 2+2 slots fold back into the primary scale sets at unchanged aggregate — no budget or storage-ceiling change.

Also drops the stale comment claiming the job "will queue until an `eph-linux-x64-nested` runner is attached to the fleet".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4JgdPtUJfzSSa61DA7Xkz