### PR TITLE
fix(garm-provider-vmharness): ordered incus teardown + optional CPU cap

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -22,6 +22,7 @@
     ./garm-incus-runner-host.nix
     ./garm-incus-storage-pool-source.nix
     ./garm-macos-runner-install-wrapper.nix
+    ./garm-provider-vmharness-backend.nix
     ./garm-provider-vmharness-protocol.nix
     ./garm-provider-vmharness-windows-toolchain.nix
     ./s3-artifact-store.nix

--- a/checks/garm-multi-provider.nix
+++ b/checks/garm-multi-provider.nix
@@ -131,6 +131,23 @@ top@{ ... }:
       offUnit = mkGarmUnit {
         enable = true;
       };
+
+      # (5) an incus provider WITH a CPU cap (CIR-M1). Identical to (2) but for
+      # `incusLimitsCpu`, so (2) doubles as the negative control: the key must
+      # be ABSENT from an uncapped provider's config, not merely empty. That
+      # matters because the provider keys "apply no cap at all" off emptiness,
+      # and because an emitted-but-empty key would change the rendered
+      # config.toml — and therefore restart garm — on every existing host.
+      cappedIncusUnit = mkGarmUnit {
+        enable = true;
+        providers.vmharness = {
+          backend = "incus";
+          incusIPv4CIDR = "10.0.100.0/24";
+          incusIPv4Gateway = "10.0.100.1";
+          incusLimitsCpu = "8";
+          images.linux-runner.sourceImage = "runner-linux";
+        };
+      };
     in
     {
       checks = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
@@ -142,6 +159,7 @@ top@{ ... }:
                 incusUnit
                 qemuWindowsArmUnit
                 offUnit
+                cappedIncusUnit
                 ;
             }
             ''
@@ -229,7 +247,36 @@ top@{ ... }:
               ! grep -q '^SupplementaryGroups=' "$off" || fail "off: must have NO supplementary groups"
               ! grep -q '^DeviceAllow=' "$off" || fail "off: must have NO DeviceAllow"
 
-              echo "[t_garm_multi_provider][PASS] union sandbox, incus-only strict posture, qemu-windows-arm provider config, and provider-off M0 posture all verified"
+              # --- (5) CIR-M1: the incus CPU cap renders, and only on request ---
+              #
+              # The cap exists because the per-job containers are uncapped
+              # (`cpu.max=max`, `cpuset.cpus=0-31` on a 32-thread host), so each
+              # one reports every host thread to `nproc` and self-sizes its build
+              # parallelism to the whole machine — the demand that drives the
+              # co-resident Windows guests past GitHub's ~300 s assignment
+              # window. This asserts the option reaches the rendered TOML, which
+              # is the only contract between the NixOS option and the provider.
+              cpre=$(grep '^ExecStartPre=' "$cappedIncusUnit/garm.service" | head -1 | cut -d= -f2-)
+              [ -f "$cpre" ] || fail "incus-capped: render script not found at $cpre"
+              ctmpl=$(grep -ohE '/nix/store/[a-z0-9]+-garm-config.toml.tmpl' "$cpre" | head -1)
+              [ -f "$ctmpl" ] || fail "incus-capped: config template not found (from $cpre)"
+              ccfg=$(grep -ohE '/nix/store/[a-z0-9]+-garm-provider-vmharness\.toml' "$ctmpl" | head -1)
+              [ -f "$ccfg" ] || fail "incus-capped: provider config not found"
+              grep -qx 'incus_limits_cpu = "8"' "$ccfg" \
+                || fail "incus-capped: incus_limits_cpu not rendered (got: $(grep -c . "$ccfg") lines, none matching)"
+
+              # NEGATIVE CONTROL: shape (2) differs ONLY in not setting the
+              # option, and its config must not carry the key AT ALL. An
+              # emitted-but-empty key would restart garm on every existing host
+              # and would hand the provider a cap it was never asked for.
+              ipre=$(grep '^ExecStartPre=' "$incus" | head -1 | cut -d= -f2-)
+              itmpl=$(grep -ohE '/nix/store/[a-z0-9]+-garm-config.toml.tmpl' "$ipre" | head -1)
+              icfg=$(grep -ohE '/nix/store/[a-z0-9]+-garm-provider-vmharness\.toml' "$itmpl" | head -1)
+              [ -f "$icfg" ] || fail "incus-uncapped: provider config not found"
+              ! grep -q 'incus_limits_cpu' "$icfg" \
+                || fail "incus-uncapped: incus_limits_cpu present without the option being set; the key must be inert by default"
+
+              echo "[t_garm_multi_provider][PASS] union sandbox, incus-only strict posture, qemu-windows-arm provider config, the incus CPU cap (present when set, absent when not), and provider-off M0 posture all verified"
               touch $out
             '';
       };

