### PR TITLE
ci: fire the downstream flake-update on dev, this repo's mainline

### DIFF
--- a/.github/workflows/trigger-downstream-flake-update.yml
+++ b/.github/workflows/trigger-downstream-flake-update.yml
@@ -2,8 +2,11 @@ name: Trigger Downstream Flake Update on Push to Main
 
 on:
   push:
+    # The branches a flake change can land on: `dev`, this repo's
+    # manifest-declared mainline, and the legacy `main`.
     branches:
-      - main # Or the branch you want to track
+      - main
+      - dev
 
 jobs:
   trigger-downstream-repo:


### PR DESCRIPTION
`trigger-downstream-flake-update.yml` filtered on `main` alone. This repo's manifest-declared mainline is `dev`, so a flake change landing on the mainline notified no downstream repo — `infra` and `nix-blockchain-development` were never told to refresh their lock against it.

| File | Before | After |
|---|---|---|
| `trigger-downstream-flake-update.yml` | push `[main]` (`# Or the branch you want to track`) | push `[main, dev]`, comment replaced with one naming what the list is |

`main` **does** exist here as a real remote branch and is kept; this widens coverage rather than moving it. Nothing else in this repo is changed — the job body, the downstream matrix, and every other workflow are untouched.

### Downstream-trigger safety

`trigger-downstream-flake-update.yml` does exactly one thing: POST a `{"event_type":"flake-update"}` `repository_dispatch` to the listed repos. I traced the receiving end — each downstream `update-flake-lock.yml` handles `repository_dispatch: types: [flake-update]` by calling `nixos-modules/.github/workflows/reusable-update-flake-lock.yml`, which runs `nix flake update` and opens a PR via `peter-evans/create-pull-request` with `add-paths: flake.lock`. It does not deploy, apply, or push to any mainline. Benign and reversible, so adding `dev` is safe.

Validated with `actionlint`: parses clean. Any remaining diagnostics are pre-existing `runner-label` warnings about self-hosted `eph-*` labels on lines this PR does not touch.

Per [branching-policy.md](https://github.com/metacraft-labs/metacraft-dev-guidelines/blob/main/policies/branching-policy.md): CI workflow branch filters must include the branch names they protect or deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4JgdPtUJfzSSa61DA7Xkz