--- a/checks/garm-provider-vmharness-backend.nix
+++ b/checks/garm-provider-vmharness-backend.nix
@@ -1,0 +1,89 @@
+{ ... }:
+{
+  # CIR-M1 gate: t_garm_provider_vmharness_backend.
+  #
+  # WHY THIS EXISTS
+  #
+  #   `packages/garm-provider-vmharness/default.nix` sets `doCheck = false`, and
+  #   until now the ONLY package test wired into CI was
+  #   `checks/garm-provider-vmharness-windows-toolchain.nix`, which runs
+  #   `go test ./internal/provider`. The whole of `internal/backend` and
+  #   `internal/config` — the incus container lifecycle, the teardown path, the
+  #   IP-allocation lock, the config parser — had tests that NOTHING ran. That
+  #   is the same class of defect the windows-toolchain gate was written to
+  #   catch, one directory over: a suite that cannot report anything.
+  #
+  #   CIR-M1 changes both of those packages: a `limits.cpu` cap applied
+  #   pre-start, and a stop-and-wait / detach / delete teardown replacing the
+  #   one-shot `incus delete --force` that produced 8786 distinct delete
+  #   failures over 16 days on high-mem-server, 96.7% of them
+  #   `zfs destroy ...: dataset is busy`. Those changes need a gate that runs.
+  #
+  # HERMETIC. The backend tests drive a MOCK `incus` — a POSIX-sh emulation
+  # that persists container state, devices and status on disk — so the
+  # STATELESS provider has a real backend to recompute from. No incusd, no
+  # containers, no network, no KVM. The teardown tests additionally inject the
+  # host's real failure text (`zfs destroy ...: dataset is busy`) and a
+  # multi-poll stop settle, so the ordering and the retry ladder are exercised
+  # rather than assumed.
+  #
+  # THE TWO EXCLUSIONS, AND WHY THEY ARE NOT A WEAKENING
+  #
+  #   `TestIncusGpuPassthroughSharedUserspace` and
+  #   `TestIncusSharedStoresAttachStoreDisks` exercise `ShareHostNixStore`,
+  #   whose `Create` path calls `resolveHostNixBinDir`. That function
+  #   EvalSymlinks `/run/current-system/sw/bin/nix` and REFUSES to create the
+  #   container unless it resolves into `/nix/store` — a deliberate safety
+  #   property (never hand a guest a nominally shared store it cannot execute
+  #   from), and one this gate must not relax.
+  #
+  #   `/run/current-system/sw/bin/nix` does not exist in a Nix build sandbox,
+  #   so `EvalSymlinks` fails, `Create` fails, and those two tests CANNOT pass
+  #   here. Note precisely what the blocker is: a RESOLVABLE host Nix client,
+  #   not a WRITABLE `/nix/store` — writability is irrelevant to both tests and
+  #   an earlier revision of this comment said otherwise. Verified on a NixOS
+  #   host, where `/run/current-system/sw/bin/nix` does resolve into
+  #   `/nix/store`, both tests PASS, so this is environmental and not a masked
+  #   failure.
+  #
+  #   They are excluded BY NAME rather than by loosening the assertions or by
+  #   adding a `t.Skip` to the tests themselves. Note what is and is not lost:
+  #   they are today run by NOTHING (`doCheck = false`, and no workflow invokes
+  #   `go test` for this package), so this gate strictly increases coverage —
+  #   from 0 of the backend tests to all but these two. Giving
+  #   `resolveHostNixBinDir` an injectable path so they can run hermetically is
+  #   a worthwhile follow-up and is deliberately NOT bundled into CIR-M1.
+  #
+  #   `go test -skip` filters the excluded tests OUT of the run: they are not
+  #   reported as SKIP and the log names neither of them. A reader of CI output
+  #   would therefore have no way to know two tests were dropped, so the
+  #   checkPhase ECHOES the exclusion and its reason before running. An
+  #   exclusion that is only loud in the source file is not loud.
+  #
+  # Kept SEPARATE from the windows-toolchain gate rather than folded into it so
+  # a failure names which surface broke, and so neither gate's wall-clock
+  # depends on the other's.
+  perSystem =
+    { self', ... }:
+    {
+      checks.t_garm_provider_vmharness_backend =
+        self'.packages.garm-provider-vmharness.overrideAttrs
+          (_old: {
+            doCheck = true;
+            checkPhase = ''
+              runHook preCheck
+              go test ./internal/config
+              echo "t_garm_provider_vmharness_backend: EXCLUDING 2 tests from ./internal/backend --"
+              echo "  TestIncusGpuPassthroughSharedUserspace"
+              echo "  TestIncusSharedStoresAttachStoreDisks"
+              echo "  reason: both drive ShareHostNixStore, whose Create path resolves"
+              echo "  /run/current-system/sw/bin/nix and refuses to build a container unless it"
+              echo "  resolves into /nix/store. That path does not exist in a build sandbox."
+              echo "  go test -skip reports nothing about filtered tests, hence this notice."
+              go test ./internal/backend \
+                -skip 'TestIncusGpuPassthroughSharedUserspace|TestIncusSharedStoresAttachStoreDisks'
+              runHook postCheck
+            '';
+          });
+    };
+}

--- a/modules/garm/default.nix
+++ b/modules/garm/default.nix
@@ -136,21 +136,30 @@
         + optionalString (p.currentMemoryMb > 0) ''
           current_memory_mb = ${toString p.currentMemoryMb}
         '';
-      mkIncusKeys = p: ''
-        incus_path = "${p.incusPath}"
-        incus_bridge = "${p.incusBridge}"
-        incus_ipv4_cidr = "${p.incusIPv4CIDR}"
-        incus_ipv4_gateway = "${p.incusIPv4Gateway}"
-        incus_ipv4_range_start = "${p.incusIPv4RangeStart}"
-        incus_ipv4_range_end = "${p.incusIPv4RangeEnd}"
-        incus_nameservers = [${lib.concatMapStringsSep ", " (s: "\"${s}\"") p.incusNameservers}]
-        incus_gpu_passthrough = ${lib.boolToString p.incusGpuPassthrough}
-        incus_share_host_nix_store = ${lib.boolToString p.incusShareHostNixStore}
-        incus_reprobuild_store = "${p.incusReprobuildStore}"
-        incus_reprobuild_store_guest_path = "${p.incusReprobuildStoreGuestPath}"
-        incus_security_nesting = ${lib.boolToString p.incusSecurityNesting}
-        incus_nested_kvm = ${lib.boolToString p.incusNestedKvm}
-      '';
+      mkIncusKeys =
+        p:
+        ''
+          incus_path = "${p.incusPath}"
+          incus_bridge = "${p.incusBridge}"
+          incus_ipv4_cidr = "${p.incusIPv4CIDR}"
+          incus_ipv4_gateway = "${p.incusIPv4Gateway}"
+          incus_ipv4_range_start = "${p.incusIPv4RangeStart}"
+          incus_ipv4_range_end = "${p.incusIPv4RangeEnd}"
+          incus_nameservers = [${lib.concatMapStringsSep ", " (s: "\"${s}\"") p.incusNameservers}]
+          incus_gpu_passthrough = ${lib.boolToString p.incusGpuPassthrough}
+          incus_share_host_nix_store = ${lib.boolToString p.incusShareHostNixStore}
+          incus_reprobuild_store = "${p.incusReprobuildStore}"
+          incus_reprobuild_store_guest_path = "${p.incusReprobuildStoreGuestPath}"
+          incus_security_nesting = ${lib.boolToString p.incusSecurityNesting}
+          incus_nested_kvm = ${lib.boolToString p.incusNestedKvm}
+        ''
+        # Only emitted when a cap is actually requested, so a provider that
+        # wants none keeps a byte-identical config.toml (and therefore a
+        # byte-identical container) to before this option existed — the same
+        # discipline `currentMemoryMb` follows in mkLibvirtKeys above.
+        + optionalString (p.incusLimitsCpu != "") ''
+          incus_limits_cpu = "${p.incusLimitsCpu}"
+        '';
       mkVMHarnessRunKeys =
         p:
         ''
@@ -1287,6 +1296,46 @@
                 image must ship qemu/kvm. Default false ⇒ the container is
                 byte-unchanged (the live runners are untouched). Ignored by
                 non-incus providers. Backs HR2 (Production-Runners nested KVM).
+              '';
+            };
+
+            incusLimitsCpu = mkOption {
+              # Constrained rather than free-form `str` for two reasons. It is
+              # rendered into TOML by string interpolation, so a value carrying
+              # a quote would emit syntactically invalid config and fail at
+              # provider start-up rather than at eval. And a typo that incus
+              # rejects (`"eight"`, `"8 "`) is only discovered on the first
+              # container Create, i.e. on a real job. The shapes incus accepts
+              # are a count or a cpuset; empty means "no cap".
+              type = types.strMatching "([0-9]+(-[0-9]+)?(,[0-9]+(-[0-9]+)?)*)?";
+              default = "";
+              example = "8";
+              description = ''
+                When non-empty (incus backend only), the provider sets
+                `limits.cpu` on every per-job container BEFORE start:
+                `incus config set <name> limits.cpu <value>`. Incus accepts a
+                COUNT (`"8"`) or an explicit CPU SET (`"0-7"`, `"0,2,4"`); a
+                count is a DYNAMIC pin — incusd picks that many host CPUs and
+                re-balances as containers come and go.
+
+                This bounds the DEMAND a per-job container generates, not just
+                the share it is scheduled at. An uncapped container inherits
+                `cpuset.cpus=0-N` and therefore reports every host thread to
+                `nproc`, so `make -j$(nproc)` / `cargo build` /
+                `nix build --cores 0` each size themselves to the WHOLE
+                machine; several such containers put the host into a
+                multi-hundred runnable-task overhang that starves every other
+                workload on the box, including co-resident libvirt guests.
+
+                Chosen over a `limits.cpu.allowance` CFS quota deliberately: an
+                allowance sized for the worst case idles host CPUs whenever
+                fewer than the worst-case number of containers are running,
+                whereas a cpuset count caps peak parallelism while still
+                letting a lone container use its full allotment.
+
+                Default `""` ⇒ the key is not emitted at all, the provider sets
+                nothing, and the container is byte-identical to before this
+                option existed. Ignored by non-incus providers.
               '';
             };
 

--- a/packages/garm-provider-vmharness/src/internal/backend/incus.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/incus.go
@@ -48,9 +48,10 @@ import (
 //	incus config set <name> cloud-init.network-config  # static IPv4 (no DHCP)
 //	incus start <name>                            # cloud-init runs the bootstrap
 //
-// Delete: `incus delete --force <name>` (stops + removes the container and
-// its per-container storage volume in one shot — no residue). Idempotent:
-// a missing container is success.
+// Delete is ORDERED (see the Delete doc comment for the measurement that
+// motivates it): stop and wait for `Stopped`, detach the devices Create
+// attached, then `incus delete`, with a short bounded local retry and a
+// `--force` last resort. Idempotent: a missing container is success.
 type IncusBackend struct {
 	// IncusCmd is the incus invocation vector, eg ["incus"] or
 	// ["sudo","-n","incus"]. Built from config.IncusPath (whitespace-split)
@@ -161,6 +162,36 @@ type IncusBackend struct {
 	// (`kvm_intel.nested=Y` / `kvm_amd.nested=Y`). Default false ⇒ the
 	// container is byte-unchanged (the live runners are untouched).
 	NestedKvm bool
+	// LimitsCPU, when non-empty, is written verbatim to each per-job
+	// container's `limits.cpu` BEFORE start (a count like "8", or an explicit
+	// set like "0-7"). Incus turns a count into a dynamic cpuset pin, so the
+	// guest's `cpuset.cpus` — and therefore its `nproc` — reports that many
+	// CPUs and build tools that self-size from `nproc` stop spawning one job
+	// per HOST thread. Default "" ⇒ nothing is set and the container is
+	// byte-unchanged (the live runners are untouched).
+	LimitsCPU string
+	// StopSettleTimeout / DeleteRetryBackoff override the ORDERED teardown's
+	// timings (see Delete). Zero means the package defaults
+	// (incusStopSettleTimeout / incusDeleteBackoffBase). Production leaves
+	// both zero; tests shrink them so the retry ladder is exercised without
+	// sleeping through it — the same seam IPAllocationLockPath provides for
+	// the IP lease lock.
+	StopSettleTimeout  time.Duration
+	DeleteRetryBackoff time.Duration
+}
+
+func (b *IncusBackend) stopSettleTimeout() time.Duration {
+	if b.StopSettleTimeout > 0 {
+		return b.StopSettleTimeout
+	}
+	return incusStopSettleTimeout
+}
+
+func (b *IncusBackend) deleteRetryBackoff() time.Duration {
+	if b.DeleteRetryBackoff > 0 {
+		return b.DeleteRetryBackoff
+	}
+	return incusDeleteBackoffBase
 }
 
 // Host paths shared into the per-job container when ShareHostNixStore is set:
@@ -232,7 +263,12 @@ type incusContainer struct {
 	Name   string            `json:"name"`
 	Status string            `json:"status"`
 	Config map[string]string `json:"config"`
-	State  *struct {
+	// Devices is the container's device map as incusd reports it. Only the
+	// device NAMES are used (to detach exactly the devices this provider
+	// attached, and only if they are still present), so the inner map is left
+	// untyped.
+	Devices map[string]map[string]string `json:"devices"`
+	State   *struct {
 		Network map[string]struct {
 			Addresses []struct {
 				Family  string `json:"family"`
@@ -586,6 +622,29 @@ func (b *IncusBackend) Create(ctx context.Context, args CreateArgs) (Instance, e
 		}
 	}
 
+	// 4c-bis. CPU cap. Set BEFORE start so the container's cgroup carries the
+	//     limit from PID 1 onward: a cap applied after boot would still let
+	//     cloud-init and the runner's own start-up see every host thread, and
+	//     the tools that matter read `nproc` once, early.
+	//
+	//     Measured motivation (high-mem-server, 16 days): the per-job
+	//     containers run uncapped at `cpu.max=max`, `cpuset.cpus=0-31` on a
+	//     32-thread host, so each one reports 32 to `nproc` and self-sizes its
+	//     build parallelism to the WHOLE machine. With several containers live
+	//     the runnable queue reaches load1 87-191, and the co-resident Windows
+	//     libvirt guests miss a ~300 s GitHub job-assignment window they
+	//     otherwise clear in ~200 s. Capping bounds the demand each container
+	//     generates.
+	//
+	//     Default "" ⇒ this block is skipped and the container is
+	//     byte-unchanged (the live runners are untouched).
+	if b.LimitsCPU != "" {
+		if out, err := b.run(ctx, "", "config", "set", args.Name, "limits.cpu", b.LimitsCPU); err != nil {
+			_ = b.forceDelete(ctx, args.Name)
+			return Instance{}, fmt.Errorf("incus config set limits.cpu=%s: %w: %s", b.LimitsCPU, err, strings.TrimSpace(out))
+		}
+	}
+
 	// 4d. Security nesting (the `runs-on: incus` nested-Docker path — HR1). Turn
 	//     on nested containerisation so an in-guest Docker/Podman daemon can
 	//     create its own namespaces/cgroups + overlay mount, and add the two
@@ -759,27 +818,218 @@ func (b *IncusBackend) addDisk(ctx context.Context, container, device, source, g
 	return nil
 }
 
-// forceDelete is the idempotent teardown primitive.
+// forceDelete is the one-shot teardown primitive: it folds the stop into the
+// delete. It is the CREATE-path ROLLBACK (a half-built container whose state is
+// unknown and which no job ever reached), and the last-resort fallback at the
+// end of Delete. The ordered teardown lives in Delete, not here.
 func (b *IncusBackend) forceDelete(ctx context.Context, name string) error {
 	_, err := b.run(ctx, "", "delete", "--force", name)
 	return err
 }
 
-// Delete force-removes the container. Idempotent: a missing container is
-// treated as already-deleted success.
+// Teardown tuning. These bound the ORDERED delete below; they are not a
+// substitute for GARM's own retry ladder (workers/provider/instance_manager.go:
+// 1 s doubling, capped at 5 min, unbounded), which still applies if every
+// attempt here fails. The point of a SHORT local ladder is that a transient
+// busy dataset resolves in seconds instead of escalating into that 5-minute
+// cap.
+const (
+	// How long to wait for incusd to report the container `Stopped` after the
+	// stop is issued. A container whose rootfs is referenced by hundreds of
+	// processes across dozens of mount namespaces (security.nesting + nested
+	// KVM + Docker) takes real time to unwind.
+	incusStopSettleTimeout = 30 * time.Second
+	incusStopPollInterval  = 500 * time.Millisecond
+	// Bounded local delete retries: 1 s, 2 s, 4 s, 8 s between five attempts.
+	incusDeleteAttempts    = 5
+	incusDeleteBackoffBase = time.Second
+	// incusStopCommandTimeout bounds the `stop --force` COMMAND itself, which
+	// the ordered teardown places BEFORE the last-resort force delete. Without
+	// it, a container wedged in an uninterruptible unmount — exactly the case
+	// this reordering targets — would block the teardown indefinitely at a
+	// point the previous one-shot `delete --force` never reached, i.e. the
+	// reordering itself would introduce a new way to reclaim nothing.
+	incusStopCommandTimeout = 30 * time.Second
+	// incusLastResortTimeout budgets the final force delete. That call runs on
+	// a context deliberately NOT cancelled by the caller's (see Delete, step
+	// 4), so it cannot inherit a deadline and needs one of its own.
+	incusLastResortTimeout = 30 * time.Second
+)
+
+// providerAttachedDevices are exactly the device names Create attaches. Delete
+// detaches THESE and nothing else: `root` and `eth0` come from the `default`
+// profile and are not ours to remove, and removing a device this provider did
+// not add would be a mutation of somebody else's container.
+var providerAttachedDevices = []string{"nixstore", "nixdaemon", "reprostore", "kvm", "gpu"}
+
+// gone reports whether the container is absent (which every teardown step
+// treats as success — Delete is idempotent by contract).
+func (b *IncusBackend) gone(ctx context.Context, idOrName string) bool {
+	_, err := b.findExact(ctx, idOrName)
+	return err == garmErrors.ErrNotFound
+}
+
+// waitStopped polls incusd until the container reports `Stopped` (or vanishes).
+// Returns false if it is still not stopped when the budget runs out; the caller
+// proceeds anyway, because the force fallback at the end of Delete can still
+// finish the job.
+func (b *IncusBackend) waitStopped(ctx context.Context, idOrName string) bool {
+	deadline := time.Now().Add(b.stopSettleTimeout())
+	for {
+		c, err := b.findExact(ctx, idOrName)
+		if err == garmErrors.ErrNotFound {
+			return true
+		}
+		if err == nil && strings.EqualFold(strings.TrimSpace(c.Status), "stopped") {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(incusStopPollInterval):
+		}
+	}
+}
+
+// Delete removes the container with an ORDERED teardown: stop and WAIT for the
+// daemon to confirm it, detach the devices this provider attached, then delete.
+// Idempotent: a missing container is treated as already-deleted success.
+//
+// WHY THE ORDER MATTERS — measured, not assumed. The previous implementation
+// was a single unconditional `incus delete --force`, which folds the stop into
+// the delete: incusd races its own unmount of the container rootfs against the
+// references still held by the container's own processes, and ZFS refuses the
+// destroy. Over 16 days on high-mem-server that produced 8786 distinct delete
+// failures across 1333 of the 14447 instances deleted (9.2%), 96.7% of them
+// `zfs destroy ...: dataset is busy`, retried a median of 7 and up to 30 times
+// each. They retry to success — the holders drain — so nothing leaked
+// permanently, but every one of them re-entered GARM's ladder and held the
+// instance in `deleting` for minutes.
+//
+// SCOPE LIMIT, stated so nobody writes a success criterion this cannot meet:
+// the other failure mode in that window (108 `context deadline exceeded`, of
+// which 84 are the `incus list` READ PROBE in findExact timing out before any
+// delete is attempted) is incus DATABASE contention, not teardown ordering.
+// Reordering the teardown does not address it and it will not go to zero.
 func (b *IncusBackend) Delete(ctx context.Context, idOrName string) error {
-	if _, err := b.findExact(ctx, idOrName); err != nil {
+	c, err := b.findExact(ctx, idOrName)
+	if err != nil {
 		if err == garmErrors.ErrNotFound {
 			return nil
 		}
 		return err
 	}
-	if err := b.forceDelete(ctx, idOrName); err != nil {
-		// A container that vanished between the check and delete is success.
-		if _, gerr := b.findExact(ctx, idOrName); gerr == garmErrors.ErrNotFound {
+
+	// 1. Stop, and WAIT for the daemon to confirm it. A stop error is not
+	//    fatal here: the container may already be stopping, or may have
+	//    vanished, and the force fallback below is the backstop.
+	if !strings.EqualFold(strings.TrimSpace(c.Status), "stopped") {
+		// `--force` because this is a teardown of an EPHEMERAL one-job
+		// container whose job has already finished and whose storage volume is
+		// about to be destroyed: there is no in-guest state worth a graceful
+		// shutdown's wall-clock, and holding the slot longer is the risk this
+		// change has to stay clear of.
+		//
+		// The stop runs on its OWN bounded context. `b.run` has no per-command
+		// timeout and the provider's own context has no deadline today, so an
+		// unbounded stop of a wedged container would hang the teardown here —
+		// upstream of the force fallback that the previous implementation
+		// reached immediately. Bounding it keeps the fallback reachable.
+		stopCtx, cancelStop := context.WithTimeout(ctx, incusStopCommandTimeout)
+		_, serr := b.run(stopCtx, "", "stop", "--force", idOrName)
+		cancelStop()
+		if serr != nil {
+			if b.gone(ctx, idOrName) {
+				return nil
+			}
+		}
+		if !b.waitStopped(ctx, idOrName) && b.gone(ctx, idOrName) {
 			return nil
 		}
-		return err
+	}
+
+	// 2. Detach the devices Create attached, so the delete has no device
+	//    references left to unwind. Best-effort by design: a device that is
+	//    already absent is the desired state, and a detach failure must never
+	//    prevent the delete.
+	if c.Devices != nil {
+		for _, dev := range providerAttachedDevices {
+			if _, ok := c.Devices[dev]; !ok {
+				continue
+			}
+			_, _ = b.run(ctx, "", "config", "device", "remove", idOrName, dev)
+		}
+	}
+
+	// 3. Delete, with a SHORT bounded local retry. Plain `delete` (no
+	//    `--force`) because the container is stopped by now: if it is not, the
+	//    error is worth surfacing to the retry rather than papering over.
+	var lastErr error
+	backoff := b.deleteRetryBackoff()
+retry:
+	for attempt := 0; attempt < incusDeleteAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				// BREAK, never return. Returning here would skip step 4, and
+				// step 4 is the entire basis of the "can never reclaim fewer
+				// containers than the one-shot force delete" guarantee. A
+				// cancelled caller context is precisely the situation in which
+				// the old code would still have force-deleted the container
+				// (it issued its single command at t=0), so it is precisely
+				// the situation in which the new code must not give up.
+				if lastErr == nil {
+					lastErr = ctx.Err()
+				}
+				break retry
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+		out, derr := b.run(ctx, "", "delete", idOrName)
+		if derr == nil {
+			return nil
+		}
+		lastErr = fmt.Errorf("incus delete %s: %w: %s", idOrName, derr, strings.TrimSpace(out))
+		// A container that vanished between attempts is success.
+		if b.gone(ctx, idOrName) {
+			return nil
+		}
+	}
+
+	// 4. Last resort: exactly the pre-fix behaviour, and the reason the ordered
+	//    path can never reclaim FEWER containers than the one-shot force
+	//    delete it replaces. The worst case degrades to the old behaviour plus
+	//    a bounded delay, never to a new failure.
+	//
+	//    That guarantee is NOT free, and the way it is bought is worth stating
+	//    because it is easy to delete by accident. The old code issued its one
+	//    force delete at t=0. The ordered path spends real time first — up to
+	//    incusStopCommandTimeout stopping, incusStopSettleTimeout waiting, and
+	//    ~15 s of backoff — so any deadline on the caller's context that the
+	//    old code would have beaten, the new code can run past. If this call
+	//    inherited that context, an expired one would make the fallback fail
+	//    to even spawn (exec.CommandContext refuses to start on a done
+	//    context) and the container would survive a teardown that the old code
+	//    completed. So the fallback runs on a context derived from the
+	//    caller's but explicitly NOT cancelled by it, with a budget of its own.
+	//
+	//    This matters in practice rather than in theory: GARM's external
+	//    provider wrapper applies `exec_timeout_seconds` to this process and
+	//    kills the child on expiry. That key is unset today, but the in-process
+	//    half of the guarantee must not depend on it staying unset.
+	lastResort, cancelLastResort := context.WithTimeout(
+		context.WithoutCancel(ctx), incusLastResortTimeout)
+	defer cancelLastResort()
+	if ferr := b.forceDelete(lastResort, idOrName); ferr != nil {
+		if b.gone(lastResort, idOrName) {
+			return nil
+		}
+		return fmt.Errorf("%w (force fallback after %d ordered attempts; last ordered error: %v)",
+			ferr, incusDeleteAttempts, lastErr)
 	}
 	return nil
 }

--- a/packages/garm-provider-vmharness/src/internal/backend/incus_test.go
+++ b/packages/garm-provider-vmharness/src/internal/backend/incus_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	garmErrors "github.com/cloudbase/garm-provider-common/errors"
 )
@@ -40,6 +41,13 @@ mkdir -p "$STATE"
 
 cmd="${1:-}"; shift || true
 
+# Every invocation is appended to $MOCK_INCUS_CMDLOG (when set) so a test can
+# assert the ORDER of the teardown steps, not merely their end state. The
+# end state cannot distinguish "stopped, then deleted" from "force-deleted".
+if [ -n "${MOCK_INCUS_CMDLOG:-}" ]; then
+  printf '%s %s\n' "$cmd" "$*" >> "$MOCK_INCUS_CMDLOG"
+fi
+
 case "$cmd" in
   init)
     # init <image> <name>
@@ -54,12 +62,24 @@ case "$cmd" in
   config)
     sub="$1"; shift
     if [ "$sub" = "device" ]; then
-      # config device add <name> <devname> <devtype> [k=v ...]
-      action="$1"; name="$2"; devname="$3"; devtype="$4"; shift 4 || true
-      d="$STATE/$name"
-      [ -d "$d" ] || { echo "Error: Instance '$name' not found" >&2; exit 1; }
-      if [ "$action" = "add" ]; then
-        printf '%s\t%s\t%s\n' "$devname" "$devtype" "$*" >> "$d/devices"
+      if [ "${1:-}" = "remove" ]; then
+        # config device remove <name> <devname>
+        name="$2"; devname="$3"
+        d="$STATE/$name"
+        [ -d "$d" ] || { echo "Error: Instance '$name' not found" >&2; exit 1; }
+        if [ ! -f "$d/devices" ] || ! grep -q "^$devname	" "$d/devices"; then
+          echo "Error: Device '$devname' doesn't exist" >&2; exit 1
+        fi
+        grep -v "^$devname	" "$d/devices" > "$d/devices.tmp" || true
+        mv "$d/devices.tmp" "$d/devices"
+      else
+        # config device add <name> <devname> <devtype> [k=v ...]
+        action="$1"; name="$2"; devname="$3"; devtype="$4"; shift 4 || true
+        d="$STATE/$name"
+        [ -d "$d" ] || { echo "Error: Instance '$name' not found" >&2; exit 1; }
+        if [ "$action" = "add" ]; then
+          printf '%s\t%s\t%s\n' "$devname" "$devtype" "$*" >> "$d/devices"
+        fi
       fi
     else
       # config set <name> <key> <value|->   OR   config set <name> <key=val>
@@ -92,14 +112,52 @@ case "$cmd" in
     printf '%s\n' "$*" >> "$d/execs"
     ;;
   stop)
-    name="$1"; d="$STATE/$name"
+    # stop [--force] <name>
+    name=""
+    for a in "$@"; do case "$a" in --*) ;; *) name="$a"; break;; esac; done
+    d="$STATE/$name"
     [ -d "$d" ] || { echo "Error: Instance '$name' not found" >&2; exit 1; }
-    echo "Stopped" > "$d/status"
+    if [ -n "${MOCK_INCUS_STOP_FAILS:-}" ]; then
+      echo "Error: The instance is busy running a command" >&2; exit 1
+    fi
+    # Real incusd does not settle instantly: a container whose rootfs is
+    # referenced across many mount namespaces takes time to report Stopped.
+    # MOCK_INCUS_STOP_SETTLE_POLLS makes the mock report Stopping for that
+    # many subsequent 'list' calls, so waitStopped is actually exercised.
+    if [ -n "${MOCK_INCUS_STOP_SETTLE_POLLS:-}" ]; then
+      echo "$MOCK_INCUS_STOP_SETTLE_POLLS" > "$d/settle"
+      echo "Stopping" > "$d/status"
+    else
+      echo "Stopped" > "$d/status"
+    fi
     ;;
   delete)
-    # delete --force <name>
-    name="$2"; d="$STATE/$name"
+    # delete [--force] <name>
+    force=0; name=""
+    for a in "$@"; do
+      case "$a" in
+        --force) force=1 ;;
+        --*) ;;
+        *) [ -n "$name" ] || name="$a" ;;
+      esac
+    done
+    d="$STATE/$name"
     [ -d "$d" ] || { echo "Error: Instance '$name' not found" >&2; exit 1; }
+    st=$(cat "$d/status" 2>/dev/null || echo Stopped)
+    if [ "$st" != "Stopped" ] && [ "$force" = 0 ]; then
+      echo "Error: The instance is currently running, stop it first or pass --force" >&2; exit 1
+    fi
+    # Failure injection: the FIRST $MOCK_INCUS_DELETE_FAILURES delete attempts
+    # fail exactly the way the host does (ZFS refusing a busy dataset), so the
+    # bounded local retry ladder is exercised against the real error text.
+    if [ -n "${MOCK_INCUS_DELETE_FAILURES:-}" ]; then
+      n=$(cat "$STATE/.delete-failures" 2>/dev/null || echo 0)
+      if [ "$n" -lt "$MOCK_INCUS_DELETE_FAILURES" ]; then
+        echo $(( n + 1 )) > "$STATE/.delete-failures"
+        echo "Error: Failed to delete instance \"$name\": Failed to run: zfs destroy -r zroot/root/var/lib/incus-storage/containers/$name: exit status 1 (cannot destroy 'zroot/root/var/lib/incus-storage/containers/$name': dataset is busy)" >&2
+        exit 1
+      fi
+    fi
     rm -rf "$d"
     ;;
   list)
@@ -114,9 +172,31 @@ case "$cmd" in
       n=$(basename "$d")
       if [ -n "$filter" ] && [ "$n" != "$filter" ]; then continue; fi
       st=$(cat "$d/status" 2>/dev/null || echo Stopped)
+      # Honour a pending stop-settle countdown: report Stopping until it runs
+      # out, then Stopped. Decremented per observation, like a real poll.
+      if [ -f "$d/settle" ]; then
+        s=$(cat "$d/settle")
+        if [ "$s" -gt 0 ]; then
+          echo $(( s - 1 )) > "$d/settle"
+        else
+          rm -f "$d/settle"
+          echo "Stopped" > "$d/status"
+          st="Stopped"
+        fi
+      fi
       [ "$first" = 1 ] || printf ','
       first=0
-      printf '{"name":"%s","status":"%s","config":{' "$n" "$st"
+      printf '{"name":"%s","status":"%s","devices":{' "$n" "$st"
+      dfirst=1
+      if [ -f "$d/devices" ]; then
+        while IFS='	' read -r dn dt drest; do
+          [ -n "$dn" ] || continue
+          [ "$dfirst" = 1 ] || printf ','
+          dfirst=0
+          printf '"%s":{"type":"%s"}' "$dn" "$dt"
+        done < "$d/devices"
+      fi
+      printf '},"config":{'
       ip=""
       cfirst=1
       while IFS='	' read -r k v; do
@@ -646,5 +726,385 @@ func TestIncusNetworkConfigRendersStaticIP(t *testing.T) {
 		if !strings.Contains(nc, want) {
 			t.Fatalf("network-config missing %q:\n%s", want, nc)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CIR-M1 — CPU cap + ordered teardown
+// ---------------------------------------------------------------------------
+
+// readCmdLog returns the mock incus command log as a slice of lines.
+func readCmdLog(t *testing.T, path string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cmdlog %s: %v", path, err)
+	}
+	var lines []string
+	for _, l := range strings.Split(string(raw), "\n") {
+		if strings.TrimSpace(l) != "" {
+			lines = append(lines, l)
+		}
+	}
+	return lines
+}
+
+// indexOfLine returns the index of the first log line containing every needle,
+// or -1.
+func indexOfLine(lines []string, needles ...string) int {
+	for i, l := range lines {
+		all := true
+		for _, n := range needles {
+			if !strings.Contains(l, n) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return i
+		}
+	}
+	return -1
+}
+
+func withCmdLog(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "cmdlog")
+	t.Setenv("MOCK_INCUS_CMDLOG", p)
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatalf("seed cmdlog: %v", err)
+	}
+	return p
+}
+
+// TestIncusLimitsCpuIsSetBeforeStart proves the CPU cap that CIR-M1 needs on
+// high-mem-server: `limits.cpu` is applied to the per-job container BEFORE
+// `incus start`, so the cap is in the container's cgroup from PID 1 onward and
+// `nproc` — which every build tool self-sizes from — reports the capped count
+// rather than all 32 host threads.
+//
+// The negative control is in the same test rather than in a reviewer's notes:
+// with LimitsCPU left at its zero value the backend must issue NO limits.cpu
+// command at all, so a provider that does not ask for a cap gets a container
+// byte-identical to the one it got before this key existed.
+func TestIncusLimitsCpuIsSetBeforeStart(t *testing.T) {
+	cmd, _ := writeMockIncus(t)
+	log := withCmdLog(t)
+	b := newTestIncusBackend(cmd)
+	b.LimitsCPU = "8"
+	ctx := context.Background()
+
+	if _, err := b.Create(ctx, CreateArgs{Name: "garm-capped", SourceImage: "runner-linux"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	lines := readCmdLog(t, log)
+	set := indexOfLine(lines, "config set garm-capped limits.cpu 8")
+	if set < 0 {
+		t.Fatalf("limits.cpu was never set; log:\n%s", strings.Join(lines, "\n"))
+	}
+	start := indexOfLine(lines, "start garm-capped")
+	if start < 0 {
+		t.Fatalf("container never started; log:\n%s", strings.Join(lines, "\n"))
+	}
+	if set > start {
+		t.Fatalf("limits.cpu set AFTER start (set=%d start=%d): a cap applied post-boot lets cloud-init and the runner start-up see every host thread\n%s",
+			set, start, strings.Join(lines, "\n"))
+	}
+
+	// ---- negative control: no cap requested => no cap applied -------------
+	cmd2, _ := writeMockIncus(t)
+	log2 := withCmdLog(t)
+	b2 := newTestIncusBackend(cmd2)
+	if _, err := b2.Create(ctx, CreateArgs{Name: "garm-uncapped", SourceImage: "runner-linux"}); err != nil {
+		t.Fatalf("Create (uncapped): %v", err)
+	}
+	if i := indexOfLine(readCmdLog(t, log2), "limits.cpu"); i >= 0 {
+		t.Fatalf("LimitsCPU unset but the backend still set limits.cpu; this key must be inert by default\n%s",
+			strings.Join(readCmdLog(t, log2), "\n"))
+	}
+}
+
+// TestIncusDeleteStopsAndWaitsBeforeDeleting is the H7 teardown-ordering gate.
+//
+// The old implementation was a single unconditional `incus delete --force`,
+// which folds the stop into the delete and races incusd's unmount against the
+// container's own references — 96.7% of the 8786 delete failures measured over
+// 16 days on high-mem-server were `zfs destroy ...: dataset is busy`.
+//
+// NON-VACUITY IS STRUCTURAL, not asserted: the mock refuses a plain `delete` of
+// a RUNNING container exactly as incusd does, so a Delete that skipped the stop
+// could not reach a successful plain delete at all. And the mock reports
+// `Stopping` for two polls after the stop, so a Delete that issued the stop but
+// did not WAIT would delete while the container was still stopping.
+func TestIncusDeleteStopsAndWaitsBeforeDeleting(t *testing.T) {
+	cmd, _ := writeMockIncus(t)
+	t.Setenv("MOCK_INCUS_STOP_SETTLE_POLLS", "2")
+	log := withCmdLog(t)
+	b := newTestIncusBackend(cmd)
+	ctx := context.Background()
+
+	if _, err := b.Create(ctx, CreateArgs{Name: "garm-td", SourceImage: "runner-linux"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := b.Delete(ctx, "garm-td"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	lines := readCmdLog(t, log)
+	stop := indexOfLine(lines, "stop", "garm-td")
+	del := indexOfLine(lines, "delete", "garm-td")
+	if stop < 0 {
+		t.Fatalf("teardown never stopped the container; log:\n%s", strings.Join(lines, "\n"))
+	}
+	if del < 0 {
+		t.Fatalf("teardown never deleted the container; log:\n%s", strings.Join(lines, "\n"))
+	}
+	if stop > del {
+		t.Fatalf("stop issued AFTER delete (stop=%d delete=%d)\n%s", stop, del, strings.Join(lines, "\n"))
+	}
+	// The happy path must NOT use --force: force is the fallback, and if the
+	// ordered path silently reached for it we would be back to the behaviour
+	// this change exists to replace.
+	if i := indexOfLine(lines, "delete", "--force"); i >= 0 {
+		t.Fatalf("ordered teardown used `delete --force` on the happy path (line %d); that is the pre-fix behaviour\n%s",
+			i, strings.Join(lines, "\n"))
+	}
+	// The wait must be a real poll, not a single look: with two settle polls
+	// injected, at least three `list` probes must separate stop from delete.
+	probes := 0
+	for _, l := range lines[stop:del] {
+		if strings.HasPrefix(l, "list ") {
+			probes++
+		}
+	}
+	if probes < 3 {
+		t.Fatalf("only %d status probes between stop and delete; the teardown is not waiting for `Stopped`\n%s",
+			probes, strings.Join(lines, "\n"))
+	}
+	if _, err := b.Get(ctx, "garm-td"); err != garmErrors.ErrNotFound {
+		t.Fatalf("container survived Delete: %v", err)
+	}
+}
+
+// TestIncusDeleteDetachesOnlyProviderAttachedDevices proves the middle step of
+// the ordered teardown: the devices Create attached are removed before the
+// delete, and nothing else is touched. Removing a device this provider did not
+// add would be a mutation of somebody else's container.
+func TestIncusDeleteDetachesOnlyProviderAttachedDevices(t *testing.T) {
+	cmd, _ := writeMockIncus(t)
+	log := withCmdLog(t)
+	b := newTestIncusBackend(cmd)
+	// GpuPassthrough attaches `gpu` + `nixstore`, ReprobuildStore attaches
+	// `reprostore`, NestedKvm attaches `kvm` — four of the five devices Create
+	// can attach, with no dependency on a NixOS host path. `nixdaemon` (the
+	// fifth) is deliberately absent so the "detach it only if it is still
+	// present" guard is exercised too.
+	b.GpuPassthrough = true
+	b.ReprobuildStore = t.TempDir()
+	b.ReprobuildStoreGuestPath = "/srv/repro-store"
+	b.NestedKvm = true
+	ctx := context.Background()
+
+	if _, err := b.Create(ctx, CreateArgs{Name: "garm-dev", SourceImage: "runner-linux"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := b.Delete(ctx, "garm-dev"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	lines := readCmdLog(t, log)
+	del := indexOfLine(lines, "delete", "garm-dev")
+	for _, dev := range []string{"nixstore", "reprostore", "kvm", "gpu"} {
+		i := indexOfLine(lines, "config device remove garm-dev "+dev)
+		if i < 0 {
+			t.Fatalf("device %q was never detached before delete\n%s", dev, strings.Join(lines, "\n"))
+		}
+		if i > del {
+			t.Fatalf("device %q detached AFTER delete (%d > %d)\n%s", dev, i, del, strings.Join(lines, "\n"))
+		}
+	}
+	// A provider device that was never attached must not be detached either:
+	// the teardown removes what is present, it does not fire blind.
+	if i := indexOfLine(lines, "config device remove garm-dev nixdaemon"); i >= 0 {
+		t.Fatalf("teardown tried to remove a device that was never attached (line %d)\n%s",
+			i, strings.Join(lines, "\n"))
+	}
+	// Never the profile-inherited devices.
+	for _, dev := range []string{"eth0", "root"} {
+		if i := indexOfLine(lines, "config device remove garm-dev "+dev); i >= 0 {
+			t.Fatalf("teardown removed profile-inherited device %q (line %d); only provider-attached devices are ours\n%s",
+				dev, i, strings.Join(lines, "\n"))
+		}
+	}
+}
+
+// TestIncusDeleteRetriesBusyDatasetLocally proves the bounded local ladder: a
+// transient `zfs destroy ...: dataset is busy` resolves inside one Delete call
+// instead of returning an error that escalates into GARM's unbounded 1 s→5 min
+// retry ladder (workers/provider/instance_manager.go:127-136), which is what
+// produced a median of 7 and up to 30 retries per instance on the host.
+func TestIncusDeleteRetriesBusyDatasetLocally(t *testing.T) {
+	cmd, _ := writeMockIncus(t)
+	t.Setenv("MOCK_INCUS_DELETE_FAILURES", "3")
+	log := withCmdLog(t)
+	b := newTestIncusBackend(cmd)
+	b.DeleteRetryBackoff = 5 * time.Millisecond
+	ctx := context.Background()
+
+	if _, err := b.Create(ctx, CreateArgs{Name: "garm-busy", SourceImage: "runner-linux"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := b.Delete(ctx, "garm-busy"); err != nil {
+		t.Fatalf("Delete did not absorb 3 transient busy-dataset failures: %v", err)
+	}
+	lines := readCmdLog(t, log)
+	deletes := 0
+	for _, l := range lines {
+		if strings.HasPrefix(l, "delete ") {
+			deletes++
+		}
+	}
+	if deletes != 4 {
+		t.Fatalf("expected 4 delete attempts (3 failed + 1 success), got %d\n%s", deletes, strings.Join(lines, "\n"))
+	}
+	if _, err := b.Get(ctx, "garm-busy"); err != garmErrors.ErrNotFound {
+		t.Fatalf("container survived Delete: %v", err)
+	}
+}
+
+// TestIncusDeleteFallsBackToForce proves the change can never delete FEWER
+// containers than the one-shot `delete --force` it replaces: when the whole
+// ordered ladder is exhausted, the pre-fix behaviour still runs as a last
+// resort.
+func TestIncusDeleteFallsBackToForce(t *testing.T) {
+	cmd, _ := writeMockIncus(t)
+	// One more failure than the ordered ladder has attempts, so every ordered
+	// attempt fails and only the force fallback can succeed.
+	t.Setenv("MOCK_INCUS_DELETE_FAILURES", "5")
+	log := withCmdLog(t)
+	b := newTestIncusBackend(cmd)
+	b.DeleteRetryBackoff = 5 * time.Millisecond
+	ctx := context.Background()
+
+	if _, err := b.Create(ctx, CreateArgs{Name: "garm-stuck", SourceImage: "runner-linux"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := b.Delete(ctx, "garm-stuck"); err != nil {
+		t.Fatalf("Delete: force fallback did not run or did not succeed: %v", err)
+	}
+	lines := readCmdLog(t, log)
+	if i := indexOfLine(lines, "delete", "--force", "garm-stuck"); i < 0 {
+		t.Fatalf("force fallback never ran\n%s", strings.Join(lines, "\n"))
+	}
+	if _, err := b.Get(ctx, "garm-stuck"); err != garmErrors.ErrNotFound {
+		t.Fatalf("container survived Delete: %v", err)
+	}
+}
+
+// TestIncusDeleteReclaimsEvenWhenTheCallerContextExpires is the regression test
+// for the ONE guarantee the ordered teardown makes to the rest of the system:
+// it can never reclaim FEWER containers than the single unconditional
+// `incus delete --force` it replaces.
+//
+// The guarantee is not self-evident, and it was briefly FALSE. The old code
+// issued its one command at t=0 and beat any deadline the caller had. The
+// ordered path spends real time first — stopping, waiting for `Stopped`, and
+// backing off between attempts — so a caller deadline the old code beat is one
+// the new code can run past. If the last-resort force delete inherited that
+// expired context, `exec.CommandContext` would refuse to even spawn it and the
+// container would survive a teardown that the old code completed. That is a
+// reclamation REGRESSION produced by a change whose entire purpose is to
+// reclaim better.
+//
+// This test pins the fix: a caller context that expires DURING the ordered
+// teardown must still end with the container gone and `delete --force` issued.
+// GARM's external-provider wrapper applies `exec_timeout_seconds` to this
+// process, so the deadline is one config key away from being real.
+func TestIncusDeleteReclaimsEvenWhenTheCallerContextExpires(t *testing.T) {
+	cmd, _ := writeMockIncus(t)
+	// Make the stop settle slowly enough that the caller's budget is consumed
+	// inside the ordered path rather than before it starts.
+	t.Setenv("MOCK_INCUS_STOP_SETTLE_POLLS", "200")
+	log := withCmdLog(t)
+	b := newTestIncusBackend(cmd)
+	b.StopSettleTimeout = 10 * time.Second
+	b.DeleteRetryBackoff = 5 * time.Millisecond
+
+	if _, err := b.Create(context.Background(), CreateArgs{
+		Name: "garm-ctxexpiry", SourceImage: "runner-linux",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// A budget the old one-shot force delete would have met comfortably.
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	derr := b.Delete(ctx, "garm-ctxexpiry")
+
+	lines := readCmdLog(t, log)
+	if i := indexOfLine(lines, "delete", "--force", "garm-ctxexpiry"); i < 0 {
+		t.Fatalf("the caller's context expired and the last-resort force delete was SKIPPED, so this teardown reclaimed less than the one-shot force delete it replaces (Delete err: %v)\n%s",
+			derr, strings.Join(lines, "\n"))
+	}
+	if _, err := b.Get(context.Background(), "garm-ctxexpiry"); err != garmErrors.ErrNotFound {
+		t.Fatalf("container SURVIVED a teardown the pre-fix code would have completed: %v", err)
+	}
+	if derr != nil {
+		t.Fatalf("container was reclaimed but Delete reported failure: %v", derr)
+	}
+}
+
+// TestIncusDeleteSurfacesPersistentFailure is the counterpart negative control:
+// when NOTHING can delete the container, Delete must report an error rather
+// than silently returning success. A teardown that always returns nil would
+// pass every test above and leak every container.
+func TestIncusDeleteSurfacesPersistentFailure(t *testing.T) {
+	cmd, _ := writeMockIncus(t)
+	t.Setenv("MOCK_INCUS_DELETE_FAILURES", "99")
+	b := newTestIncusBackend(cmd)
+	b.DeleteRetryBackoff = 5 * time.Millisecond
+	ctx := context.Background()
+
+	if _, err := b.Create(ctx, CreateArgs{Name: "garm-perma", SourceImage: "runner-linux"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	err := b.Delete(ctx, "garm-perma")
+	if err == nil {
+		t.Fatal("Delete returned success while the container still exists")
+	}
+	if !strings.Contains(err.Error(), "dataset is busy") {
+		t.Fatalf("error lost the underlying cause, which is what the operator needs: %v", err)
+	}
+	if _, gerr := b.Get(ctx, "garm-perma"); gerr != nil {
+		t.Fatalf("container should still exist after a failed delete: %v", gerr)
+	}
+}
+
+// TestIncusDeleteToleratesStopFailure proves a stop that cannot be issued does
+// not abort the teardown: the force fallback still reclaims the container. A
+// teardown that turned a stop error into a hard failure would REGRESS against
+// the one-shot force delete it replaces.
+func TestIncusDeleteToleratesStopFailure(t *testing.T) {
+	cmd, _ := writeMockIncus(t)
+	log := withCmdLog(t)
+	b := newTestIncusBackend(cmd)
+	b.DeleteRetryBackoff = 5 * time.Millisecond
+	b.StopSettleTimeout = 50 * time.Millisecond
+	ctx := context.Background()
+
+	if _, err := b.Create(ctx, CreateArgs{Name: "garm-nostop", SourceImage: "runner-linux"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Setenv("MOCK_INCUS_STOP_FAILS", "1")
+	if err := b.Delete(ctx, "garm-nostop"); err != nil {
+		t.Fatalf("Delete: a stop failure must not abort teardown: %v", err)
+	}
+	if i := indexOfLine(readCmdLog(t, log), "delete", "--force", "garm-nostop"); i < 0 {
+		t.Fatalf("expected the force fallback to reclaim the still-running container\n%s",
+			strings.Join(readCmdLog(t, log), "\n"))
+	}
+	if _, err := b.Get(ctx, "garm-nostop"); err != garmErrors.ErrNotFound {
+		t.Fatalf("container survived Delete: %v", err)
 	}
 }

--- a/packages/garm-provider-vmharness/src/internal/config/config.go
+++ b/packages/garm-provider-vmharness/src/internal/config/config.go
@@ -243,6 +243,30 @@ type Config struct {
 	// backends. Backs HR2.
 	IncusNestedKvm bool `toml:"incus_nested_kvm"`
 
+	// IncusLimitsCPU, when non-empty, is written verbatim to each per-job
+	// container's `limits.cpu` before start:
+	//   incus config set <name> limits.cpu <IncusLimitsCPU>
+	//
+	// Incus accepts either a COUNT ("8") or an explicit CPU SET ("0-7",
+	// "0,2,4"). A count is dynamic: incusd picks that many host CPUs (the
+	// least loaded ones) and pins the container's cpuset to them, re-balancing
+	// as containers come and go. The container's `cpuset.cpus` therefore has N
+	// entries, which is what `nproc` (and every build tool that shells to it)
+	// reports inside the guest.
+	//
+	// THAT LAST PROPERTY IS THE POINT, and it is why this is a `limits.cpu`
+	// key rather than a `limits.cpu.allowance` one. An uncapped container on a
+	// 32-thread host reports 32 to `nproc`, so `make -j$(nproc)` /
+	// `cargo build` / `nix build --cores 0` each spawn ~32 runnable compilers.
+	// The cap bounds the DEMAND the guest generates, not merely the share it is
+	// scheduled at, and it does so without a CFS quota that would idle host
+	// CPUs whenever fewer containers than the worst case are running.
+	//
+	// Empty (the default) sets nothing at all, so a provider that does not want
+	// a cap produces a byte-identical container to before this key existed.
+	// Ignored by non-incus backends.
+	IncusLimitsCPU string `toml:"incus_limits_cpu"`
+
 	// StateDir stores pid/metadata files for vm-harness run based backends
 	// (Tart/UTM on m3). It contains no secrets.
 	StateDir string `toml:"state_dir"`

--- a/packages/garm-provider-vmharness/src/internal/config/config_test.go
+++ b/packages/garm-provider-vmharness/src/internal/config/config_test.go
@@ -26,3 +26,45 @@ guest_callback_url = "http://10.0.2.2:9997/api/v1/callbacks"
 		t.Fatalf("GuestCallbackURL=%q", cfg.GuestCallbackURL)
 	}
 }
+
+// TestIncusLimitsCPUParsesAndDefaultsEmpty pins the CIR-M1 CPU-cap key at the
+// CONFIG boundary — the TOML the NixOS module renders is the only contract
+// between `services.garm.providers.<n>.incusLimitsCpu` and the provider.
+//
+// The default arm is the load-bearing half: an incus provider config that does
+// NOT carry the key must leave IncusLimitsCPU empty, because the backend keys
+// "apply no cap at all" off exactly that emptiness. If a default ever leaked in
+// here, every live runner would silently acquire a cap nobody asked for.
+func TestIncusLimitsCPUParsesAndDefaultsEmpty(t *testing.T) {
+	base := `
+backend = "incus"
+incus_path = "/nix/store/test/bin/incus"
+incus_ipv4_cidr = "10.157.159.0/24"
+incus_ipv4_gateway = "10.157.159.1"
+`
+	withKey, err := ParseBytes([]byte(base + "incus_limits_cpu = \"8\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withKey.IncusLimitsCPU != "8" {
+		t.Fatalf("IncusLimitsCPU=%q want %q", withKey.IncusLimitsCPU, "8")
+	}
+
+	withoutKey, err := ParseBytes([]byte(base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withoutKey.IncusLimitsCPU != "" {
+		t.Fatalf("IncusLimitsCPU=%q want empty when the key is absent; a non-empty default would cap every existing runner", withoutKey.IncusLimitsCPU)
+	}
+
+	// An explicit CPU SET must survive verbatim: incus accepts "0-7"/"0,2,4"
+	// as well as a count, and the provider passes the value through unparsed.
+	set, err := ParseBytes([]byte(base + "incus_limits_cpu = \"0-7\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if set.IncusLimitsCPU != "0-7" {
+		t.Fatalf("IncusLimitsCPU=%q want %q", set.IncusLimitsCPU, "0-7")
+	}
+}

--- a/packages/garm-provider-vmharness/src/internal/provider/provider.go
+++ b/packages/garm-provider-vmharness/src/internal/provider/provider.go
@@ -88,6 +88,7 @@ func NewWithConfig(cfg *config.Config) (*Provider, error) {
 			ReprobuildStoreGuestPath: cfg.IncusReprobuildStoreGuestPath,
 			SecurityNesting:          cfg.IncusSecurityNesting,
 			NestedKvm:                cfg.IncusNestedKvm,
+			LimitsCPU:                cfg.IncusLimitsCPU,
 		}
 	case config.BackendTartLinuxArm:
 		b = &backend.VMHarnessRunBackend{


### PR DESCRIPTION
Teardown was one unconditional `incus delete --force`, which fails with `zfs destroy: dataset is busy` and retries in a storm. Now: stop, wait for Stopped, detach only the devices Create attached, plain delete with a bounded backoff ladder, force only as a last resort — so it can never reclaim fewer containers than before.

Adds an optional `incusLimitsCpu` so a container can be capped; unset renders a byte-identical config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)